### PR TITLE
Use gradients for featured section background if image cannot be blurred

### DIFF
--- a/shared/src/androidMain/kotlin/dev/sasikanth/rss/reader/utils/PlatformExt.kt
+++ b/shared/src/androidMain/kotlin/dev/sasikanth/rss/reader/utils/PlatformExt.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 Sasikanth Miriyampalli
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sasikanth.rss.reader.utils
+
+import android.os.Build
+import androidx.annotation.ChecksSdkIntAtLeast
+
+@ChecksSdkIntAtLeast(api = Build.VERSION_CODES.S)
+internal actual val canBlurImage: Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/components/DynamicContentTheme.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/components/DynamicContentTheme.kt
@@ -44,6 +44,7 @@ import kotlinx.coroutines.withContext
 private const val TINTED_BACKGROUND = "tinted_background"
 private const val TINTED_SURFACE = "tinted_surface"
 private const val TINTED_FOREGROUND = "tinted_foreground"
+private const val TINTED_HIGHLIGHT = "tinted_highlight"
 private const val OUTLINE = "outline"
 private const val OUTLINE_VARIANT = "outline_VARIANT"
 private const val SURFACE = "surface"
@@ -65,6 +66,8 @@ internal fun DynamicContentTheme(
   val tintedSurface by
     animateColorAsState(dynamicColorState.tintedSurface, spring(stiffness = Spring.StiffnessLow))
   val tintedForeground by
+    animateColorAsState(dynamicColorState.tintedForeground, spring(stiffness = Spring.StiffnessLow))
+  val tintedHighlight by
     animateColorAsState(dynamicColorState.tintedForeground, spring(stiffness = Spring.StiffnessLow))
   val outline by
     animateColorAsState(dynamicColorState.outline, spring(stiffness = Spring.StiffnessLow))
@@ -104,6 +107,7 @@ internal fun DynamicContentTheme(
       tintedBackground = tintedBackground,
       tintedSurface = tintedSurface,
       tintedForeground = tintedForeground,
+      tintedHighlight = tintedHighlight,
       outline = outline,
       outlineVariant = outlineVariant,
       surface = surface,
@@ -124,6 +128,7 @@ internal fun rememberDynamicColorState(
   defaultTintedBackground: Color = AppTheme.colorScheme.tintedBackground,
   defaultTintedSurface: Color = AppTheme.colorScheme.tintedSurface,
   defaultTintedForeground: Color = AppTheme.colorScheme.tintedForeground,
+  defaultTintedHighlight: Color = AppTheme.colorScheme.tintedHighlight,
   defaultOutline: Color = AppTheme.colorScheme.outline,
   defaultOutlineVariant: Color = AppTheme.colorScheme.outlineVariant,
   defaultSurface: Color = AppTheme.colorScheme.surface,
@@ -142,6 +147,7 @@ internal fun rememberDynamicColorState(
       defaultTintedBackground,
       defaultTintedSurface,
       defaultTintedForeground,
+      defaultTintedHighlight,
       defaultOutline,
       defaultOutlineVariant,
       defaultSurface,
@@ -169,6 +175,7 @@ class DynamicColorState(
   private val defaultTintedBackground: Color,
   private val defaultTintedSurface: Color,
   private val defaultTintedForeground: Color,
+  private val defaultTintedHighlight: Color,
   private val defaultOutline: Color,
   private val defaultOutlineVariant: Color,
   private val defaultSurface: Color,
@@ -189,6 +196,9 @@ class DynamicColorState(
     private set
 
   var tintedForeground by mutableStateOf(defaultTintedForeground)
+    private set
+
+  var tintedHighlight by mutableStateOf(defaultTintedHighlight)
     private set
 
   var outline by mutableStateOf(defaultOutline)
@@ -232,6 +242,7 @@ class DynamicColorState(
     tintedBackground = result?.tintedBackground ?: defaultTintedBackground
     tintedSurface = result?.tintedSurface ?: defaultTintedSurface
     tintedForeground = result?.tintedForeground ?: defaultTintedForeground
+    tintedHighlight = result?.tintedHighlight ?: defaultTintedHighlight
     outline = result?.outline ?: defaultOutline
     outlineVariant = result?.outlineVariant ?: defaultOutlineVariant
     surface = result?.surface ?: defaultSurface
@@ -248,6 +259,7 @@ class DynamicColorState(
     tintedBackground = defaultTintedBackground
     tintedSurface = defaultTintedSurface
     tintedForeground = defaultTintedForeground
+    tintedHighlight = defaultTintedHighlight
     outline = defaultOutline
     outlineVariant = defaultOutlineVariant
     surface = defaultSurface
@@ -276,6 +288,7 @@ class DynamicColorState(
               tintedBackground = Color(colorsMap[TINTED_BACKGROUND]!!),
               tintedSurface = Color(colorsMap[TINTED_SURFACE]!!),
               tintedForeground = Color(colorsMap[TINTED_FOREGROUND]!!),
+              tintedHighlight = Color(colorsMap[TINTED_HIGHLIGHT]!!),
               outline = Color(colorsMap[OUTLINE]!!),
               outlineVariant = Color(colorsMap[OUTLINE_VARIANT]!!),
               surface = Color(colorsMap[SURFACE]!!),
@@ -347,6 +360,19 @@ class DynamicColorState(
                 )
               }
             ),
+          TINTED_HIGHLIGHT to
+            DynamicColor.fromPalette(
+              palette = { s: DynamicScheme -> s.primaryPalette },
+              tone = { s: DynamicScheme -> 40.0 },
+              background = { s: DynamicScheme -> dynamicColors.highestSurface(s) },
+              toneDeltaConstraint = { s: DynamicScheme ->
+                ToneDeltaConstraint(
+                  MaterialDynamicColors.CONTAINER_ACCENT_TONE_DELTA,
+                  dynamicColors.primaryContainer(),
+                  TonePolarity.DARKER
+                )
+              }
+            ),
           OUTLINE to dynamicColors.outline(),
           OUTLINE_VARIANT to dynamicColors.outlineVariant(),
           SURFACE to dynamicColors.surface(),
@@ -372,6 +398,7 @@ private data class DynamicColors(
   val tintedBackground: Color,
   val tintedSurface: Color,
   val tintedForeground: Color,
+  val tintedHighlight: Color,
   val outline: Color,
   val outlineVariant: Color,
   val surface: Color,

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/ui/FeaturedSection.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/ui/FeaturedSection.kt
@@ -57,6 +57,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
 import androidx.compose.ui.draw.BlurredEdgeTreatment
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.geometry.Offset
@@ -73,6 +74,7 @@ import dev.sasikanth.rss.reader.resources.icons.TwineIcons
 import dev.sasikanth.rss.reader.resources.strings.LocalStrings
 import dev.sasikanth.rss.reader.ui.AppTheme
 import dev.sasikanth.rss.reader.utils.LocalWindowSizeClass
+import dev.sasikanth.rss.reader.utils.canBlurImage
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.flow.collectLatest
 
@@ -259,14 +261,35 @@ private fun OverflowMenu(onSettingsClicked: () -> Unit) {
 @Composable
 private fun FeaturedSectionBlurredBackground(modifier: Modifier = Modifier, imageUrl: String?) {
   BoxWithConstraints(modifier = modifier) {
-    AsyncImage(
-      url = imageUrl!!,
-      modifier =
-        Modifier.aspectRatio(featuredImageBackgroundAspectRatio)
-          .blur(100.dp, BlurredEdgeTreatment.Unbounded),
-      contentDescription = null,
-      contentScale = ContentScale.Crop
-    )
+    if (canBlurImage) {
+      AsyncImage(
+        url = imageUrl!!,
+        modifier =
+          Modifier.aspectRatio(featuredImageBackgroundAspectRatio)
+            .blur(100.dp, BlurredEdgeTreatment.Unbounded),
+        contentDescription = null,
+        contentScale = ContentScale.Crop
+      )
+    } else {
+      Box(
+        modifier =
+          Modifier.aspectRatio(0.8f).composed {
+            val colorStops =
+              listOf(
+                AppTheme.colorScheme.tintedHighlight.copy(alpha = 0.0f),
+                AppTheme.colorScheme.tintedHighlight.copy(alpha = 0.33f),
+                AppTheme.colorScheme.tintedHighlight.copy(alpha = 0.50f),
+                AppTheme.colorScheme.tintedHighlight.copy(alpha = 0.70f),
+                AppTheme.colorScheme.tintedHighlight.copy(alpha = 0.60f),
+                AppTheme.colorScheme.tintedHighlight.copy(alpha = 0.33f),
+                AppTheme.colorScheme.tintedHighlight.copy(alpha = 0.10f),
+                AppTheme.colorScheme.tintedHighlight.copy(alpha = 0.0f),
+              )
+
+            background(Brush.verticalGradient(colorStops))
+          }
+      )
+    }
 
     Box(
       modifier =

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/ui/AppColorScheme.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/ui/AppColorScheme.kt
@@ -28,6 +28,7 @@ class AppColorScheme(
   tintedBackground: Color = Color(0xFF002117),
   tintedSurface: Color = Color(0xFF00382A),
   tintedForeground: Color = Color(0xFF63DBB5),
+  tintedHighlight: Color = Color(0xFF63DBB5),
   outline: Color = Color(0xFF89938E),
   outlineVariant: Color = Color(0xFF3F4944),
   surface: Color = Color(0xFF111412),
@@ -49,6 +50,9 @@ class AppColorScheme(
     internal set
 
   var tintedForeground by mutableStateOf(tintedForeground, structuralEqualityPolicy())
+    internal set
+
+  var tintedHighlight by mutableStateOf(tintedHighlight, structuralEqualityPolicy())
     internal set
 
   var outline by mutableStateOf(outline, structuralEqualityPolicy())
@@ -91,6 +95,7 @@ class AppColorScheme(
     tintedBackground: Color = this.tintedBackground,
     tintedSurface: Color = this.surfaceContainer,
     tintedForeground: Color = this.tintedForeground,
+    tintedHighlight: Color = this.tintedHighlight,
     outline: Color = this.outline,
     outlineVariant: Color = this.outlineVariant,
     surface: Color = this.surface,
@@ -108,6 +113,7 @@ class AppColorScheme(
       tintedBackground = tintedBackground,
       tintedSurface = tintedSurface,
       tintedForeground = tintedForeground,
+      tintedHighlight = tintedHighlight,
       outline = outline,
       outlineVariant = outlineVariant,
       surface = surface,

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/utils/PlatformExt.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/utils/PlatformExt.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2023 Sasikanth Miriyampalli
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sasikanth.rss.reader.utils
+
+internal expect val canBlurImage: Boolean

--- a/shared/src/iosMain/kotlin/dev/sasikanth/rss/reader/utils/PlatformExt.kt
+++ b/shared/src/iosMain/kotlin/dev/sasikanth/rss/reader/utils/PlatformExt.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2023 Sasikanth Miriyampalli
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sasikanth.rss.reader.utils
+
+internal actual val canBlurImage: Boolean = true


### PR DESCRIPTION
For now on Android, we cannot blur content using `Modifier.blur` on Android 11 and below. We will fallback to using gradients instead to give that "feel"

unblocks #57