### PR TITLE
Fix featured section background size on android devices with api level 30 or below

### DIFF
--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/ui/FeaturedSection.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/ui/FeaturedSection.kt
@@ -90,6 +90,17 @@ private val featuredImageBackgroundAspectRatio: Float
       else -> 1.1f
     }
 
+private val featuredGradientBackgroundAspectRatio: Float
+  @Composable
+  @ReadOnlyComposable
+  get() =
+    when (LocalWindowSizeClass.current.widthSizeClass) {
+      WindowWidthSizeClass.Compact -> 0.8f
+      WindowWidthSizeClass.Medium -> 1.11f
+      WindowWidthSizeClass.Expanded -> 2.3f
+      else -> 0.8f
+    }
+
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 internal fun FeaturedSection(
@@ -278,7 +289,7 @@ private fun FeaturedSectionBlurredBackground(modifier: Modifier = Modifier, imag
     } else {
       Box(
         modifier =
-          Modifier.aspectRatio(0.8f).composed {
+          Modifier.aspectRatio(featuredGradientBackgroundAspectRatio).composed {
             val colorStops =
               listOf(
                 AppTheme.colorScheme.tintedHighlight.copy(alpha = 0.0f),


### PR DESCRIPTION
![Screenshot_20230918_161213](https://github.com/msasikanth/twine/assets/1983249/d5875cf6-080c-40e2-bf55-655d0004a81f)
