### PR TITLE
Move background workers on Android back to root package

### DIFF
--- a/androidApp/src/androidMain/kotlin/dev/sasikanth/rss/reader/PostsCleanUpWorker.kt
+++ b/androidApp/src/androidMain/kotlin/dev/sasikanth/rss/reader/PostsCleanUpWorker.kt
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package dev.sasikanth.rss.reader.background
+
+package dev.sasikanth.rss.reader
 
 import android.content.Context
 import androidx.work.Constraints
@@ -22,25 +23,23 @@ import androidx.work.NetworkType
 import androidx.work.PeriodicWorkRequest
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkerParameters
-import dev.sasikanth.rss.reader.refresh.LastUpdatedAt
 import dev.sasikanth.rss.reader.repository.RssRepository
-import io.sentry.kotlin.multiplatform.Sentry
-import io.sentry.kotlin.multiplatform.SentryLevel
-import io.sentry.kotlin.multiplatform.protocol.Breadcrumb
-import java.lang.Exception
+import dev.sasikanth.rss.reader.repository.SettingsRepository
+import dev.sasikanth.rss.reader.utils.calculateInstantBeforePeriod
+import io.sentry.Sentry
 import java.time.Duration
-import kotlinx.coroutines.CancellationException
+import kotlin.coroutines.cancellation.CancellationException
 
-class FeedsRefreshWorker(
+class PostsCleanUpWorker(
   context: Context,
   workerParameters: WorkerParameters,
   private val rssRepository: RssRepository,
-  private val lastUpdatedAt: LastUpdatedAt
+  private val settingsRepository: SettingsRepository
 ) : CoroutineWorker(context, workerParameters) {
 
   companion object {
 
-    const val TAG = "REFRESH_FEEDS"
+    const val TAG = "POSTS_CLEAN_UP"
 
     fun periodicRequest(): PeriodicWorkRequest {
       val constraints =
@@ -49,28 +48,23 @@ class FeedsRefreshWorker(
           .setRequiresBatteryNotLow(true)
           .build()
 
-      return PeriodicWorkRequestBuilder<FeedsRefreshWorker>(repeatInterval = Duration.ofHours(1))
+      return PeriodicWorkRequestBuilder<PostsCleanUpWorker>(repeatInterval = Duration.ofDays(1))
         .setConstraints(constraints)
         .build()
     }
   }
 
   override suspend fun doWork(): Result {
-    return if (lastUpdatedAt.hasExpired()) {
-      try {
-        rssRepository.updateFeeds()
-        lastUpdatedAt.refresh()
-        Result.success()
-      } catch (e: CancellationException) {
-        Result.failure()
-      } catch (e: Exception) {
-        Sentry.captureException(e) {
-          it.addBreadcrumb(Breadcrumb(level = SentryLevel.INFO, category = "Background"))
-        }
-        Result.failure()
-      }
-    } else {
-      Result.failure()
+    try {
+      val postsDeletionPeriod = settingsRepository.postsDeletionPeriodImmediate()
+      rssRepository.deleteReadPosts(before = postsDeletionPeriod.calculateInstantBeforePeriod())
+      return Result.success()
+    } catch (e: CancellationException) {
+      // no-op
+    } catch (e: Exception) {
+      Sentry.captureException(e)
     }
+
+    return Result.failure()
   }
 }

--- a/androidApp/src/androidMain/kotlin/dev/sasikanth/rss/reader/ReaderApplication.kt
+++ b/androidApp/src/androidMain/kotlin/dev/sasikanth/rss/reader/ReaderApplication.kt
@@ -24,8 +24,6 @@ import androidx.work.ListenableWorker
 import androidx.work.WorkManager
 import androidx.work.WorkerFactory
 import androidx.work.WorkerParameters
-import dev.sasikanth.rss.reader.background.FeedsRefreshWorker
-import dev.sasikanth.rss.reader.background.PostsCleanUpWorker
 import dev.sasikanth.rss.reader.di.ApplicationComponent
 import dev.sasikanth.rss.reader.di.create
 
@@ -70,7 +68,9 @@ class ReaderApplication : Application(), Configuration.Provider {
                     settingsRepository = appComponent.settingsRepository
                   )
                 }
-                else -> throw IllegalArgumentException("Unknown background worker")
+                else -> {
+                  throw IllegalArgumentException("Unknown background worker: $workerClassName")
+                }
               }
             }
           }


### PR DESCRIPTION
Since we already have an existing work scheduled in existing installs, those will not have `background` package in the class name, which leads to a `IllegalArgumentException`. I can cancel existing workers and have a proper migration for it. But it seems to much effort for a little gain. So moving them back to the root package for now.
