### PR TITLE
Stop removing `www .` when transforming the URL for fetching the feed

### DIFF
--- a/core/network/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/network/fetcher/FeedFetcher.kt
+++ b/core/network/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/network/fetcher/FeedFetcher.kt
@@ -123,7 +123,7 @@ class FeedFetcher(private val httpClient: HttpClient, private val feedParser: Fe
       URLBuilder()
         .apply {
           protocol = URLProtocol.HTTPS
-          host = url.replace(Regex("^https?://"), "").replace(Regex("^www\\."), "")
+          host = url.replace(Regex("^https?://"), "")
         }
         .build()
     } else {


### PR DESCRIPTION
I assumed all website will redirect to URL with `www.` if we pass a URL without one. But that doesn't seem to be the case. It looks like some websites fail with SSL handshake error. So, we are keeping the `www.`. There is an off chance, where some domains are not properly configured to open with `www.` (I doubt there are many), but I can handle it if I see those errors.
