### PR TITLE
Fix app crashing when opening bookmarked posts

### DIFF
--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/app/AppPresenter.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/app/AppPresenter.kt
@@ -63,7 +63,7 @@ private typealias BookmarkPresenterFactory =
   (
     ComponentContext,
     goBack: () -> Unit,
-    openPost: (String) -> Unit,
+    openReaderView: (String) -> Unit,
   ) -> BookmarksPresenter
 
 private typealias SettingsPresenterFactory =

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/bookmarks/BookmarksEffect.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/bookmarks/BookmarksEffect.kt
@@ -17,3 +17,5 @@
 package dev.sasikanth.rss.reader.bookmarks
 
 sealed interface BookmarksEffect
+
+data class OpenLink(val link: String) : BookmarksEffect

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/bookmarks/ui/BookmarksScreen.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/bookmarks/ui/BookmarksScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -51,6 +52,7 @@ import androidx.compose.ui.unit.dp
 import app.cash.paging.compose.collectAsLazyPagingItems
 import dev.sasikanth.rss.reader.bookmarks.BookmarksEvent
 import dev.sasikanth.rss.reader.bookmarks.BookmarksPresenter
+import dev.sasikanth.rss.reader.bookmarks.OpenLink
 import dev.sasikanth.rss.reader.components.CompactFloatingActionButton
 import dev.sasikanth.rss.reader.home.ui.PostListItem
 import dev.sasikanth.rss.reader.platform.LocalLinkHandler
@@ -58,6 +60,7 @@ import dev.sasikanth.rss.reader.resources.icons.Bookmarks
 import dev.sasikanth.rss.reader.resources.icons.TwineIcons
 import dev.sasikanth.rss.reader.resources.strings.LocalStrings
 import dev.sasikanth.rss.reader.ui.AppTheme
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
 @Composable
@@ -72,6 +75,14 @@ internal fun BookmarksScreen(
   val showScrollToTop by remember { derivedStateOf { listState.firstVisibleItemIndex > 0 } }
   val layoutDirection = LocalLayoutDirection.current
   val linkHandler = LocalLinkHandler.current
+
+  LaunchedEffect(Unit) {
+    bookmarksPresenter.effects.collectLatest { effect ->
+      when (effect) {
+        is OpenLink -> coroutineScope.launch { linkHandler.openLink(effect.link) }
+      }
+    }
+  }
 
   Scaffold(
     modifier = modifier,

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/repository/RssRepository.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/repository/RssRepository.kt
@@ -292,6 +292,10 @@ class RssRepository(
     )
   }
 
+  suspend fun hasPost(link: String): Boolean {
+    return withContext(ioDispatcher) { postQueries.hasPost(link).executeAsOne() }
+  }
+
   suspend fun hasFeed(link: String): Boolean {
     return withContext(ioDispatcher) { feedQueries.hasFeed(link).executeAsOne() }
   }

--- a/shared/src/commonMain/sqldelight/dev/sasikanth/rss/reader/database/Post.sq
+++ b/shared/src/commonMain/sqldelight/dev/sasikanth/rss/reader/database/Post.sq
@@ -103,3 +103,6 @@ WHERE feedLink = :feedLink;
 post:
 SELECT * FROM post
 WHERE post.link = :link;
+
+hasPost:
+SELECT EXISTS(SELECT 1 FROM post WHERE link = :link);


### PR DESCRIPTION
App crashes when opening bookmark posts, when posts are no longer present in main table or the feed is removed. In that scenario we are going to fallback to opening webpages directly.