### PR TITLE
Update posts count query to support posts type config

### DIFF
--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/repository/RssRepository.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/repository/RssRepository.kt
@@ -175,7 +175,9 @@ class RssRepository(
       countQuery =
         postQueries.count(
           feedLink = selectedFeedLink,
-          featuredPostsLimit = NUMBER_OF_FEATURED_POSTS
+          featuredPostsLimit = NUMBER_OF_FEATURED_POSTS,
+          unreadOnly = unreadOnly,
+          postsAfter = after,
         ),
       transacter = postQueries,
       context = ioDispatcher,

--- a/shared/src/commonMain/sqldelight/dev/sasikanth/rss/reader/database/Post.sq
+++ b/shared/src/commonMain/sqldelight/dev/sasikanth/rss/reader/database/Post.sq
@@ -25,11 +25,22 @@ UPDATE SET title = excluded.title, description = excluded.description, rawConten
 
 count:
 SELECT COUNT(*) FROM post
-WHERE (:feedLink IS NULL OR post.feedLink = :feedLink) AND post.link NOT IN (
-  SELECT post.link FROM post
-  WHERE (:feedLink IS NULL OR post.feedLink = :feedLink) AND post.imageUrl IS NOT NULL
-  ORDER BY post.date DESC LIMIT :featuredPostsLimit
-);
+WHERE
+  (:unreadOnly IS NULL OR post.read != :unreadOnly) AND
+  (:feedLink IS NULL OR post.feedLink = :feedLink) AND
+  -- Skip featured posts --
+  post.link NOT IN (
+    SELECT post.link FROM post
+    WHERE
+    (:unreadOnly IS NULL OR post.read != :unreadOnly) AND
+    (:feedLink IS NULL OR post.feedLink = :feedLink) AND
+    post.imageUrl IS NOT NULL AND
+    post.date > :postsAfter
+    ORDER BY post.date DESC LIMIT :featuredPostsLimit
+  ) AND
+  -- Skip featured posts --
+  post.date > :postsAfter
+ORDER BY post.date DESC;
 
 featuredPosts:
 SELECT
@@ -71,6 +82,7 @@ INNER JOIN feed ON post.feedLink == feed.link
 WHERE
   (:unreadOnly IS NULL OR post.read != :unreadOnly) AND
   (:feedLink IS NULL OR post.feedLink = :feedLink) AND
+  -- Skip featured posts --
   post.link NOT IN (
     SELECT post.link FROM post
     WHERE
@@ -80,6 +92,7 @@ WHERE
     post.date > :postsAfter
     ORDER BY post.date DESC LIMIT :featuredPostsLimit
   ) AND
+  -- Skip featured posts --
   post.date > :postsAfter
 ORDER BY post.date DESC
 LIMIT :limit OFFSET :offset;


### PR DESCRIPTION
Since we have support for showing different posts type in home screen

- All
- Unread only
- Today

We are updating the count query to support them, similar to how we do when getting the posts.

fixes #272
