### PR TITLE
Fix a memory leak in AndroidFileManager

### DIFF
--- a/shared/src/androidMain/kotlin/dev/sasikanth/rss/reader/filemanager/AndroidFileManager.kt
+++ b/shared/src/androidMain/kotlin/dev/sasikanth/rss/reader/filemanager/AndroidFileManager.kt
@@ -73,10 +73,10 @@ class AndroidFileManager(context: Context) : FileManager {
             registerDocumentOpenActivityResult(activity)
           }
         }
-        
+
         override fun onActivityDestroyed(activity: Activity) {
-            createDocumentLauncher = null
-            openDocumentLauncher = null
+          createDocumentLauncher = null
+          openDocumentLauncher = null
         }
       }
     application.registerActivityLifecycleCallbacks(callback)

--- a/shared/src/androidMain/kotlin/dev/sasikanth/rss/reader/filemanager/AndroidFileManager.kt
+++ b/shared/src/androidMain/kotlin/dev/sasikanth/rss/reader/filemanager/AndroidFileManager.kt
@@ -37,8 +37,8 @@ class AndroidFileManager(context: Context) : FileManager {
   private val application = context as Application
   private val result = Channel<String?>()
 
-  private lateinit var createDocumentLauncher: ActivityResultLauncher<String>
-  private lateinit var openDocumentLauncher: ActivityResultLauncher<Array<String>>
+  private var createDocumentLauncher: ActivityResultLauncher<String>? = null
+  private var openDocumentLauncher: ActivityResultLauncher<Array<String>>? = null
 
   private var content: String? = null
 
@@ -46,12 +46,12 @@ class AndroidFileManager(context: Context) : FileManager {
     this.content = content
 
     if (!this.content.isNullOrBlank()) {
-      createDocumentLauncher.launch(name)
+      createDocumentLauncher?.launch(name)
     }
   }
 
   override suspend fun read(): String? {
-    openDocumentLauncher.launch(
+    openDocumentLauncher?.launch(
       arrayOf("application/xml", "application/octet-stream", "text/xml", "text/x-opml")
     )
     return result.receiveAsFlow().first()
@@ -72,6 +72,11 @@ class AndroidFileManager(context: Context) : FileManager {
             registerDocumentCreateActivityResult(activity)
             registerDocumentOpenActivityResult(activity)
           }
+        }
+        
+        override fun onActivityDestroyed(activity: Activity) {
+            createDocumentLauncher = null
+            openDocumentLauncher = null
         }
       }
     application.registerActivityLifecycleCallbacks(callback)


### PR DESCRIPTION
`createDocumentLauncher` & `openDocumentLauncher` implicitly reference the main activity preventing it from being garbage collected when the activity is destroyed due to a configuration change for example.

Luckily, the fix is simple: just nullify/clear both properties when the activity is destroyed.

**How I was able to reproduce the leak**:

1. Add LeakCanary to the project, specifically to the debug build variant of the android app module.
2. Run the app on an emulator or physical device.
3. open any screen of the app & trigger a config change by rotating phone's screen.
4. the destroyed instance of main activity is watched by LeakCanary and after a few seconds, LeakCanary sees that it remains in memory despite receiving `onDestroy` call because there are still some references to the old instance.
5. following heap dump leak trace produced by LeakCanary leads to the suspicious reference `createDocumentLauncher`

UPDATE, leak trace: 
```
┬───
│ GC Root: System class
│
├─ android.provider.FontsContract class
│    Leaking: NO (ReaderApplication↓ is not leaking and a class is never
│    leaking)
│    ↓ static FontsContract.sContext
├─ dev.sasikanth.rss.reader.ReaderApplication instance
│    Leaking: NO (Application is a singleton)
│    mBase instance of android.app.ContextImpl
│    ↓ ReaderApplication.appComponent
│                        ~~~~~~~~~~~
├─ dev.sasikanth.rss.reader.di.ApplicationComponent instance
│    Leaking: UNKNOWN
│    Retaining 1.9 MB in 28036 objects
│    application instance of dev.sasikanth.rss.reader.ReaderApplication
│    ↓ ApplicationComponent.initializers
│                           ~~~~~~~~~~~~
├─ kotlin.collections.Set instance
│    ↓ LinkedHashSet.map
│                   ~~~~
├─ java.util.HashMap instance
│    ↓ HashMap.table
│              ~~~~~
├─ build.tools.jdwpgen.Node[] array
│    ↓ Node[].[0]
│             ~~~
├─ dev.sasikanth.rss.reader.filemanager.AndroidFileManagerInitializer instance
│    Leaking: UNKNOWN
│    Retaining 1.7 MB in 24147 objects
│    ↓ AndroidFileManagerInitializer.fileManager
│                                    ~~~~~~~~~~
├─ dev.sasikanth.rss.reader.filemanager.AndroidFileManager instance
│    Leaking: UNKNOWN
│    Retaining 1.3 MB in 19381 objects
│    initializer instance of dev.sasikanth.rss.reader.filemanager.AndroidFileManagerInitializer
│    ↓ AndroidFileManager.createDocumentLauncher
│                         ~~~~~~~~~~~~~~~~~~~~~~
├─ androidx.activity.result.ActivityResultRegistry$register$2 instance
│    Leaking: UNKNOWN
│    Retaining 32 B in 2 objects
│    Anonymous subclass of androidx.activity.result.ActivityResultLauncher
│    ↓ ActivityResultRegistry$register$2.this$0
│                                        ~~~~~~
├─ androidx.activity.ComponentActivity$activityResultRegistry$1 instance
│    Leaking: UNKNOWN
│    Retaining 1.7 MB in 24138 objects
│    Anonymous subclass of androidx.activity.result.ActivityResultRegistry
│    this$0 instance of dev.sasikanth.rss.reader.MainActivity with mDestroyed = true
│    ↓ ComponentActivity$activityResultRegistry$1.this$0
│                                                 ~~~~~~
╰→ dev.sasikanth.rss.reader.MainActivity instance
​     Leaking: YES (ObjectWatcher was watching this because dev.sasikanth.rss.reader.MainActivity received Activity#onDestroy() callback and
​     Activity#mDestroyed is true)
​     Retaining 1.7 MB in 24123 objects
​     key = e5793cd7-1e46-4ab8-bac4-79552981be8c
​     watchDurationMillis = 27801
​     retainedDurationMillis = 22783
​     mApplication instance of dev.sasikanth.rss.reader.ReaderApplication
​     mBase instance of android.app.ContextImpl
```