### PR TITLE
Wrap HTML content in reader view with a `div`

### DIFF
--- a/shared/src/commonMain/composeResources/files/reader/main.js
+++ b/shared/src/commonMain/composeResources/files/reader/main.js
@@ -119,8 +119,9 @@ async function renderReaderView(link, html, colors) {
     {}
   );
 
+  const sanitizedHtml = `<div>${html}</div>`
   //noinspection JSUnresolvedVariable
-  const result = await Mercury.parse(link, { html: html });
+  const result = await Mercury.parse(link, { html: sanitizedHtml });
   const content = result.content || html;
 
   document.getElementById("content").innerHTML += content;


### PR DESCRIPTION
This is to make sure even the normal text content is parsed correctly by Mercury parser