### PR TITLE
Feature read correct favicon from feed rss

### DIFF
--- a/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/repository/RssRepository.kt
+++ b/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/repository/RssRepository.kt
@@ -280,7 +280,7 @@ class RssRepository(
             id: String,
             name: String,
             feedIds: List<String>,
-            feedHomepageLinks: String,
+            feedIconLinks: String,
             createdAt: Instant,
             updatedAt: Instant,
             pinnedAt: Instant?,
@@ -289,7 +289,7 @@ class RssRepository(
               id = id,
               name = name,
               feedIds = feedIds.filterNot { it.isBlank() },
-              feedHomepageLinks = feedHomepageLinks.split(",").filterNot { it.isBlank() },
+              feedIconLinks = feedIconLinks.split(",").filterNot { it.isBlank() },
               createdAt = createdAt,
               updatedAt = updatedAt,
               pinnedAt = pinnedAt,
@@ -626,7 +626,7 @@ class RssRepository(
           lastCleanUpAt: Instant?,
           numberOfUnreadPosts: Long,
           feedIds: List<String>?,
-          feedHomepageLinks: String?,
+          feedIconLinks: String?,
           updatedAt: Instant?,
           pinnedPosition: Double ->
           if (type == "group") {
@@ -634,8 +634,8 @@ class RssRepository(
               id = id,
               name = name,
               feedIds = feedIds?.filterNot { it.isBlank() }.orEmpty(),
-              feedHomepageLinks =
-                feedHomepageLinks?.split(",")?.filterNot { it.isBlank() }.orEmpty(),
+              feedIconLinks =
+                feedIconLinks?.split(",")?.filterNot { it.isBlank() }.orEmpty(),
               createdAt = createdAt!!,
               updatedAt = updatedAt!!,
               pinnedAt = pinnedAt,
@@ -690,15 +690,15 @@ class RssRepository(
             lastCleanUpAt: Instant?,
             numberOfUnreadPosts: Long,
             feedIds: List<String>?,
-            feedHomepageLinks: String?,
+            feedIconLinks: String?,
             updatedAt: Instant? ->
             if (type == "group") {
               FeedGroup(
                 id = id,
                 name = name,
                 feedIds = feedIds?.filterNot { it.isBlank() }.orEmpty(),
-                feedHomepageLinks =
-                  feedHomepageLinks?.split(",")?.filterNot { it.isBlank() }.orEmpty(),
+                feedIconLinks =
+                  feedIconLinks?.split(",")?.filterNot { it.isBlank() }.orEmpty(),
                 createdAt = createdAt,
                 updatedAt = updatedAt!!,
                 pinnedAt = pinnedAt,
@@ -737,7 +737,7 @@ class RssRepository(
             id: String,
             name: String,
             feedIds: List<String>,
-            feedHomepageLinks: String,
+            feedIconLinks: String,
             createdAt: Instant,
             updatedAt: Instant,
             pinnedAt: Instant?,
@@ -746,7 +746,7 @@ class RssRepository(
               id = id,
               name = name,
               feedIds = feedIds.filterNot { it.isBlank() },
-              feedHomepageLinks = feedHomepageLinks.split(",").filterNot { it.isBlank() },
+              feedIconLinks = feedIconLinks.split(",").filterNot { it.isBlank() },
               createdAt = createdAt,
               updatedAt = updatedAt,
               pinnedAt = pinnedAt,
@@ -771,7 +771,7 @@ class RssRepository(
             id: String,
             name: String,
             feedIds: List<String>,
-            feedHomepageLinks: String,
+            feedIconLinks: String,
             createdAt: Instant,
             updatedAt: Instant,
             pinnedAt: Instant? ->
@@ -779,7 +779,7 @@ class RssRepository(
               id = id,
               name = name,
               feedIds = feedIds.filterNot { it.isBlank() },
-              feedHomepageLinks = feedHomepageLinks.split(",").filterNot { it.isBlank() },
+              feedIconLinks = feedIconLinks.split(",").filterNot { it.isBlank() },
               createdAt = createdAt,
               updatedAt = updatedAt,
               pinnedAt = pinnedAt,
@@ -798,7 +798,7 @@ class RssRepository(
           id: String,
           name: String,
           feedIds: List<String>,
-          feedHomepageLinks: String,
+          feedIconLinks: String,
           createdAt: Instant,
           updatedAt: Instant,
           pinnedAt: Instant? ->
@@ -806,7 +806,7 @@ class RssRepository(
             id = id,
             name = name,
             feedIds = feedIds.filterNot { it.isBlank() },
-            feedHomepageLinks = feedHomepageLinks.split(",").filterNot { it.isBlank() },
+            feedIconLinks = feedIconLinks.split(",").filterNot { it.isBlank() },
             createdAt = createdAt,
             updatedAt = updatedAt,
             pinnedAt = pinnedAt,

--- a/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/repository/RssRepository.kt
+++ b/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/repository/RssRepository.kt
@@ -634,8 +634,7 @@ class RssRepository(
               id = id,
               name = name,
               feedIds = feedIds?.filterNot { it.isBlank() }.orEmpty(),
-              feedIconLinks =
-                feedIconLinks?.split(",")?.filterNot { it.isBlank() }.orEmpty(),
+              feedIconLinks = feedIconLinks?.split(",")?.filterNot { it.isBlank() }.orEmpty(),
               createdAt = createdAt!!,
               updatedAt = updatedAt!!,
               pinnedAt = pinnedAt,
@@ -697,8 +696,7 @@ class RssRepository(
                 id = id,
                 name = name,
                 feedIds = feedIds?.filterNot { it.isBlank() }.orEmpty(),
-                feedIconLinks =
-                  feedIconLinks?.split(",")?.filterNot { it.isBlank() }.orEmpty(),
+                feedIconLinks = feedIconLinks?.split(",")?.filterNot { it.isBlank() }.orEmpty(),
                 createdAt = createdAt,
                 updatedAt = updatedAt!!,
                 pinnedAt = pinnedAt,

--- a/core/data/src/commonMain/sqldelight/dev/sasikanth/rss/reader/data/database/FeedGroup.sq
+++ b/core/data/src/commonMain/sqldelight/dev/sasikanth/rss/reader/data/database/FeedGroup.sq
@@ -26,10 +26,10 @@ SELECT
   id,
   name,
   feedIds,
-  COALESCE((SELECT GROUP_CONCAT(feed.homepageLink)
+  COALESCE((SELECT GROUP_CONCAT(feed.icon)
               FROM feed
               WHERE INSTR(feedGroup.feedIds, feed.id)
-              LIMIT 4), '') AS feedHomepageLinks,
+              LIMIT 4), '') AS feedIconLinks,
   createdAt,
   updatedAt,
   pinnedAt,
@@ -42,10 +42,10 @@ SELECT
   id,
   name,
   feedIds,
-  COALESCE((SELECT GROUP_CONCAT(feed.homepageLink)
+  COALESCE((SELECT GROUP_CONCAT(feed.icon)
               FROM feed
               WHERE INSTR(feedGroup.feedIds, feed.id)
-              LIMIT 4), '') AS feedHomepageLinks,
+              LIMIT 4), '') AS feedIconLinks,
   createdAt,
   updatedAt,
   pinnedAt,
@@ -79,10 +79,10 @@ SELECT
   id,
   name,
   feedIds,
-  COALESCE((SELECT GROUP_CONCAT(feed.homepageLink)
+  COALESCE((SELECT GROUP_CONCAT(feed.icon)
               FROM feed
               WHERE INSTR(feedGroup.feedIds, feed.id)
-              LIMIT 4), '') AS feedHomepageLinks,
+              LIMIT 4), '') AS feedIconLinks,
   createdAt,
   updatedAt,
   pinnedAt

--- a/core/data/src/commonMain/sqldelight/dev/sasikanth/rss/reader/data/database/Source.sq
+++ b/core/data/src/commonMain/sqldelight/dev/sasikanth/rss/reader/data/database/Source.sq
@@ -59,10 +59,10 @@ FROM (
     NULL AS lastCleanUpAt,
     COUNT(CASE WHEN p.read == 0 THEN 1 ELSE NULL END) AS numberOfUnreadPosts,
     fg.feedIds,
-    COALESCE((SELECT GROUP_CONCAT(feed.homepageLink)
+    COALESCE((SELECT GROUP_CONCAT(feed.icon)
                 FROM feed
                 WHERE INSTR(fg.feedIds, feed.id)
-                LIMIT 4), '') AS feedHomepageLinks,
+                LIMIT 4), '') AS feedIconLinks,
     fg.createdAt,
     fg.pinnedAt,
     fg.updatedAt,
@@ -123,10 +123,10 @@ FROM (
     NULL AS lastCleanUpAt,
     COUNT(CASE WHEN p.read == 0 THEN 1 ELSE NULL END) AS numberOfUnreadPosts,
     fg.feedIds,
-    COALESCE((SELECT GROUP_CONCAT(feed.homepageLink)
+    COALESCE((SELECT GROUP_CONCAT(feed.icon)
                 FROM feed
                 WHERE INSTR(fg.feedIds, feed.id)
-                LIMIT 4), '') AS feedHomepageLinks,
+                LIMIT 4), '') AS feedIconLinks,
     fg.createdAt,
     fg.pinnedAt,
     fg.updatedAt

--- a/core/model/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/model/local/FeedGroup.kt
+++ b/core/model/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/model/local/FeedGroup.kt
@@ -19,14 +19,14 @@ package dev.sasikanth.rss.reader.core.model.local
 import kotlinx.datetime.Instant
 
 data class FeedGroup(
-  override val id: String,
-  val name: String,
-  val feedIds: List<String>,
-  val feedHomepageLinks: List<String>,
-  val numberOfUnreadPosts: Long = 0,
-  val createdAt: Instant,
-  val updatedAt: Instant,
-  override val pinnedAt: Instant?,
-  override val sourceType: SourceType = SourceType.FeedGroup,
-  override val pinnedPosition: Double = 0.0,
+    override val id: String,
+    val name: String,
+    val feedIds: List<String>,
+    val feedIconLinks: List<String>,
+    val numberOfUnreadPosts: Long = 0,
+    val createdAt: Instant,
+    val updatedAt: Instant,
+    override val pinnedAt: Instant?,
+    override val sourceType: SourceType = SourceType.FeedGroup,
+    override val pinnedPosition: Double = 0.0,
 ) : Source

--- a/core/model/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/model/local/FeedGroup.kt
+++ b/core/model/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/model/local/FeedGroup.kt
@@ -19,14 +19,14 @@ package dev.sasikanth.rss.reader.core.model.local
 import kotlinx.datetime.Instant
 
 data class FeedGroup(
-    override val id: String,
-    val name: String,
-    val feedIds: List<String>,
-    val feedIconLinks: List<String>,
-    val numberOfUnreadPosts: Long = 0,
-    val createdAt: Instant,
-    val updatedAt: Instant,
-    override val pinnedAt: Instant?,
-    override val sourceType: SourceType = SourceType.FeedGroup,
-    override val pinnedPosition: Double = 0.0,
+  override val id: String,
+  val name: String,
+  val feedIds: List<String>,
+  val feedIconLinks: List<String>,
+  val numberOfUnreadPosts: Long = 0,
+  val createdAt: Instant,
+  val updatedAt: Instant,
+  override val pinnedAt: Instant?,
+  override val sourceType: SourceType = SourceType.FeedGroup,
+  override val pinnedPosition: Double = 0.0,
 ) : Source

--- a/core/network/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/network/parser/FeedParser.kt
+++ b/core/network/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/network/parser/FeedParser.kt
@@ -77,6 +77,8 @@ class FeedParser(private val dispatchersProvider: DispatchersProvider) {
 
     internal const val TAG_RSS_CHANNEL = "channel"
     internal const val TAG_ATOM_FEED = "feed"
+    internal const val TAG_ATOM_ICON = "icon"
+    internal const val TAG_ATOM_LOGO = "logo"
     internal const val TAG_RSS_ITEM = "item"
     internal const val TAG_ATOM_ENTRY = "entry"
 
@@ -101,16 +103,13 @@ class FeedParser(private val dispatchersProvider: DispatchersProvider) {
     internal const val ATTR_URL = "url"
     internal const val ATTR_TYPE = "type"
     internal const val ATTR_REL = "rel"
+    internal const val ATTR_RDF_RESOURCE = "rdf:resource"
     internal const val ATTR_HREF = "href"
 
     internal const val ATTR_VALUE_ALTERNATE = "alternate"
     internal const val ATTR_VALUE_IMAGE = "image/jpeg"
 
     fun cleanText(text: String?) = text?.replace(htmlTag, "")?.replace(blankLine, "")?.trim()
-
-    fun feedIcon(host: String): String {
-      return "https://icon.horse/icon/$host"
-    }
 
     fun safeUrl(host: String?, url: String?): String? {
       if (host.isNullOrBlank()) return null

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feed/ui/FeedInfoBottomSheet.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feed/ui/FeedInfoBottomSheet.kt
@@ -247,7 +247,7 @@ private fun FeedLabelInput(
       .fillMaxWidth()
   ) {
     FeedFavIcon(
-      url = feed.homepageLink,
+      url = feed.icon,
       contentDescription = feed.name,
       modifier = Modifier.requiredSize(56.dp).clip(RoundedCornerShape(16.dp)),
     )

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/BottomSheetCollapsedContent.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/BottomSheetCollapsedContent.kt
@@ -96,7 +96,7 @@ internal fun BottomSheetCollapsedContent(
           is Feed -> {
             FeedBottomBarItem(
               badgeCount = source.numberOfUnreadPosts,
-              homePageUrl = source.homepageLink,
+              iconUrl = source.icon,
               canShowUnreadPostsCount = canShowUnreadPostsCount,
               onClick = { onSourceClick(source) },
               selected = activeSource?.id == source.id

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/FeedBottomBarItem.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/FeedBottomBarItem.kt
@@ -42,7 +42,7 @@ import dev.sasikanth.rss.reader.utils.Constants.BADGE_COUNT_TRIM_LIMIT
 @Composable
 internal fun FeedBottomBarItem(
   badgeCount: Long,
-  homePageUrl: String,
+  iconUrl: String,
   canShowUnreadPostsCount: Boolean,
   onClick: () -> Unit,
   modifier: Modifier = Modifier,
@@ -52,7 +52,7 @@ internal fun FeedBottomBarItem(
     Box(contentAlignment = Alignment.Center) {
       SelectionIndicator(selected = selected, animationProgress = 1f)
       FeedFavIcon(
-        url = homePageUrl,
+        url = iconUrl,
         contentDescription = null,
         modifier =
           Modifier.requiredSize(56.dp).clip(RoundedCornerShape(16.dp)).clickable(onClick = onClick)

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/FeedGroupBottomBarItem.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/FeedGroupBottomBarItem.kt
@@ -58,21 +58,21 @@ internal fun FeedGroupBottomBarItem(
         contentAlignment = Alignment.Center
       ) {
         val iconSize =
-          if (feedGroup.feedHomepageLinks.size > 2) {
+          if (feedGroup.feedIconLinks.size > 2) {
             18.dp
           } else {
             20.dp
           }
 
         val iconSpacing =
-          if (feedGroup.feedHomepageLinks.size > 2) {
+          if (feedGroup.feedIconLinks.size > 2) {
             4.dp
           } else {
             0.dp
           }
 
         FeedGroupIconGrid(
-          icons = feedGroup.feedHomepageLinks,
+          icons = feedGroup.feedIconLinks,
           iconSize = iconSize,
           iconShape = CircleShape,
           verticalArrangement = Arrangement.spacedBy(iconSpacing),

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/FeedGroupItem.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/FeedGroupItem.kt
@@ -99,14 +99,14 @@ internal fun FeedGroupItem(
   ) {
     Row(verticalAlignment = Alignment.CenterVertically) {
       val iconSize =
-        if (feedGroup.feedHomepageLinks.size > 2) {
+        if (feedGroup.feedIconLinks.size > 2) {
           17.dp
         } else {
           19.dp
         }
 
       val iconSpacing =
-        if (feedGroup.feedHomepageLinks.size > 2) {
+        if (feedGroup.feedIconLinks.size > 2) {
           2.dp
         } else {
           0.dp
@@ -114,7 +114,7 @@ internal fun FeedGroupItem(
 
       FeedGroupIconGrid(
         modifier = Modifier.requiredSize(36.dp),
-        icons = feedGroup.feedHomepageLinks,
+        icons = feedGroup.feedIconLinks,
         iconSize = iconSize,
         iconShape = CircleShape,
         verticalArrangement = Arrangement.spacedBy(iconSpacing),

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/FeedListItem.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/FeedListItem.kt
@@ -96,7 +96,7 @@ internal fun FeedListItem(
   ) {
     Row(modifier = Modifier.padding(all = 8.dp), verticalAlignment = Alignment.CenterVertically) {
       FeedFavIcon(
-        url = feed.homepageLink,
+        url = feed.icon,
         contentDescription = null,
         modifier = Modifier.requiredSize(36.dp).clip(RoundedCornerShape(8.dp)),
         contentScale = ContentScale.Crop,

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/ui/HomeTopAppBar.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/ui/HomeTopAppBar.kt
@@ -215,7 +215,7 @@ private fun SourceIcon(source: Source?, modifier: Modifier = Modifier) {
       }
       is Feed -> {
         FeedFavIcon(
-          url = source.homepageLink,
+          url = source.icon,
           contentDescription = null,
           modifier = Modifier.clip(MaterialTheme.shapes.small).requiredSize(24.dp)
         )

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/ui/HomeTopAppBar.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/ui/HomeTopAppBar.kt
@@ -192,21 +192,21 @@ private fun SourceIcon(source: Source?, modifier: Modifier = Modifier) {
     when (source) {
       is FeedGroup -> {
         val iconSize =
-          if (source.feedHomepageLinks.size > 2) {
+          if (source.feedIconLinks.size > 2) {
             18.dp
           } else {
             20.dp
           }
 
         val iconSpacing =
-          if (source.feedHomepageLinks.size > 2) {
+          if (source.feedIconLinks.size > 2) {
             4.dp
           } else {
             0.dp
           }
 
         FeedGroupIconGrid(
-          icons = source.feedHomepageLinks,
+          icons = source.feedIconLinks,
           iconSize = iconSize,
           iconShape = RoundedCornerShape(percent = 30),
           horizontalArrangement = Arrangement.spacedBy(iconSpacing),


### PR DESCRIPTION
Hi, this relates to issue #785.

I have done a further investigation and discovered that in current version of the app the icon loaded is retrieved using the `<link>` property from the feed, and not the `<image><url>` for RSS or` <icon>` `<logo>` for ATOM. 

So I have replaced this logic, and now it gets the configured icon for the feed, and when is not available, uses the previous logic, so it gets from `feed.homepageLink`.

I am not a mobile developer, so all insights are welcome.

And I have already mentioned, but thanks again, amazing app! 

Evidence:
![evidence](https://github.com/user-attachments/assets/78ce9c0a-a1f2-4dac-a7f8-ea3c1b195446)

I am using same OPML file that on issue, I can share privately with project maintainers, as I am self hosting my feeds.
