### PR TITLE
Simplify source filtering in post queries

### DIFF
--- a/.idea/AndroidProjectSystem.xml
+++ b/.idea/AndroidProjectSystem.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AndroidProjectSystem">
+    <option name="providerId" value="com.android.tools.idea.GradleProjectSystem" />
+  </component>
+</project>

--- a/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/repository/RssRepository.kt
+++ b/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/repository/RssRepository.kt
@@ -169,13 +169,14 @@ class RssRepository(
   }
 
   fun featuredPosts(
-    selectedFeedId: String?,
+    activeSourceIds: List<String>,
     unreadOnly: Boolean? = null,
     after: Instant = Instant.DISTANT_PAST
   ): Flow<List<PostWithMetadata>> {
     return postQueries
       .featuredPosts(
-        sourceId = selectedFeedId,
+        isSourceIdsEmpty = activeSourceIds.isEmpty(),
+        sourceIds = activeSourceIds,
         unreadOnly = unreadOnly,
         postsAfter = after,
         limit = NUMBER_OF_FEATURED_POSTS,
@@ -186,7 +187,7 @@ class RssRepository(
   }
 
   fun posts(
-    selectedFeedId: String?,
+    activeSourceIds: List<String>,
     featuredPostsIds: List<String>,
     unreadOnly: Boolean? = null,
     after: Instant = Instant.DISTANT_PAST,
@@ -194,7 +195,8 @@ class RssRepository(
     return QueryPagingSource(
       countQuery =
         postQueries.count(
-          sourceId = selectedFeedId,
+          isSourceIdsEmpty = activeSourceIds.isEmpty(),
+          sourceIds = activeSourceIds,
           featuredPosts = featuredPostsIds,
           unreadOnly = unreadOnly,
           postsAfter = after,
@@ -203,7 +205,8 @@ class RssRepository(
       context = ioDispatcher,
       queryProvider = { limit, offset ->
         postQueries.posts(
-          sourceId = selectedFeedId,
+          isSourceIdsEmpty = activeSourceIds.isEmpty(),
+          sourceIds = activeSourceIds,
           featuredPosts = featuredPostsIds,
           unreadOnly = unreadOnly,
           postsAfter = after,
@@ -890,11 +893,15 @@ class RssRepository(
   }
 
   fun hasUnreadPostsInSource(
-    sourceId: String?,
+    activeSourceIds: List<String>,
     postsAfter: Instant = Instant.DISTANT_PAST
   ): Flow<Boolean> {
     return postQueries
-      .unreadPostsCountInSource(sourceId = sourceId, after = postsAfter)
+      .unreadPostsCountInSource(
+        isSourceIdsEmpty = activeSourceIds.isEmpty(),
+        sourceIds = activeSourceIds,
+        after = postsAfter
+      )
       .asFlow()
       .mapToOne(ioDispatcher)
       .map { it > 0 }

--- a/core/data/src/commonMain/sqldelight/dev/sasikanth/rss/reader/data/database/Post.sq
+++ b/core/data/src/commonMain/sqldelight/dev/sasikanth/rss/reader/data/database/Post.sq
@@ -65,22 +65,17 @@ UPDATE SET
     read = CASE WHEN :isDateParsedCorrectly AND date < excluded.date THEN excluded.read ELSE read END;
 
 count:
-SELECT COUNT(DISTINCT post.id) FROM post
-LEFT JOIN feedGroup ON INSTR(feedGroup.feedIds, post.sourceId)
+SELECT COUNT(post.id) FROM post
 WHERE
+  ((:isSourceIdsEmpty) OR post.sourceId IN :sourceIds) AND
   post.isHidden == 0 AND
   (:unreadOnly IS NULL OR post.read != :unreadOnly) AND
-  (
-    :sourceId IS NULL OR
-    post.sourceId = :sourceId OR
-    feedGroup.id = :sourceId
-  ) AND
   post.id NOT IN :featuredPosts AND
   post.date > :postsAfter
 ORDER BY post.date DESC;
 
 featuredPosts:
-SELECT DISTINCT
+SELECT
   post.id,
   sourceId,
   post.title,
@@ -95,21 +90,16 @@ SELECT DISTINCT
   feed.icon AS feedIcon
 FROM post
 INNER JOIN feed ON post.sourceId == feed.id
-LEFT JOIN  feedGroup ON INSTR(feedGroup.feedIds, post.sourceId)
 WHERE
+  ((:isSourceIdsEmpty) OR post.sourceId IN :sourceIds) AND
   post.isHidden == 0 AND
   (:unreadOnly IS NULL OR post.read != :unreadOnly) AND
-  (
-    :sourceId IS NULL OR
-    post.sourceId = :sourceId OR
-    feedGroup.id = :sourceId
-  ) AND
   post.imageUrl IS NOT NULL AND
   post.date > :postsAfter
 ORDER BY post.date DESC LIMIT :limit;
 
 posts:
-SELECT DISTINCT
+SELECT
   post.id,
   sourceId,
   post.title,
@@ -124,15 +114,10 @@ SELECT DISTINCT
   feed.icon AS feedIcon
 FROM post
 INNER JOIN feed ON post.sourceId == feed.id
-LEFT JOIN feedGroup ON INSTR(feedGroup.feedIds, post.sourceId)
 WHERE
+  ((:isSourceIdsEmpty) OR post.sourceId IN :sourceIds) AND
   post.isHidden == 0 AND
   (:unreadOnly IS NULL OR post.read != :unreadOnly) AND
-  (
-    :sourceId IS NULL OR
-    post.sourceId = :sourceId OR
-    feedGroup.id = :sourceId
-  ) AND
   post.id NOT IN :featuredPosts AND
   post.date > :postsAfter
 ORDER BY post.date DESC
@@ -163,13 +148,8 @@ SELECT EXISTS(SELECT 1 FROM post WHERE id = :id);
 
 unreadPostsCountInSource:
 SELECT COUNT(*) FROM post
-LEFT JOIN feedGroup ON INSTR(feedGroup.feedIds, post.sourceId)
 WHERE
+  ((:isSourceIdsEmpty) OR post.sourceId IN :sourceIds) AND
   post.isHidden == 0 AND
   read != 1 AND
-  date > :after AND
-  (
-    :sourceId IS NULL OR
-    post.sourceId = :sourceId OR
-    feedGroup.id = :sourceId
-  );
+  date > :after;


### PR DESCRIPTION
This should avoid making any unnecessary joins and improve the memory usage and performance.