### PR TITLE
Load posts based on `lastSyncedAt` in the reader screen

### DIFF
--- a/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/repository/RssRepository.kt
+++ b/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/repository/RssRepository.kt
@@ -181,6 +181,7 @@ class RssRepository(
     activeSourceIds: List<String>,
     unreadOnly: Boolean? = null,
     after: Instant = Instant.DISTANT_PAST,
+    lastSyncedAt: Instant = Instant.DISTANT_PAST,
   ): PagingSource<Int, PostWithMetadata> {
     return QueryPagingSource(
       countQuery =
@@ -189,6 +190,7 @@ class RssRepository(
           sourceIds = activeSourceIds,
           unreadOnly = unreadOnly,
           postsAfter = after,
+          lastSyncedAt = lastSyncedAt,
         ),
       transacter = postQueries,
       context = dispatchersProvider.databaseRead,
@@ -199,6 +201,7 @@ class RssRepository(
           unreadOnly = unreadOnly,
           postsAfter = after,
           numberOfFeaturedPosts = Constants.NUMBER_OF_FEATURED_POSTS,
+          lastSyncedAt = lastSyncedAt,
           limit = limit,
           offset = offset,
           mapper = {

--- a/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/repository/RssRepository.kt
+++ b/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/repository/RssRepository.kt
@@ -181,7 +181,7 @@ class RssRepository(
     activeSourceIds: List<String>,
     unreadOnly: Boolean? = null,
     after: Instant = Instant.DISTANT_PAST,
-    lastSyncedAt: Instant = Instant.DISTANT_PAST,
+    lastSyncedAt: Instant = Instant.DISTANT_FUTURE,
   ): PagingSource<Int, PostWithMetadata> {
     return QueryPagingSource(
       countQuery =

--- a/core/data/src/commonMain/sqldelight/dev/sasikanth/rss/reader/data/database/Post.sq
+++ b/core/data/src/commonMain/sqldelight/dev/sasikanth/rss/reader/data/database/Post.sq
@@ -88,7 +88,7 @@ WHERE
   post.isHidden == 0 AND
   (:unreadOnly IS NULL OR post.read != :unreadOnly) AND
   post.date > :postsAfter AND
-  post.syncedAt > :lastSyncedAt;
+  post.syncedAt < :lastSyncedAt;
 
 allPosts:
 WITH featuredPosts AS (
@@ -117,7 +117,7 @@ WITH featuredPosts AS (
     (:unreadOnly IS NULL OR post.read != :unreadOnly) AND
     post.imageUrl IS NOT NULL AND
     post.date > :postsAfter AND
-    post.syncedAt > :lastSyncedAt
+    post.syncedAt < :lastSyncedAt
   ORDER BY post.date DESC
   LIMIT :numberOfFeaturedPosts
 )
@@ -151,7 +151,7 @@ WHERE
   (:unreadOnly IS NULL OR post.read != :unreadOnly) AND
   post.id NOT IN (SELECT id FROM featuredPosts) AND
   post.date > :postsAfter AND
-  post.syncedAt > :lastSyncedAt
+  post.syncedAt < :lastSyncedAt
 ORDER BY isFeatured DESC, date DESC
 LIMIT :limit OFFSET :offset;
 

--- a/core/data/src/commonMain/sqldelight/dev/sasikanth/rss/reader/data/database/Post.sq
+++ b/core/data/src/commonMain/sqldelight/dev/sasikanth/rss/reader/data/database/Post.sq
@@ -87,7 +87,8 @@ WHERE
   ((:isSourceIdsEmpty) OR post.sourceId IN :sourceIds) AND
   post.isHidden == 0 AND
   (:unreadOnly IS NULL OR post.read != :unreadOnly) AND
-  post.date > :postsAfter;
+  post.date > :postsAfter AND
+  post.syncedAt > :lastSyncedAt;
 
 allPosts:
 WITH featuredPosts AS (
@@ -115,7 +116,8 @@ WITH featuredPosts AS (
     post.isHidden == 0 AND
     (:unreadOnly IS NULL OR post.read != :unreadOnly) AND
     post.imageUrl IS NOT NULL AND
-    post.date > :postsAfter
+    post.date > :postsAfter AND
+    post.syncedAt > :lastSyncedAt
   ORDER BY post.date DESC
   LIMIT :numberOfFeaturedPosts
 )
@@ -148,7 +150,8 @@ WHERE
   post.isHidden == 0 AND
   (:unreadOnly IS NULL OR post.read != :unreadOnly) AND
   post.id NOT IN (SELECT id FROM featuredPosts) AND
-  post.date > :postsAfter
+  post.date > :postsAfter AND
+  post.syncedAt > :lastSyncedAt
 ORDER BY isFeatured DESC, date DESC
 LIMIT :limit OFFSET :offset;
 

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/reader/ReaderPresenter.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/reader/ReaderPresenter.kt
@@ -46,6 +46,7 @@ import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
 import me.tatarka.inject.annotations.Assisted
@@ -167,6 +168,7 @@ class ReaderPresenter(
 
     private fun init() {
       coroutineScope.launch {
+        val currentTime = Clock.System.now()
         val activeSource = observableActiveSource.activeSource.firstOrNull()
         val postsType = settingsRepository.postsType.first()
 
@@ -189,6 +191,7 @@ class ReaderPresenter(
                     activeSourceIds = activeSourceIds,
                     unreadOnly = unreadOnly,
                     after = postsAfter,
+                    lastSyncedAt = currentTime,
                   )
                 }
                 is Search -> {


### PR DESCRIPTION

### Description
**Summary**  
This pull request enhances the post retrieval logic by adding a `lastSyncedAt` filter to the `allPosts` query. It ensures that posts in the reader screen are loaded based on the `lastSyncedAt` timestamp. This prevents auto-updating of posts, which could inadvertently shift the opened post index when new posts are loaded.

**Changes**  
- Added `lastSyncedAt` filter to `allPosts` query.
- Updated the reader screen to load posts using the `lastSyncedAt` filter. 

**Impact**  
This change improves the user experience by maintaining the context when new data is synced, avoiding disruptions caused by index shifts