### PR TITLE
Select Xcode 16.1 to building archive when publishing to App Store

### DIFF
--- a/.github/workflows/ios_prod_release.yml
+++ b/.github/workflows/ios_prod_release.yml
@@ -64,6 +64,9 @@ jobs:
           /usr/libexec/Plistbuddy -c "Set CFBundleVersion ${{ steps.tramline.outputs.version_code }}" "iosApp/iosApp/Info.plist"
           /usr/libexec/Plistbuddy -c "Set CFBundleShortVersionString ${{ steps.tramline.outputs.version_name }}" "iosApp/iosApp/Info.plist"
 
+      - name: Select latest Xcode
+        run: "sudo xcode-select -s /Applications/Xcode_16.1.app"
+
       - name: Build Archive
         run: |          
           xcodebuild -project ./iosApp/iosApp.xcodeproj \

--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,6 @@ androidApp/release
 .idea/assetWizardSettings.xml
 .idea/modules.xml
 .idea/appInsightsSettings.xml
+.idea/shelf
 gradle.xml
 *.iml


### PR DESCRIPTION
We need this to satisfy the min SDK requirements when publishing to App Store.