### PR TITLE
Update HomePresenter and UI for current date handling

### DIFF
--- a/core/base/src/androidMain/kotlin/dev/sasikanth/rss/reader/util/DateExt.android.kt
+++ b/core/base/src/androidMain/kotlin/dev/sasikanth/rss/reader/util/DateExt.android.kt
@@ -16,14 +16,21 @@
 
 package dev.sasikanth.rss.reader.util
 
-import java.time.LocalDateTime
+import java.time.LocalDateTime as JavaLocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.TimeZone
 import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.toJavaInstant
+import kotlinx.datetime.toJavaLocalDateTime
 
 actual fun Instant.readerDateTimestamp(): String {
   val dateTimeFormatter = DateTimeFormatter.ofPattern("MMM dd, yyyy • hh:mm a")
-  val dateTime = LocalDateTime.ofInstant(toJavaInstant(), TimeZone.getDefault().toZoneId())
+  val dateTime = JavaLocalDateTime.ofInstant(toJavaInstant(), TimeZone.getDefault().toZoneId())
   return dateTimeFormatter.format(dateTime)
+}
+
+actual fun LocalDateTime.homeAppBarTimestamp(): String {
+  val dateTimeFormatter = DateTimeFormatter.ofPattern("EEE, MMM dd")
+  return dateTimeFormatter.format(toJavaLocalDateTime())
 }

--- a/core/base/src/commonMain/kotlin/dev/sasikanth/rss/reader/util/DateExt.kt
+++ b/core/base/src/commonMain/kotlin/dev/sasikanth/rss/reader/util/DateExt.kt
@@ -16,7 +16,10 @@
 package dev.sasikanth.rss.reader.util
 
 import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDateTime
 
 expect fun Instant.relativeDurationString(): String
 
 expect fun Instant.readerDateTimestamp(): String
+
+expect fun LocalDateTime.homeAppBarTimestamp(): String

--- a/core/base/src/iosMain/kotlin/dev/sasikanth/rss/reader/util/DateExt.ios.kt
+++ b/core/base/src/iosMain/kotlin/dev/sasikanth/rss/reader/util/DateExt.ios.kt
@@ -17,7 +17,9 @@
 package dev.sasikanth.rss.reader.util
 
 import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.toNSDate
+import kotlinx.datetime.toNSDateComponents
 import platform.Foundation.NSDateFormatter
 import platform.Foundation.NSLocale
 import platform.Foundation.currentLocale
@@ -28,4 +30,13 @@ actual fun Instant.readerDateTimestamp(): String {
   formatter.dateFormat = "MMM dd, yyyy • hh:mm a"
 
   return formatter.stringFromDate(this.toNSDate())
+}
+
+actual fun LocalDateTime.homeAppBarTimestamp(): String {
+  val formatter = NSDateFormatter()
+  formatter.locale = NSLocale.currentLocale()
+  formatter.dateFormat = "EEE, MMM dd"
+
+  val date = this.toNSDateComponents().date ?: return ""
+  return formatter.stringFromDate(date)
 }

--- a/resources/icons/src/commonMain/kotlin/dev/sasikanth/rss/reader/resources/icons/Dropdown.kt
+++ b/resources/icons/src/commonMain/kotlin/dev/sasikanth/rss/reader/resources/icons/Dropdown.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2025 Sasikanth Miriyampalli
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.sasikanth.rss.reader.resources.icons
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType.Companion.NonZero
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap.Companion.Butt
+import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.ImageVector.Builder
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+
+val TwineIcons.DropdownIcon: ImageVector
+  get() {
+    if (dropdownIcon != null) {
+      return dropdownIcon!!
+    }
+    dropdownIcon =
+      Builder(
+          name = "Icon",
+          defaultWidth = 20.0.dp,
+          defaultHeight = 20.0.dp,
+          viewportWidth = 20.0f,
+          viewportHeight = 20.0f
+        )
+        .apply {
+          path(
+            fill = SolidColor(Color(0xFF77574F)),
+            stroke = null,
+            fillAlpha = 0.08f,
+            strokeLineWidth = 0.0f,
+            strokeLineCap = Butt,
+            strokeLineJoin = Miter,
+            strokeLineMiter = 4.0f,
+            pathFillType = NonZero
+          ) {
+            moveTo(0.0f, 10.0f)
+            curveTo(0.0f, 4.477f, 4.477f, 0.0f, 10.0f, 0.0f)
+            curveTo(15.523f, 0.0f, 20.0f, 4.477f, 20.0f, 10.0f)
+            curveTo(20.0f, 15.523f, 15.523f, 20.0f, 10.0f, 20.0f)
+            curveTo(4.477f, 20.0f, 0.0f, 15.523f, 0.0f, 10.0f)
+            close()
+          }
+          path(
+            fill = SolidColor(Color(0x00000000)),
+            stroke = SolidColor(Color(0xFF77574F)),
+            strokeAlpha = 0.16f,
+            strokeLineWidth = 1.0f,
+            strokeLineCap = Butt,
+            strokeLineJoin = Miter,
+            strokeLineMiter = 4.0f,
+            pathFillType = NonZero
+          ) {
+            moveTo(10.0f, 0.5f)
+            curveTo(15.247f, 0.5f, 19.5f, 4.753f, 19.5f, 10.0f)
+            curveTo(19.5f, 15.247f, 15.247f, 19.5f, 10.0f, 19.5f)
+            curveTo(4.753f, 19.5f, 0.5f, 15.247f, 0.5f, 10.0f)
+            curveTo(0.5f, 4.753f, 4.753f, 0.5f, 10.0f, 0.5f)
+            close()
+          }
+          path(
+            fill = SolidColor(Color(0xFF1F1A1F)),
+            stroke = null,
+            strokeLineWidth = 0.0f,
+            strokeLineCap = Butt,
+            strokeLineJoin = Miter,
+            strokeLineMiter = 4.0f,
+            pathFillType = NonZero
+          ) {
+            moveTo(10.0f, 13.569f)
+            curveTo(9.895f, 13.569f, 9.796f, 13.553f, 9.704f, 13.52f)
+            curveTo(9.612f, 13.487f, 9.527f, 13.431f, 9.448f, 13.352f)
+            lineTo(5.817f, 9.722f)
+            curveTo(5.672f, 9.577f, 5.6f, 9.393f, 5.6f, 9.17f)
+            curveTo(5.6f, 8.946f, 5.672f, 8.762f, 5.817f, 8.617f)
+            curveTo(5.962f, 8.472f, 6.146f, 8.4f, 6.37f, 8.4f)
+            curveTo(6.593f, 8.4f, 6.777f, 8.472f, 6.922f, 8.617f)
+            lineTo(10.0f, 11.695f)
+            lineTo(13.078f, 8.617f)
+            curveTo(13.223f, 8.472f, 13.407f, 8.4f, 13.631f, 8.4f)
+            curveTo(13.854f, 8.4f, 14.038f, 8.472f, 14.183f, 8.617f)
+            curveTo(14.328f, 8.762f, 14.4f, 8.946f, 14.4f, 9.17f)
+            curveTo(14.4f, 9.393f, 14.328f, 9.577f, 14.183f, 9.722f)
+            lineTo(10.553f, 13.352f)
+            curveTo(10.474f, 13.431f, 10.388f, 13.487f, 10.296f, 13.52f)
+            curveTo(10.204f, 13.553f, 10.105f, 13.569f, 10.0f, 13.569f)
+            close()
+          }
+        }
+        .build()
+    return dropdownIcon!!
+  }
+
+private var dropdownIcon: ImageVector? = null

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/HomeEvent.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/HomeEvent.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.SheetValue
 import dev.sasikanth.rss.reader.core.model.local.PostWithMetadata
 import dev.sasikanth.rss.reader.core.model.local.PostsType
 import dev.sasikanth.rss.reader.core.model.local.Source
+import kotlinx.datetime.LocalDateTime
 
 sealed interface HomeEvent {
 
@@ -58,4 +59,6 @@ sealed interface HomeEvent {
   data object MarkScrolledPostsAsRead : HomeEvent
 
   data class MarkFeaturedPostsAsRead(val postId: String) : HomeEvent
+
+  data class UpdateCurrentDateTime(val dateTime: LocalDateTime) : HomeEvent
 }

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/HomePresenter.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/HomePresenter.kt
@@ -216,7 +216,12 @@ class HomePresenter(
     }
 
     private fun updateCurrentDateTime(dateTime: LocalDateTime) {
-      coroutineScope.launch { _state.update { it.copy(currentDateTime = dateTime) } }
+      coroutineScope.launch {
+        val currentDateTime = _state.value.currentDateTime
+        if (dateTime.date > currentDateTime.date) {
+          _state.update { it.copy(currentDateTime = dateTime) }
+        }
+      }
     }
 
     private fun markFeaturedPostAsRead(postId: String) {

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/HomePresenter.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/HomePresenter.kt
@@ -51,6 +51,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.launchIn
@@ -295,7 +296,10 @@ class HomePresenter(
       val activeSourceFlow = observableActiveSource.activeSource
       val postsTypeFlow = settingsRepository.postsType
 
-      observePosts(activeSourceFlow, postsTypeFlow)
+      _state
+        .distinctUntilChangedBy { it.currentDateTime }
+        .onEach { observePosts(activeSourceFlow, postsTypeFlow) }
+        .launchIn(coroutineScope)
 
       rssRepository
         .hasFeeds()

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/HomeState.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/HomeState.kt
@@ -26,6 +26,7 @@ import dev.sasikanth.rss.reader.core.model.local.PostsType
 import dev.sasikanth.rss.reader.core.model.local.Source
 import dev.sasikanth.rss.reader.home.HomeLoadingState.Loading
 import kotlinx.coroutines.flow.Flow
+import kotlinx.datetime.LocalDateTime
 
 @Immutable
 internal data class HomeState(
@@ -35,12 +36,13 @@ internal data class HomeState(
   val activeSource: Source?,
   val hasFeeds: Boolean?,
   val postsType: PostsType,
-  val hasUnreadPosts: Boolean
+  val hasUnreadPosts: Boolean,
+  val currentDateTime: LocalDateTime,
 ) {
 
   companion object {
 
-    val DEFAULT =
+    fun default(currentDateTime: LocalDateTime) =
       HomeState(
         posts = null,
         loadingState = HomeLoadingState.Idle,
@@ -49,6 +51,7 @@ internal data class HomeState(
         hasFeeds = null,
         postsType = PostsType.ALL,
         hasUnreadPosts = false,
+        currentDateTime = currentDateTime,
       )
   }
 

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/ui/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/ui/HomeScreen.kt
@@ -200,6 +200,7 @@ internal fun HomeScreen(
                 homeTopAppBar = {
                   HomeTopAppBar(
                     source = state.activeSource,
+                    currentDateTime = state.currentDateTime,
                     postsType = state.postsType,
                     listState = listState,
                     hasFeeds = hasFeeds,

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/ui/HomeTopAppBar.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/ui/HomeTopAppBar.kt
@@ -20,7 +20,6 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -32,7 +31,6 @@ import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.foundation.layout.systemBars
@@ -41,7 +39,6 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.DoneAll
-import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.outlined.BookmarkBorder
 import androidx.compose.material.icons.rounded.MoreVert
 import androidx.compose.material.icons.rounded.Search
@@ -72,7 +69,6 @@ import androidx.compose.ui.semantics.role
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.offset
 import dev.sasikanth.rss.reader.components.DropdownMenu
 import dev.sasikanth.rss.reader.components.DropdownMenuItem
 import dev.sasikanth.rss.reader.components.image.FeedIcon
@@ -81,15 +77,20 @@ import dev.sasikanth.rss.reader.core.model.local.FeedGroup
 import dev.sasikanth.rss.reader.core.model.local.PostsType
 import dev.sasikanth.rss.reader.core.model.local.Source
 import dev.sasikanth.rss.reader.feeds.ui.FeedGroupIconGrid
+import dev.sasikanth.rss.reader.resources.icons.DropdownIcon
+import dev.sasikanth.rss.reader.resources.icons.TwineIcons
 import dev.sasikanth.rss.reader.resources.strings.LocalStrings
 import dev.sasikanth.rss.reader.ui.AppTheme
+import dev.sasikanth.rss.reader.util.homeAppBarTimestamp
 import dev.sasikanth.rss.reader.utils.LocalShowFeedFavIconSetting
+import kotlinx.datetime.LocalDateTime
 
 private const val APP_BAR_OPAQUE_THRESHOLD = 200f
 
 @Composable
 internal fun HomeTopAppBar(
   source: Source?,
+  currentDateTime: LocalDateTime,
   postsType: PostsType,
   listState: LazyListState,
   hasFeeds: Boolean?,
@@ -128,6 +129,7 @@ internal fun HomeTopAppBar(
     SourceInfo(
       modifier = Modifier.weight(1f),
       source = source,
+      currentDateTime = currentDateTime,
       postsType = postsType,
       hasFeeds = hasFeeds,
       onPostTypeChanged = onPostTypeChanged
@@ -166,6 +168,7 @@ internal fun HomeTopAppBar(
 @Composable
 fun SourceInfo(
   source: Source?,
+  currentDateTime: LocalDateTime,
   postsType: PostsType,
   hasFeeds: Boolean?,
   modifier: Modifier = Modifier,
@@ -178,9 +181,11 @@ fun SourceInfo(
   Box(modifier) {
     Row(
       modifier =
-        Modifier.clip(MaterialTheme.shapes.large).onGloballyPositioned { coordinates ->
-          buttonHeight = with(density) { coordinates.size.height.toDp() }
-        },
+        Modifier.clip(MaterialTheme.shapes.small)
+          .clickable(enabled = hasFeeds == true) { showPostsTypeDropDown = true }
+          .onGloballyPositioned { coordinates ->
+            buttonHeight = with(density) { coordinates.size.height.toDp() }
+          },
       verticalAlignment = Alignment.CenterVertically
     ) {
       SourceIcon(source)
@@ -189,43 +194,32 @@ fun SourceInfo(
         when (source) {
           is FeedGroup -> source.name
           is Feed -> source.name
-          else -> LocalStrings.current.appName
+          else -> currentDateTime.homeAppBarTimestamp()
         }
 
-      Column(
-        modifier =
-          Modifier.padding(start = 16.dp, end = 8.dp).clickable(
-            interactionSource = remember { MutableInteractionSource() },
-            indication = null,
-            enabled = hasFeeds == true
-          ) {
-            showPostsTypeDropDown = true
-          }
-      ) {
+      Column(modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)) {
         Text(
           modifier = Modifier.basicMarquee(),
           text = sourceLabel,
-          style = MaterialTheme.typography.titleLarge,
-          color = AppTheme.colorScheme.textEmphasisHigh,
+          style = MaterialTheme.typography.labelSmall,
+          color = AppTheme.colorScheme.onSurface,
           maxLines = 1,
         )
 
         AnimatedVisibility(visible = hasFeeds == true) {
-          Spacer(Modifier.requiredHeight(8.dp))
-
           val postsTypeLabel = getPostTypeLabel(postsType)
 
-          Row {
+          Row(verticalAlignment = Alignment.CenterVertically) {
             Text(
               text = postsTypeLabel,
-              style = MaterialTheme.typography.bodyMedium,
-              color = AppTheme.colorScheme.textEmphasisHigh,
+              style = MaterialTheme.typography.titleMedium,
+              color = AppTheme.colorScheme.onSurface,
             )
 
             Spacer(Modifier.requiredWidth(4.dp))
 
             Icon(
-              imageVector = Icons.Filled.ExpandMore,
+              imageVector = TwineIcons.DropdownIcon,
               contentDescription = null,
               modifier = Modifier.requiredSize(20.dp),
               tint = AppTheme.colorScheme.textEmphasisHigh,

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/utils/DateExt.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/utils/DateExt.kt
@@ -24,7 +24,7 @@ import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.atStartOfDayIn
 import kotlinx.datetime.minus
-import kotlinx.datetime.toLocalDateTime
+import kotlinx.datetime.todayIn
 
 fun Period.calculateInstantBeforePeriod(): Instant {
   val period =
@@ -40,10 +40,11 @@ fun Period.calculateInstantBeforePeriod(): Instant {
   return currentMoment.minus(period, TimeZone.currentSystemDefault())
 }
 
-internal fun getTodayStartInstant() =
-  Clock.System.now()
-    .toLocalDateTime(TimeZone.currentSystemDefault())
-    .date
+internal fun getTodayStartInstant(): Instant {
+  return Clock.System.todayIn(TimeZone.currentSystemDefault())
     .atStartOfDayIn(TimeZone.currentSystemDefault())
+}
 
-internal fun getLast24HourStart() = Clock.System.now().minus(24.hours)
+internal fun getLast24HourStart(): Instant {
+  return Clock.System.now().minus(24.hours)
+}


### PR DESCRIPTION
### Description

This pull request introduces improvements and updates to how the app handles and displays the current date across the home screen and app bar. 

Key changes include:
- Enhanced `updateCurrentDateTime` in `HomePresenter` to only update the state when the new date surpasses the current state date.
- Displaying the current date in the app bar title when no source is selected.
- Ensuring the posts list refreshes whenever the current date changes.
- Automatically updating the current date upon resuming the home screen.
- Refactoring date-related extensions to improve code clarity and maintainability.

These changes enhance the user experience by ensuring date-dependent functionality operates consistently and accurately.