### PR TITLE
Fix app opening incorrect article in the reader screen

### DIFF
--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/reader/ReaderEvent.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/reader/ReaderEvent.kt
@@ -27,8 +27,6 @@ sealed interface ReaderEvent {
 
   data class PostPageChanged(val post: PostWithMetadata) : ReaderEvent
 
-  data object MarkOpenedPostsAsRead : ReaderEvent
-
   data class LoadFullArticleClicked(val postId: String) : ReaderEvent
 
   data class PostLoaded(val post: PostWithMetadata) : ReaderEvent

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/reader/ReaderPresenter.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/reader/ReaderPresenter.kt
@@ -179,7 +179,6 @@ class ReaderPresenter(
                   pageSize = 4,
                   enablePlaceholders = false,
                 ),
-              initialKey = readerScreenArgs.postIndex
             ) {
               when (readerScreenArgs.fromScreen) {
                 Home -> {

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/reader/ui/ReaderScreen.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/reader/ui/ReaderScreen.kt
@@ -176,7 +176,7 @@ internal fun ReaderScreen(
 ) {
   val state by presenter.state.collectAsState()
   val posts = state.posts.collectAsLazyPagingItems()
-  val pagerState = rememberPagerState { posts.itemCount }
+  val pagerState = rememberPagerState(initialPage = state.initialIndex) { posts.itemCount }
   val coroutineScope = rememberCoroutineScope()
   val linkHandler = LocalLinkHandler.current
   val scrollBehaviour = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()


### PR DESCRIPTION
Since `lifecycle.doOnDestroy` is called everytime config change happens, we are marking posts as read, causing the intial key/post index to change which causes issue #1028 when unread filter is selected in the home screen.

This change would only mark posts as read only when the reader screen component instance is destroyed. Since this instance is config changes safe, it should fix #1028 