### PR TITLE
Add support for different view modes in the home screen

### DIFF
--- a/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/repository/SettingsRepository.kt
+++ b/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/repository/SettingsRepository.kt
@@ -43,6 +43,7 @@ class SettingsRepository(private val dataStore: DataStore<Preferences>) {
   private val enableAutoSyncKey = booleanPreferencesKey("enable_auto_sync")
   private val showFeedFavIconKey = booleanPreferencesKey("show_feed_fav_icon")
   private val markPostsAsReadOnKey = stringPreferencesKey("mark_posts_as_read_on")
+  private val homeViewModeKey = stringPreferencesKey("home_view_mode")
 
   val browserType: Flow<BrowserType> =
     dataStore.data.map { preferences ->
@@ -86,6 +87,9 @@ class SettingsRepository(private val dataStore: DataStore<Preferences>) {
 
   val markAsReadOn: Flow<MarkAsReadOn> =
     dataStore.data.map { preferences -> mapToMarkAsReadOnType(preferences[markPostsAsReadOnKey]) }
+
+  val homeViewMode: Flow<HomeViewMode> =
+    dataStore.data.map { preferences -> mapToHomeViewMode(preferences[homeViewModeKey]) }
 
   suspend fun enableAutoSyncImmediate(): Boolean {
     return enableAutoSync.first()
@@ -139,6 +143,10 @@ class SettingsRepository(private val dataStore: DataStore<Preferences>) {
     dataStore.edit { preferences -> preferences[markPostsAsReadOnKey] = value.name }
   }
 
+  suspend fun updateHomeViewMode(value: HomeViewMode) {
+    dataStore.edit { preferences -> preferences[homeViewModeKey] = value.name }
+  }
+
   private fun mapToAppThemeMode(pref: String?): AppThemeMode? {
     if (pref.isNullOrBlank()) return null
     return AppThemeMode.valueOf(pref)
@@ -173,6 +181,11 @@ class SettingsRepository(private val dataStore: DataStore<Preferences>) {
     if (pref.isNullOrBlank()) return MarkAsReadOn.Open
     return MarkAsReadOn.valueOf(pref)
   }
+
+  private fun mapToHomeViewMode(pref: String?): HomeViewMode {
+    if (pref.isNullOrBlank()) return HomeViewMode.Default
+    return HomeViewMode.valueOf(pref)
+  }
 }
 
 enum class AppThemeMode {
@@ -197,4 +210,10 @@ enum class Period {
 enum class MarkAsReadOn {
   Open,
   Scroll
+}
+
+enum class HomeViewMode {
+  Default,
+  Simple,
+  Compact
 }

--- a/resources/strings/src/commonMain/kotlin/dev/sasikanth/rss/reader/resources/strings/DeTwineStrings.kt
+++ b/resources/strings/src/commonMain/kotlin/dev/sasikanth/rss/reader/resources/strings/DeTwineStrings.kt
@@ -187,5 +187,9 @@ val DeTwineStrings =
       "No content to display in the reader, please try fetching article or visiting the website.",
     pullToClose = "Pull down to close",
     readerSettings = "Reader screen settings",
-    comingSoon = "Coming soon"
+    comingSoon = "Coming soon",
+    homeViewMode = "View modes",
+    homeViewModeDefault = "Default",
+    homeViewModeSimple = "Simple",
+    homeViewModeCompact = "Compact",
   )

--- a/resources/strings/src/commonMain/kotlin/dev/sasikanth/rss/reader/resources/strings/EnTwineStrings.kt
+++ b/resources/strings/src/commonMain/kotlin/dev/sasikanth/rss/reader/resources/strings/EnTwineStrings.kt
@@ -194,5 +194,9 @@ val EnTwineStrings =
       "No content to display in the reader, please try fetching article or visiting the website.",
     pullToClose = "Pull down to close",
     readerSettings = "Reader screen settings",
-    comingSoon = "Coming soon"
+    comingSoon = "Coming soon",
+    homeViewMode = "View modes",
+    homeViewModeDefault = "Default",
+    homeViewModeSimple = "Simple",
+    homeViewModeCompact = "Compact",
   )

--- a/resources/strings/src/commonMain/kotlin/dev/sasikanth/rss/reader/resources/strings/TrTwineStrings.kt
+++ b/resources/strings/src/commonMain/kotlin/dev/sasikanth/rss/reader/resources/strings/TrTwineStrings.kt
@@ -180,5 +180,9 @@ val TrTwineStrings =
       "Okuyucuda gösterilecek içerik yok, lütfen makaleyi getirmeyi deneyin veya web sitesini ziyaret edin.",
     pullToClose = "Pull down to close",
     readerSettings = "Reader screen settings",
-    comingSoon = "Coming soon"
+    comingSoon = "Coming soon",
+    homeViewMode = "View modes",
+    homeViewModeDefault = "Default",
+    homeViewModeSimple = "Simple",
+    homeViewModeCompact = "Compact",
   )

--- a/resources/strings/src/commonMain/kotlin/dev/sasikanth/rss/reader/resources/strings/TwineStrings.kt
+++ b/resources/strings/src/commonMain/kotlin/dev/sasikanth/rss/reader/resources/strings/TwineStrings.kt
@@ -172,6 +172,10 @@ data class TwineStrings(
   val pullToClose: String,
   val readerSettings: String,
   val comingSoon: String,
+  val homeViewMode: String,
+  val homeViewModeDefault: String,
+  val homeViewModeSimple: String,
+  val homeViewModeCompact: String,
 )
 
 object Locales {

--- a/resources/strings/src/commonMain/kotlin/dev/sasikanth/rss/reader/resources/strings/ZhTwineStrings.kt
+++ b/resources/strings/src/commonMain/kotlin/dev/sasikanth/rss/reader/resources/strings/ZhTwineStrings.kt
@@ -174,5 +174,9 @@ val ZhTwineStrings =
       "No content to display in the reader, please try fetching article or visiting the website.",
     pullToClose = "Pull down to close",
     readerSettings = "Reader screen settings",
-    comingSoon = "Coming soon"
+    comingSoon = "Coming soon",
+    homeViewMode = "View modes",
+    homeViewModeDefault = "Default",
+    homeViewModeSimple = "Simple",
+    homeViewModeCompact = "Compact",
   )

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/components/DropdownMenu.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/components/DropdownMenu.kt
@@ -17,7 +17,6 @@
 package dev.sasikanth.rss.reader.components
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
@@ -42,26 +41,16 @@ internal fun DropdownMenu(
   offset: DpOffset = DpOffset.Zero,
   content: @Composable ColumnScope.() -> Unit
 ) {
-  MaterialTheme(
-    colorScheme =
-      MaterialTheme.colorScheme.copy(surface = AppTheme.colorScheme.surfaceContainerLowest),
-    shapes = MaterialTheme.shapes.copy(extraSmall = MaterialTheme.shapes.large)
-  ) {
+  MaterialTheme(shapes = MaterialTheme.shapes.copy(extraSmall = MaterialTheme.shapes.large)) {
     androidx.compose.material3.DropdownMenu(
       expanded = expanded,
       onDismissRequest = onDismissRequest,
       offset = offset,
       modifier =
-        modifier
-          .background(
-            color = AppTheme.colorScheme.surfaceContainerLowest,
-            shape = MaterialTheme.shapes.large
-          )
-          .border(
-            width = 1.dp,
-            color = AppTheme.colorScheme.outlineVariant,
-            shape = MaterialTheme.shapes.large
-          ),
+        modifier.background(
+          color = AppTheme.colorScheme.surface,
+          shape = MaterialTheme.shapes.large
+        ),
       content = content
     )
   }

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/HomeEvent.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/HomeEvent.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.SheetValue
 import dev.sasikanth.rss.reader.core.model.local.PostWithMetadata
 import dev.sasikanth.rss.reader.core.model.local.PostsType
 import dev.sasikanth.rss.reader.core.model.local.Source
+import dev.sasikanth.rss.reader.data.repository.HomeViewMode
 import kotlinx.datetime.LocalDateTime
 
 sealed interface HomeEvent {
@@ -61,4 +62,6 @@ sealed interface HomeEvent {
   data class MarkFeaturedPostsAsRead(val postId: String) : HomeEvent
 
   data class UpdateCurrentDateTime(val dateTime: LocalDateTime) : HomeEvent
+
+  data class ChangeHomeViewMode(val homeViewMode: HomeViewMode) : HomeEvent
 }

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/HomePresenter.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/HomePresenter.kt
@@ -301,6 +301,10 @@ class HomePresenter(
       val activeSourceFlow = observableActiveSource.activeSource
       val postsTypeFlow = settingsRepository.postsType
 
+      settingsRepository.homeViewMode
+        .onEach { homeViewMode -> _state.update { it.copy(homeViewMode = homeViewMode) } }
+        .launchIn(coroutineScope)
+
       _state
         .distinctUntilChangedBy { it.currentDateTime }
         .onEach { observePosts(activeSourceFlow, postsTypeFlow) }

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/HomePresenter.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/HomePresenter.kt
@@ -33,6 +33,7 @@ import dev.sasikanth.rss.reader.core.model.local.FeedGroup
 import dev.sasikanth.rss.reader.core.model.local.PostWithMetadata
 import dev.sasikanth.rss.reader.core.model.local.PostsType
 import dev.sasikanth.rss.reader.core.model.local.Source
+import dev.sasikanth.rss.reader.data.repository.HomeViewMode
 import dev.sasikanth.rss.reader.data.repository.MarkAsReadOn
 import dev.sasikanth.rss.reader.data.repository.ObservableActiveSource
 import dev.sasikanth.rss.reader.data.repository.RssRepository
@@ -212,7 +213,12 @@ class HomePresenter(
         HomeEvent.MarkScrolledPostsAsRead -> markScrolledPostsAsRead()
         is HomeEvent.MarkFeaturedPostsAsRead -> markFeaturedPostAsRead(event.postId)
         is HomeEvent.UpdateCurrentDateTime -> updateCurrentDateTime(event.dateTime)
+        is HomeEvent.ChangeHomeViewMode -> changeHomeViewMode(event.homeViewMode)
       }
+    }
+
+    private fun changeHomeViewMode(homeViewMode: HomeViewMode) {
+      coroutineScope.launch { settingsRepository.updateHomeViewMode(homeViewMode) }
     }
 
     private fun updateCurrentDateTime(dateTime: LocalDateTime) {

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/HomeState.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/HomeState.kt
@@ -24,6 +24,7 @@ import app.cash.paging.PagingData
 import dev.sasikanth.rss.reader.core.model.local.PostWithMetadata
 import dev.sasikanth.rss.reader.core.model.local.PostsType
 import dev.sasikanth.rss.reader.core.model.local.Source
+import dev.sasikanth.rss.reader.data.repository.HomeViewMode
 import dev.sasikanth.rss.reader.home.HomeLoadingState.Loading
 import kotlinx.coroutines.flow.Flow
 import kotlinx.datetime.LocalDateTime
@@ -38,6 +39,7 @@ internal data class HomeState(
   val postsType: PostsType,
   val hasUnreadPosts: Boolean,
   val currentDateTime: LocalDateTime,
+  val homeViewMode: HomeViewMode,
 ) {
 
   companion object {
@@ -52,6 +54,7 @@ internal data class HomeState(
         postsType = PostsType.ALL,
         hasUnreadPosts = false,
         currentDateTime = currentDateTime,
+        homeViewMode = HomeViewMode.Default,
       )
   }
 

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/ui/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/ui/HomeScreen.kt
@@ -207,13 +207,17 @@ internal fun HomeScreen(
                     listState = listState,
                     hasFeeds = hasFeeds,
                     hasUnreadPosts = state.hasUnreadPosts,
+                    homeViewMode = state.homeViewMode,
                     onSearchClicked = { homePresenter.dispatch(HomeEvent.SearchClicked) },
                     onBookmarksClicked = { homePresenter.dispatch(HomeEvent.BookmarksClicked) },
                     onSettingsClicked = { homePresenter.dispatch(HomeEvent.SettingsClicked) },
                     onPostTypeChanged = {
                       homePresenter.dispatch(HomeEvent.OnPostsTypeChanged(it))
                     },
-                    onMarkPostsAsRead = { homePresenter.dispatch(HomeEvent.MarkPostsAsRead(it)) }
+                    onMarkPostsAsRead = { homePresenter.dispatch(HomeEvent.MarkPostsAsRead(it)) },
+                    onChangeHomeViewMode = {
+                      homePresenter.dispatch(HomeEvent.ChangeHomeViewMode(it))
+                    }
                   )
                 },
                 body = { paddingValues ->

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/ui/PostList.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/ui/PostList.kt
@@ -15,64 +15,26 @@
  */
 package dev.sasikanth.rss.reader.home.ui
 
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.WindowInsetsSides
-import androidx.compose.foundation.layout.only
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.requiredHeight
-import androidx.compose.foundation.layout.requiredSize
-import androidx.compose.foundation.layout.systemBars
-import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.pager.PagerState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
-import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.snapshotFlow
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import app.cash.paging.compose.LazyPagingItems
-import dev.sasikanth.rss.reader.components.image.AsyncImage
 import dev.sasikanth.rss.reader.core.model.local.PostWithMetadata
+import dev.sasikanth.rss.reader.data.repository.HomeViewMode
 import dev.sasikanth.rss.reader.ui.AppTheme
-import dev.sasikanth.rss.reader.ui.LocalDynamicColorState
-import dev.sasikanth.rss.reader.util.relativeDurationString
-import dev.sasikanth.rss.reader.utils.Constants
-import dev.sasikanth.rss.reader.utils.LocalShowFeedFavIconSetting
-import dev.sasikanth.rss.reader.utils.LocalWindowSizeClass
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.onEach
-
-private val postListPadding
-  @Composable
-  @ReadOnlyComposable
-  get() =
-    when (LocalWindowSizeClass.current.widthSizeClass) {
-      WindowWidthSizeClass.Expanded -> PaddingValues(horizontal = 128.dp)
-      else -> PaddingValues(0.dp)
-    }
 
 @OptIn(FlowPreview::class)
 @Composable
@@ -83,6 +45,7 @@ internal fun PostsList(
   useDarkTheme: Boolean,
   listState: LazyListState,
   featuredPostsPagerState: PagerState,
+  homeViewMode: HomeViewMode,
   markPostAsRead: (String) -> Unit,
   postsScrolled: (List<String>) -> Unit,
   markScrolledPostsAsRead: () -> Unit,
@@ -93,7 +56,6 @@ internal fun PostsList(
   onTogglePostReadClick: (String, Boolean) -> Unit,
   modifier: Modifier = Modifier,
 ) {
-  val dynamicColorState = LocalDynamicColorState.current
   val topContentPadding =
     if (featuredPosts.isEmpty()) {
       paddingValues.calculateTopPadding()
@@ -158,99 +120,39 @@ internal fun PostsList(
       contentType = { "post_item" }
     ) { index ->
       val adjustedIndex = index + featuredPosts.size
-      val post = posts[adjustedIndex]
+      val post = posts[adjustedIndex] ?: return@items
 
-      if (post != null) {
-        PostListItem(
-          item = post,
-          reduceReadItemAlpha = true,
-          onClick = { onPostClicked(post, adjustedIndex) },
-          onPostBookmarkClick = { onPostBookmarkClick(post) },
-          onPostCommentsClick = { onPostCommentsClick(post.commentsLink!!) },
-          onPostSourceClick = { onPostSourceClick(post.sourceId) },
-          togglePostReadClick = { onTogglePostReadClick(post.id, post.read) }
-        )
-      } else {
-        Box(Modifier.requiredHeight(132.dp))
-      }
+      when (homeViewMode) {
+        HomeViewMode.Default,
+        HomeViewMode.Simple -> {
+          PostListItem(
+            item = post,
+            reduceReadItemAlpha = true,
+            onClick = { onPostClicked(post, adjustedIndex) },
+            onPostBookmarkClick = { onPostBookmarkClick(post) },
+            onPostCommentsClick = { onPostCommentsClick(post.commentsLink!!) },
+            onPostSourceClick = { onPostSourceClick(post.sourceId) },
+            togglePostReadClick = { onTogglePostReadClick(post.id, post.read) }
+          )
+        }
+        HomeViewMode.Compact -> {
+          CompactPostListItem(
+            item = post,
+            reduceReadItemAlpha = true,
+            onClick = { onPostClicked(post, adjustedIndex) },
+            onPostBookmarkClick = { onPostBookmarkClick(post) },
+            onPostCommentsClick = { onPostCommentsClick(post.commentsLink!!) },
+            togglePostReadClick = { onTogglePostReadClick(post.id, post.read) }
+          )
 
-      if (index != posts.itemCount - 1) {
-        HorizontalDivider(
-          modifier = Modifier.fillParentMaxWidth().padding(horizontal = 24.dp),
-          color = AppTheme.colorScheme.surfaceContainer
-        )
-      }
-    }
-  }
-}
-
-@Composable
-fun PostListItem(
-  item: PostWithMetadata,
-  onClick: () -> Unit,
-  onPostBookmarkClick: () -> Unit,
-  onPostCommentsClick: () -> Unit,
-  onPostSourceClick: () -> Unit,
-  togglePostReadClick: () -> Unit,
-  modifier: Modifier = Modifier,
-  reduceReadItemAlpha: Boolean = false,
-  postMetadataConfig: PostMetadataConfig = PostMetadataConfig.DEFAULT,
-) {
-  Column(
-    modifier =
-      Modifier.then(modifier)
-        .clickable(onClick = onClick)
-        .windowInsetsPadding(WindowInsets.systemBars.only(WindowInsetsSides.Horizontal))
-        .padding(postListPadding)
-        .alpha(
-          if (item.read && reduceReadItemAlpha) Constants.ITEM_READ_ALPHA
-          else Constants.ITEM_UNREAD_ALPHA
-        )
-        .semantics { contentDescription = item.title.ifBlank { item.description } }
-  ) {
-    Row(
-      modifier = Modifier.padding(start = 24.dp, top = 20.dp, end = 24.dp),
-      horizontalArrangement = Arrangement.spacedBy(16.dp),
-    ) {
-      Text(
-        modifier = Modifier.weight(1f).align(Alignment.Top),
-        style = MaterialTheme.typography.titleMedium,
-        text = item.title.ifBlank { item.description },
-        color = AppTheme.colorScheme.textEmphasisHigh,
-        maxLines = 3,
-        overflow = TextOverflow.Ellipsis
-      )
-
-      item.imageUrl?.let { url ->
-        AsyncImage(
-          url = url,
-          modifier =
-            Modifier.requiredSize(width = 128.dp, height = 72.dp)
-              .clip(RoundedCornerShape(12.dp))
-              .align(Alignment.CenterVertically),
-          contentDescription = null,
-          contentScale = ContentScale.Crop
-        )
+          if (index != posts.itemCount - 1) {
+            HorizontalDivider(
+              modifier = Modifier.fillMaxWidth(),
+              color = AppTheme.colorScheme.outlineVariant
+            )
+          }
+        }
       }
     }
-
-    val showFeedFavIcon = LocalShowFeedFavIconSetting.current
-    val feedIconUrl = if (showFeedFavIcon) item.feedHomepageLink else item.feedIcon
-
-    PostMetadata(
-      feedName = item.feedName,
-      feedIcon = feedIconUrl,
-      postPublishedAt = item.date.relativeDurationString(),
-      config = postMetadataConfig,
-      postLink = item.link,
-      postRead = item.read,
-      postBookmarked = item.bookmarked,
-      commentsLink = item.commentsLink,
-      onBookmarkClick = onPostBookmarkClick,
-      onCommentsClick = onPostCommentsClick,
-      onSourceClick = onPostSourceClick,
-      onTogglePostReadClick = togglePostReadClick,
-      modifier = Modifier.padding(start = 24.dp, end = 12.dp)
-    )
   }
 }

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/ui/PostListItem.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/ui/PostListItem.kt
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2025 Sasikanth Miriyampalli
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.sasikanth.rss.reader.home.ui
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.foundation.layout.requiredWidth
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import dev.sasikanth.rss.reader.components.image.AsyncImage
+import dev.sasikanth.rss.reader.components.image.FeedIcon
+import dev.sasikanth.rss.reader.core.model.local.PostWithMetadata
+import dev.sasikanth.rss.reader.ui.AppTheme
+import dev.sasikanth.rss.reader.util.relativeDurationString
+import dev.sasikanth.rss.reader.utils.Constants
+import dev.sasikanth.rss.reader.utils.LocalShowFeedFavIconSetting
+import dev.sasikanth.rss.reader.utils.LocalWindowSizeClass
+
+private val postListPadding
+  @Composable
+  @ReadOnlyComposable
+  get() =
+    when (LocalWindowSizeClass.current.widthSizeClass) {
+      WindowWidthSizeClass.Expanded -> PaddingValues(horizontal = 128.dp)
+      else -> PaddingValues(0.dp)
+    }
+
+@Composable
+internal fun PostListItem(
+  item: PostWithMetadata,
+  onClick: () -> Unit,
+  onPostBookmarkClick: () -> Unit,
+  onPostCommentsClick: () -> Unit,
+  onPostSourceClick: () -> Unit,
+  togglePostReadClick: () -> Unit,
+  modifier: Modifier = Modifier,
+  reduceReadItemAlpha: Boolean = false,
+  postMetadataConfig: PostMetadataConfig = PostMetadataConfig.DEFAULT,
+) {
+  Column(
+    modifier =
+      Modifier.then(modifier)
+        .clickable(onClick = onClick)
+        .windowInsetsPadding(WindowInsets.systemBars.only(WindowInsetsSides.Horizontal))
+        .padding(postListPadding)
+        .alpha(
+          if (item.read && reduceReadItemAlpha) Constants.ITEM_READ_ALPHA
+          else Constants.ITEM_UNREAD_ALPHA
+        )
+        .semantics { contentDescription = item.title.ifBlank { item.description } }
+  ) {
+    Row(
+      modifier = Modifier.padding(start = 24.dp, top = 20.dp, end = 24.dp),
+      horizontalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+      Text(
+        modifier = Modifier.weight(1f).align(Alignment.Top),
+        style = MaterialTheme.typography.titleMedium,
+        text = item.title.ifBlank { item.description },
+        color = AppTheme.colorScheme.textEmphasisHigh,
+        maxLines = 3,
+        overflow = TextOverflow.Ellipsis
+      )
+
+      item.imageUrl?.let { url ->
+        AsyncImage(
+          url = url,
+          modifier =
+            Modifier.requiredSize(width = 128.dp, height = 72.dp)
+              .clip(RoundedCornerShape(12.dp))
+              .align(Alignment.CenterVertically),
+          contentDescription = null,
+          contentScale = ContentScale.Crop
+        )
+      }
+    }
+
+    val showFeedFavIcon = LocalShowFeedFavIconSetting.current
+    val feedIconUrl = if (showFeedFavIcon) item.feedHomepageLink else item.feedIcon
+
+    PostMetadata(
+      feedName = item.feedName,
+      feedIcon = feedIconUrl,
+      postPublishedAt = item.date.relativeDurationString(),
+      config = postMetadataConfig,
+      postLink = item.link,
+      postRead = item.read,
+      postBookmarked = item.bookmarked,
+      commentsLink = item.commentsLink,
+      onBookmarkClick = onPostBookmarkClick,
+      onCommentsClick = onPostCommentsClick,
+      onSourceClick = onPostSourceClick,
+      onTogglePostReadClick = togglePostReadClick,
+      modifier = Modifier.padding(start = 24.dp, end = 12.dp)
+    )
+  }
+}
+
+@Composable
+internal fun CompactPostListItem(
+  item: PostWithMetadata,
+  onClick: () -> Unit,
+  onPostBookmarkClick: () -> Unit,
+  onPostCommentsClick: () -> Unit,
+  togglePostReadClick: () -> Unit,
+  modifier: Modifier = Modifier,
+  reduceReadItemAlpha: Boolean = false,
+  postMetadataConfig: PostMetadataConfig = PostMetadataConfig.DEFAULT,
+) {
+  val showFeedFavIcon = LocalShowFeedFavIconSetting.current
+  val feedIconUrl = if (showFeedFavIcon) item.feedHomepageLink else item.feedIcon
+
+  Row(
+    verticalAlignment = Alignment.CenterVertically,
+    modifier =
+      Modifier.then(modifier)
+        .clickable { onClick() }
+        .padding(vertical = 12.dp)
+        .padding(start = 24.dp, end = 12.dp)
+        .alpha(
+          if (item.read && reduceReadItemAlpha) Constants.ITEM_READ_ALPHA
+          else Constants.ITEM_UNREAD_ALPHA
+        )
+  ) {
+    FeedIcon(
+      url = feedIconUrl,
+      contentDescription = null,
+      modifier = Modifier.requiredSize(16.dp).clip(RoundedCornerShape(4.dp)),
+    )
+
+    Spacer(Modifier.requiredWidth(16.dp))
+
+    Text(
+      text = item.title.ifBlank { item.description },
+      style = MaterialTheme.typography.titleSmall,
+      color = AppTheme.colorScheme.onSurface,
+      maxLines = 2,
+      overflow = TextOverflow.Ellipsis,
+      modifier = Modifier.weight(1f)
+    )
+
+    Spacer(Modifier.requiredWidth(16.dp))
+
+    PostOptionsButtonRow(
+      postLink = item.link,
+      postBookmarked = item.bookmarked,
+      postRead = item.read,
+      config = postMetadataConfig,
+      commentsLink = item.commentsLink,
+      onBookmarkClick = onPostBookmarkClick,
+      onCommentsClick = onPostCommentsClick,
+      togglePostReadClick = togglePostReadClick,
+    )
+  }
+}

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/ui/PostMetadata.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/ui/PostMetadata.kt
@@ -184,7 +184,7 @@ private fun PostSourcePill(
 }
 
 @Composable
-private fun PostOptionsButtonRow(
+internal fun PostOptionsButtonRow(
   postLink: String,
   postBookmarked: Boolean,
   postRead: Boolean,


### PR DESCRIPTION
fixes: #1000

- **Add support for saving home view modes in the datastore**
- **Track `HomeViewMode` in the `HomeState`**
- **Load `HomeViewMode` from settings when home screen is created**
- **Add compact post list item UI**
- **Add support for displaying default, simple and compact view modes in the post list**
- **Add support for changing home view modes from the home menu**

TODO: Change menu design and icons once Ed finalizes the designs
