### PR TITLE
Add support for loading text content type RSS feeds

### DIFF
--- a/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/repository/RssRepository.kt
+++ b/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/repository/RssRepository.kt
@@ -20,6 +20,7 @@ import app.cash.sqldelight.coroutines.asFlow
 import app.cash.sqldelight.coroutines.mapToList
 import app.cash.sqldelight.coroutines.mapToOne
 import app.cash.sqldelight.paging3.QueryPagingSource
+import co.touchlab.kermit.Logger
 import dev.sasikanth.rss.reader.core.model.local.Feed
 import dev.sasikanth.rss.reader.core.model.local.FeedGroup
 import dev.sasikanth.rss.reader.core.model.local.Post
@@ -129,6 +130,7 @@ class RssRepository(
         FeedAddResult.HttpStatusError(feedFetchResult.statusCode)
       }
       is FeedFetchResult.Error -> {
+        Logger.e("FeedFetchException", feedFetchResult.exception)
         FeedAddResult.NetworkError(feedFetchResult.exception)
       }
       FeedFetchResult.TooManyRedirects -> {

--- a/core/network/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/network/fetcher/FeedFetcher.kt
+++ b/core/network/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/network/fetcher/FeedFetcher.kt
@@ -140,6 +140,8 @@ class FeedFetcher(
       ContentType.Application.Rss,
       ContentType.Application.Xml,
       ContentType.Text.Xml,
+      ContentType("text", "atom+xml"),
+      ContentType("text", "rss+xml"),
       null -> {
         val content = response.bodyAsChannel()
         val responseCharset =


### PR DESCRIPTION
While we support text/xml content type, some feeds still use
text/rss+xml and text/atom+xml. So we are adding those two as custom
content types since those are not present in ktor content types list.

fixes: #1039
