### PR TITLE
Fix date formatting localization for Android

### DIFF
--- a/core/base/src/androidMain/kotlin/dev/sasikanth/rss/reader/util/DateExt.android.kt
+++ b/core/base/src/androidMain/kotlin/dev/sasikanth/rss/reader/util/DateExt.android.kt
@@ -19,6 +19,7 @@ package dev.sasikanth.rss.reader.util
 import java.time.LocalDateTime as JavaLocalDateTime
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
+import java.util.Locale
 import java.util.TimeZone
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDateTime
@@ -37,6 +38,17 @@ actual fun Instant.readerDateTimestamp(): String {
 }
 
 actual fun LocalDateTime.homeAppBarTimestamp(): String {
-  val dateTimeFormatter = DateTimeFormatter.ofPattern("EEE, MMM dd")
-  return dateTimeFormatter.format(toJavaLocalDateTime())
+  val locale = Locale.getDefault()
+
+  // Java DateTimeFormatter does not provides a localized FormatStyle corresponding to the
+  // 'EEE, MMM d' pattern, so we define a custom pattern for each locale.
+  val pattern =
+    when (locale.language) {
+      "de" -> "EEE, d. MMM"
+      "fr" -> "EEE d MMM"
+      else -> "EEE, MMM d" // fallback to English pattern
+    }
+
+  val formatter = DateTimeFormatter.ofPattern(pattern, locale)
+  return formatter.format(toJavaLocalDateTime())
 }

--- a/core/base/src/androidMain/kotlin/dev/sasikanth/rss/reader/util/DateExt.android.kt
+++ b/core/base/src/androidMain/kotlin/dev/sasikanth/rss/reader/util/DateExt.android.kt
@@ -18,6 +18,7 @@ package dev.sasikanth.rss.reader.util
 
 import java.time.LocalDateTime as JavaLocalDateTime
 import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
 import java.util.TimeZone
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDateTime
@@ -25,9 +26,14 @@ import kotlinx.datetime.toJavaInstant
 import kotlinx.datetime.toJavaLocalDateTime
 
 actual fun Instant.readerDateTimestamp(): String {
-  val dateTimeFormatter = DateTimeFormatter.ofPattern("MMM dd, yyyy • hh:mm a")
   val dateTime = JavaLocalDateTime.ofInstant(toJavaInstant(), TimeZone.getDefault().toZoneId())
-  return dateTimeFormatter.format(dateTime)
+  val dateFormatter = DateTimeFormatter.ofLocalizedDate(FormatStyle.LONG)
+  val timeFormatter = DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT)
+
+  val formattedDate = dateFormatter.format(dateTime)
+  val formattedTime = timeFormatter.format(dateTime)
+
+  return "$formattedDate • $formattedTime"
 }
 
 actual fun LocalDateTime.homeAppBarTimestamp(): String {


### PR DESCRIPTION
I noticed some problems with date formatting, so I fixed it. But I did it only for Android, since I don't have an iOS device to test the iOS implementation.

The problem with date formatting: 
| Language | Before | After (corrected version) | Comments |
 | --- | --- | --- | --- |
 | `en` | Sat, may 31 | Sat, may 31 |  |
 | `de` | Sa., Mai 31 | Sa., 31. Mai | A dot after the day number, <br/>and month is after the day |
 | `fr` | sam., mai 31 | sam. 31 mai | No comma, and month <br/>is after the day |
