### PR TITLE
Refactor HomeViewController injection

### DIFF
--- a/.idea/xcode.xml
+++ b/.idea/xcode.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="XcodeMetaData" PROJECT_FILE="$PROJECT_DIR$/iosApp/iosApp.xcodeproj" />
+</project>

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -13,7 +13,7 @@ struct ComposeView: UIViewControllerRepresentable {
 	}
 	
 	func makeUIViewController(context: Context) -> UIViewController {
-        return homeViewControllerComponent.homeViewControllerFactory(backDispatcher)
+        return homeViewControllerComponent.homeViewController.viewController()
 	}
 
     func updateUIViewController(_ uiViewController: UIViewController, context: Context) {

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -16,7 +16,8 @@ struct iOSApp: App {
         let backDispatcher = BackDispatcherKt.BackDispatcher()
         let homeViewControllerComponent = InjectHomeViewControllerComponent(
             componentContext: DefaultComponentContext(lifecycle: rootHolder.lifecycle, stateKeeper: nil, instanceKeeper: nil, backHandler: backDispatcher),
-            applicationComponent: appDelegate.applicationComponent
+            applicationComponent: appDelegate.applicationComponent,
+            backDispatcher: backDispatcher
         )
 
 		WindowGroup {

--- a/shared/src/iosMain/kotlin/dev/sasikanth/rss/reader/HomeViewController.kt
+++ b/shared/src/iosMain/kotlin/dev/sasikanth/rss/reader/HomeViewController.kt
@@ -23,32 +23,36 @@ import com.arkivanov.decompose.ExperimentalDecomposeApi
 import com.arkivanov.decompose.extensions.compose.stack.animation.predictiveback.PredictiveBackGestureOverlay
 import com.arkivanov.essenty.backhandler.BackDispatcher
 import dev.sasikanth.rss.reader.app.App
-import me.tatarka.inject.annotations.Assisted
 import me.tatarka.inject.annotations.Inject
 import platform.UIKit.UIViewController
 
-typealias HomeViewController = (backDispatcher: BackDispatcher) -> UIViewController
-
 @OptIn(ExperimentalDecomposeApi::class)
 @Inject
-fun HomeViewController(app: App, @Assisted backDispatcher: BackDispatcher): UIViewController {
-  return ComposeUIViewController(configure = { onFocusBehavior = OnFocusBehavior.DoNothing }) {
-    PredictiveBackGestureOverlay(
-      backDispatcher = backDispatcher,
-      backIcon = null,
-      modifier = Modifier.fillMaxSize()
-    ) {
-      app(
-        {
-          // no-op
-        },
-        {
-          // no-op
-        },
-        {
-          // no-op
-        }
-      )
+class HomeViewController(
+  private val app: App,
+  private val backDispatcher: BackDispatcher,
+) {
+
+  @Suppress("unused")
+  fun viewController(): UIViewController {
+    return ComposeUIViewController(configure = { onFocusBehavior = OnFocusBehavior.DoNothing }) {
+      PredictiveBackGestureOverlay(
+        backDispatcher = backDispatcher,
+        backIcon = null,
+        modifier = Modifier.fillMaxSize()
+      ) {
+        app(
+          {
+            // no-op
+          },
+          {
+            // no-op
+          },
+          {
+            // no-op
+          }
+        )
+      }
     }
   }
 }

--- a/shared/src/iosMain/kotlin/dev/sasikanth/rss/reader/di/HomeViewControllerComponent.kt
+++ b/shared/src/iosMain/kotlin/dev/sasikanth/rss/reader/di/HomeViewControllerComponent.kt
@@ -16,6 +16,7 @@
 package dev.sasikanth.rss.reader.di
 
 import com.arkivanov.decompose.ComponentContext
+import com.arkivanov.essenty.backhandler.BackDispatcher
 import dev.sasikanth.rss.reader.HomeViewController
 import dev.sasikanth.rss.reader.di.scopes.ActivityScope
 import dev.sasikanth.rss.reader.platform.PlatformComponent
@@ -27,8 +28,9 @@ import me.tatarka.inject.annotations.Provides
 @ActivityScope
 abstract class HomeViewControllerComponent(
   @get:Provides val componentContext: ComponentContext,
-  @Component val applicationComponent: ApplicationComponent
+  @Component val applicationComponent: ApplicationComponent,
+  @get:Provides val backDispatcher: BackDispatcher,
 ) : PlatformComponent, ShareComponent {
 
-  abstract val homeViewControllerFactory: HomeViewController
+  abstract val homeViewController: HomeViewController
 }


### PR DESCRIPTION
This commit refactors the `HomeViewController` injection to use a standard class constructor instead of a typealias factory. This makes the dependency injection setup more straightforward and aligns with common Kotlin DI patterns.

The following changes were made:
- `HomeViewController` is now a class instead of a typealias.
- The `viewController()` method is introduced in `HomeViewController` to return the `UIViewController` instance.
- The `HomeViewControllerComponent` now directly provides an instance of `HomeViewController` instead of a factory.
- The `BackDispatcher` is now provided directly to `HomeViewControllerComponent`.
- Consumers of `HomeViewControllerComponent` in `iOSApp.swift` and `ContentView.swift` have been updated to reflect these changes.
