### PR TITLE
Refactor: Extract Reader components

### DIFF
--- a/shared/src/androidMain/kotlin/dev/sasikanth/rss/reader/reader/ui/ReaderWebView.android.kt
+++ b/shared/src/androidMain/kotlin/dev/sasikanth/rss/reader/reader/ui/ReaderWebView.android.kt
@@ -40,7 +40,7 @@ private class ReaderJSInterface(private val contentLoaded: (String) -> Unit) {
 
 @SuppressLint("SetJavaScriptEnabled")
 @Composable
-actual fun ReaderWebView(
+internal actual fun ReaderWebView(
   link: String?,
   content: String?,
   postImage: String?,

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/reader/ui/ReaderCustomizationsContent.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/reader/ui/ReaderCustomizationsContent.kt
@@ -66,7 +66,7 @@ import twine.shared.generated.resources.Res
 import twine.shared.generated.resources.readerCustomisationsTypeface
 
 @Composable
-internal fun ReaderCustomisationsContent(
+internal fun ReaderCustomizationsContent(
   selectedFont: ReaderFont,
   fontScaleFactor: Float,
   fontLineHeightFactor: Float,

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/reader/ui/ReaderPage.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/reader/ui/ReaderPage.kt
@@ -1,0 +1,540 @@
+/*
+ * Copyright 2025 Sasikanth Miriyampalli
+ *
+ * Licensed under the GPL, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ */
+
+package dev.sasikanth.rss.reader.reader.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredHeight
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.foundation.layout.requiredWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.selection.DisableSelection
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.isTraversalGroup
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.mikepenz.markdown.compose.LocalImageTransformer
+import com.mikepenz.markdown.compose.LocalMarkdownAnimations
+import com.mikepenz.markdown.compose.LocalMarkdownAnnotator
+import com.mikepenz.markdown.compose.LocalMarkdownColors
+import com.mikepenz.markdown.compose.LocalMarkdownDimens
+import com.mikepenz.markdown.compose.LocalMarkdownExtendedSpans
+import com.mikepenz.markdown.compose.LocalMarkdownPadding
+import com.mikepenz.markdown.compose.LocalMarkdownTypography
+import com.mikepenz.markdown.compose.LocalReferenceLinkHandler
+import com.mikepenz.markdown.compose.components.markdownComponents
+import com.mikepenz.markdown.compose.elements.MarkdownHighlightedCodeBlock
+import com.mikepenz.markdown.compose.elements.MarkdownHighlightedCodeFence
+import com.mikepenz.markdown.m3.markdownColor
+import com.mikepenz.markdown.m3.markdownTypography
+import com.mikepenz.markdown.model.Input
+import com.mikepenz.markdown.model.ReferenceLinkHandlerImpl
+import com.mikepenz.markdown.model.State
+import com.mikepenz.markdown.model.markdownAnimations
+import com.mikepenz.markdown.model.markdownAnnotator
+import com.mikepenz.markdown.model.markdownDimens
+import com.mikepenz.markdown.model.markdownExtendedSpans
+import com.mikepenz.markdown.model.markdownPadding
+import dev.sasikanth.rss.reader.components.image.FeedIcon
+import dev.sasikanth.rss.reader.core.model.local.PostWithMetadata
+import dev.sasikanth.rss.reader.home.ui.FeaturedImage
+import dev.sasikanth.rss.reader.home.ui.PostMetadataConfig
+import dev.sasikanth.rss.reader.markdown.CoilMarkdownTransformer
+import dev.sasikanth.rss.reader.markdown.MarkdownStateImpl
+import dev.sasikanth.rss.reader.markdown.handleElement
+import dev.sasikanth.rss.reader.platform.LocalLinkHandler
+import dev.sasikanth.rss.reader.resources.icons.Bookmark
+import dev.sasikanth.rss.reader.resources.icons.Bookmarked
+import dev.sasikanth.rss.reader.resources.icons.Comments
+import dev.sasikanth.rss.reader.resources.icons.Share
+import dev.sasikanth.rss.reader.resources.icons.TwineIcons
+import dev.sasikanth.rss.reader.share.LocalShareHandler
+import dev.sasikanth.rss.reader.ui.AppTheme
+import dev.sasikanth.rss.reader.util.readerDateTimestamp
+import dev.sasikanth.rss.reader.utils.LocalShowFeedFavIconSetting
+import dev.sasikanth.rss.reader.utils.getOffsetFractionForPage
+import dev.snipme.highlights.Highlights
+import kotlinx.coroutines.launch
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
+import org.intellij.markdown.parser.MarkdownParser
+import org.jetbrains.compose.resources.stringResource
+import twine.shared.generated.resources.Res
+import twine.shared.generated.resources.bookmark
+import twine.shared.generated.resources.comments
+import twine.shared.generated.resources.share
+import twine.shared.generated.resources.unBookmark
+
+private val json = Json {
+  ignoreUnknownKeys = true
+  isLenient = true
+  explicitNulls = false
+}
+
+@Composable
+internal fun ReaderPage(
+  readerPost: PostWithMetadata,
+  page: Int,
+  pagerState: PagerState,
+  highlightsBuilder: Highlights.Builder,
+  loadFullArticle: Boolean,
+  onBookmarkClick: () -> Unit,
+  modifier: Modifier = Modifier,
+  contentPaddingValues: PaddingValues = PaddingValues(),
+) {
+  var readerProcessingProgress by
+    remember(readerPost.id) { mutableStateOf(ReaderProcessingProgress.Loading) }
+  var parsedContent by remember(readerPost.id) { mutableStateOf(ReaderContent("", "")) }
+  val parsedMarkdownState =
+    remember(readerPost.id, parsedContent) {
+      val flavour = GFMFlavourDescriptor()
+      val input =
+        Input(
+          content = parsedContent.content.orEmpty(),
+          lookupLinks = true,
+          flavour = flavour,
+          parser = MarkdownParser(flavour),
+          referenceLinkHandler = ReferenceLinkHandlerImpl(),
+        )
+
+      MarkdownStateImpl(input)
+    }
+
+  LaunchedEffect(parsedMarkdownState) { parsedMarkdownState.parse() }
+
+  val markdownState by parsedMarkdownState.state.collectAsState()
+  val linkHandler = LocalLinkHandler.current
+  val sharedHandler = LocalShareHandler.current
+  val coroutineScope = rememberCoroutineScope()
+  val markdownComponents = remember {
+    markdownComponents(
+      codeBlock = { cm ->
+        MarkdownHighlightedCodeBlock(
+          content = cm.content,
+          node = cm.node,
+          highlights = highlightsBuilder
+        )
+      },
+      codeFence = { cm ->
+        MarkdownHighlightedCodeFence(
+          content = cm.content,
+          node = cm.node,
+          highlights = highlightsBuilder
+        )
+      },
+    )
+  }
+
+  SelectionContainer {
+    Box(modifier = modifier) {
+      // Dummy view to parse the reader content using JS
+      ReaderWebView(
+        modifier = Modifier.requiredSize(0.dp),
+        link = readerPost.link,
+        content = readerPost.rawContent ?: readerPost.description,
+        postImage = readerPost.imageUrl,
+        fetchFullArticle = loadFullArticle,
+        contentLoaded = {
+          readerProcessingProgress = ReaderProcessingProgress.Idle
+          parsedContent = json.decodeFromString(it)
+        },
+      )
+
+      CompositionLocalProvider(
+        LocalReferenceLinkHandler provides markdownState.referenceLinkHandler,
+        LocalMarkdownPadding provides markdownPadding(),
+        LocalMarkdownDimens provides markdownDimens(),
+        LocalImageTransformer provides CoilMarkdownTransformer,
+        LocalMarkdownAnnotator provides markdownAnnotator(),
+        LocalMarkdownExtendedSpans provides markdownExtendedSpans(),
+        LocalMarkdownAnimations provides markdownAnimations(),
+        LocalMarkdownColors provides markdownColor(),
+        LocalMarkdownTypography provides
+          markdownTypography(
+            h1 = MaterialTheme.typography.displaySmall,
+            h2 = MaterialTheme.typography.headlineLarge,
+            h3 = MaterialTheme.typography.headlineMedium,
+            h4 = MaterialTheme.typography.headlineSmall,
+            h5 = MaterialTheme.typography.titleLarge,
+            h6 = MaterialTheme.typography.titleMedium,
+          ),
+      ) {
+        LazyColumn(
+          modifier = Modifier.fillMaxSize(),
+          overscrollEffect = null,
+          contentPadding =
+            PaddingValues(
+              top = contentPaddingValues.calculateTopPadding(),
+              bottom = contentPaddingValues.calculateBottomPadding()
+            )
+        ) {
+          item(key = "reader-header") {
+            PostInfo(
+              readerPost = readerPost,
+              page = page,
+              pagerState = pagerState,
+              parsedContent = parsedContent,
+              onCommentsClick = {
+                coroutineScope.launch { linkHandler.openLink(readerPost.commentsLink) }
+              },
+              onShareClick = { sharedHandler.share(readerPost.link) },
+              onBookmarkClick = onBookmarkClick
+            )
+          }
+
+          item(key = "divider") {
+            HorizontalDivider(
+              modifier = Modifier.padding(horizontal = 32.dp).padding(top = 20.dp, bottom = 24.dp),
+              color = AppTheme.colorScheme.outlineVariant
+            )
+          }
+
+          if (readerProcessingProgress == ReaderProcessingProgress.Loading) {
+            item(key = "progress-indicator") { ProgressIndicator() }
+          }
+
+          if (
+            readerProcessingProgress == ReaderProcessingProgress.Idle || parsedContent.hasContent
+          ) {
+            if (parsedContent.hasContent) {
+              when (val state = markdownState) {
+                is State.Success -> {
+                  items(items = state.node.children) { node ->
+                    Box(modifier = Modifier.padding(horizontal = 32.dp)) {
+                      handleElement(
+                        node = node,
+                        components = markdownComponents,
+                        content = state.content,
+                        includeSpacer = true,
+                        skipLinkDefinition = state.linksLookedUp,
+                      )
+                    }
+                  }
+                }
+                else -> {
+                  // no-op
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun ProgressIndicator() {
+  Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+    LinearProgressIndicator(
+      trackColor = AppTheme.colorScheme.tintedSurface,
+      color = AppTheme.colorScheme.tintedForeground,
+    )
+  }
+}
+
+@Composable
+private fun PostInfo(
+  readerPost: PostWithMetadata,
+  page: Int,
+  pagerState: PagerState,
+  parsedContent: ReaderContent,
+  onCommentsClick: () -> Unit,
+  onShareClick: () -> Unit,
+  onBookmarkClick: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  Column(
+    modifier = Modifier.fillMaxWidth().padding(horizontal = 32.dp).then(modifier),
+  ) {
+    val title = readerPost.title
+    val description = readerPost.description
+    val postImage = readerPost.imageUrl
+
+    if (!postImage.isNullOrBlank()) {
+      FeaturedImage(
+        modifier =
+          Modifier.graphicsLayer {
+              translationX =
+                if (page in 0..pagerState.pageCount) {
+                  pagerState.getOffsetFractionForPage(page) * 250f
+                } else {
+                  0f
+                }
+              scaleX = 1.08f
+              scaleY = 1.08f
+            }
+            .align(Alignment.CenterHorizontally),
+        image = postImage
+      )
+
+      Spacer(modifier = Modifier.requiredHeight(8.dp))
+    }
+
+    DisableSelection {
+      Text(
+        modifier = Modifier.padding(top = 20.dp),
+        text = readerPost.date.readerDateTimestamp(),
+        style = MaterialTheme.typography.bodyMedium,
+        color = AppTheme.colorScheme.outline,
+        maxLines = 1,
+      )
+    }
+
+    Text(
+      modifier = Modifier.padding(top = 12.dp),
+      text = title.ifBlank { description },
+      style = MaterialTheme.typography.headlineSmall,
+      color = AppTheme.colorScheme.onSurface,
+      overflow = TextOverflow.Ellipsis,
+    )
+
+    if (!parsedContent.excerpt.isNullOrBlank()) {
+      Spacer(Modifier.requiredHeight(8.dp))
+
+      Text(
+        text = parsedContent.excerpt,
+        style = MaterialTheme.typography.bodyMedium,
+        color = AppTheme.colorScheme.secondary,
+        maxLines = 3,
+        overflow = TextOverflow.Ellipsis,
+      )
+    }
+
+    Spacer(Modifier.requiredHeight(12.dp))
+
+    Row(verticalAlignment = Alignment.CenterVertically) {
+      val showFeedFavIcon = LocalShowFeedFavIconSetting.current
+      val feedIconUrl = if (showFeedFavIcon) readerPost.feedHomepageLink else readerPost.feedIcon
+
+      DisableSelection {
+        PostSourcePill(
+          modifier = Modifier.weight(1f).clearAndSetSemantics {},
+          feedName = readerPost.feedName,
+          feedIcon = feedIconUrl,
+          config =
+            PostMetadataConfig(
+              showUnreadIndicator = false,
+              showToggleReadUnreadOption = true,
+              enablePostSource = false
+            ),
+          onSourceClick = {
+            // no-op
+          },
+        )
+      }
+
+      PostOptionsButtonRow(
+        postBookmarked = readerPost.bookmarked,
+        commentsLink = readerPost.commentsLink,
+        onCommentsClick = onCommentsClick,
+        onShareClick = onShareClick,
+        onBookmarkClick = onBookmarkClick,
+      )
+    }
+  }
+}
+
+@Composable
+private fun PostSourcePill(
+  feedIcon: String,
+  feedName: String,
+  config: PostMetadataConfig,
+  onSourceClick: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  Box(modifier = modifier) {
+    val postSourceTextColor =
+      if (config.enablePostSource) {
+        AppTheme.colorScheme.onSurface
+      } else {
+        AppTheme.colorScheme.onSurfaceVariant
+      }
+
+    Row(
+      modifier =
+        Modifier.background(
+            MaterialTheme.colorScheme.secondary.copy(alpha = 0.08f),
+            RoundedCornerShape(50)
+          )
+          .border(
+            1.dp,
+            MaterialTheme.colorScheme.secondary.copy(alpha = 0.16f),
+            RoundedCornerShape(50)
+          )
+          .clip(RoundedCornerShape(50))
+          .clickable(onClick = onSourceClick, enabled = config.enablePostSource)
+          .padding(vertical = 6.dp)
+          .padding(start = 8.dp, end = 12.dp),
+      verticalAlignment = Alignment.CenterVertically
+    ) {
+      FeedIcon(
+        modifier = Modifier.requiredSize(16.dp).clip(RoundedCornerShape(4.dp)),
+        url = feedIcon,
+        contentDescription = null,
+      )
+
+      Spacer(Modifier.requiredWidth(6.dp))
+
+      Text(
+        style = MaterialTheme.typography.labelMedium,
+        maxLines = 1,
+        text = feedName,
+        color = postSourceTextColor,
+        overflow = TextOverflow.Ellipsis
+      )
+    }
+  }
+}
+
+@Composable
+private fun PostOptionsButtonRow(
+  postBookmarked: Boolean,
+  commentsLink: String?,
+  onCommentsClick: () -> Unit,
+  onShareClick: () -> Unit,
+  onBookmarkClick: () -> Unit,
+) {
+  Row(modifier = Modifier.semantics { isTraversalGroup = true }) {
+    if (!commentsLink.isNullOrBlank()) {
+      val commentsLabel = stringResource(Res.string.comments)
+      PostOptionIconButton(
+        modifier =
+          Modifier.semantics {
+            role = Role.Button
+            contentDescription = commentsLabel
+          },
+        icon = TwineIcons.Comments,
+        iconTint = AppTheme.colorScheme.onSurfaceVariant,
+        onClick = onCommentsClick
+      )
+    }
+
+    val sharedLabel = stringResource(Res.string.share)
+    PostOptionIconButton(
+      modifier =
+        Modifier.semantics {
+          role = Role.Button
+          contentDescription = sharedLabel
+        },
+      icon = TwineIcons.Share,
+      iconTint = AppTheme.colorScheme.onSurfaceVariant,
+      onClick = onShareClick
+    )
+
+    val bookmarkLabel =
+      if (postBookmarked) {
+        stringResource(Res.string.unBookmark)
+      } else {
+        stringResource(Res.string.bookmark)
+      }
+    PostOptionIconButton(
+      modifier =
+        Modifier.semantics {
+          role = Role.Button
+          contentDescription = bookmarkLabel
+        },
+      icon =
+        if (postBookmarked) {
+          TwineIcons.Bookmarked
+        } else {
+          TwineIcons.Bookmark
+        },
+      iconTint =
+        if (postBookmarked) {
+          AppTheme.colorScheme.tintedForeground
+        } else {
+          AppTheme.colorScheme.onSurfaceVariant
+        },
+      onClick = onBookmarkClick
+    )
+  }
+}
+
+@Composable
+private fun PostOptionIconButton(
+  icon: ImageVector,
+  modifier: Modifier = Modifier,
+  iconTint: Color = AppTheme.colorScheme.textEmphasisHigh,
+  onClick: () -> Unit,
+) {
+  Box(
+    modifier =
+      Modifier.requiredSize(40.dp)
+        .clip(MaterialTheme.shapes.small)
+        .clickable(onClick = onClick)
+        .then(modifier),
+    contentAlignment = Alignment.Center
+  ) {
+    Icon(
+      imageVector = icon,
+      contentDescription = null,
+      tint = iconTint,
+      modifier = Modifier.size(20.dp)
+    )
+  }
+}
+
+@Serializable
+enum class ReaderProcessingProgress {
+  Loading,
+  Idle
+}
+
+@Serializable
+data class ReaderContent(
+  val excerpt: String?,
+  val content: String?,
+) {
+
+  val hasContent: Boolean
+    get() = !content.isNullOrBlank()
+}

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/reader/ui/ReaderScreen.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/reader/ui/ReaderScreen.kt
@@ -19,138 +19,62 @@ package dev.sasikanth.rss.reader.reader.ui
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.animateBounds
-import androidx.compose.animation.animateColor
 import androidx.compose.animation.core.Spring
-import androidx.compose.animation.core.animateDp
 import androidx.compose.animation.core.spring
-import androidx.compose.animation.core.updateTransition
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.foundation.layout.requiredHeightIn
-import androidx.compose.foundation.layout.requiredSize
-import androidx.compose.foundation.layout.requiredSizeIn
-import androidx.compose.foundation.layout.requiredWidth
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
-import androidx.compose.foundation.layout.wrapContentWidth
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.selection.DisableSelection
-import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.FilledIconButton
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButtonDefaults
-import androidx.compose.material3.LinearProgressIndicator
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.LookaheadScope
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.platform.UriHandler
-import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.semantics.clearAndSetSemantics
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.isTraversalGroup
-import androidx.compose.ui.semantics.role
-import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import app.cash.paging.compose.collectAsLazyPagingItems
 import com.adamglin.composeshadow.dropShadow
-import com.mikepenz.markdown.compose.LocalImageTransformer
-import com.mikepenz.markdown.compose.LocalMarkdownAnimations
-import com.mikepenz.markdown.compose.LocalMarkdownAnnotator
-import com.mikepenz.markdown.compose.LocalMarkdownColors
-import com.mikepenz.markdown.compose.LocalMarkdownDimens
-import com.mikepenz.markdown.compose.LocalMarkdownExtendedSpans
-import com.mikepenz.markdown.compose.LocalMarkdownPadding
-import com.mikepenz.markdown.compose.LocalMarkdownTypography
-import com.mikepenz.markdown.compose.LocalReferenceLinkHandler
-import com.mikepenz.markdown.compose.components.markdownComponents
-import com.mikepenz.markdown.compose.elements.MarkdownHighlightedCodeBlock
-import com.mikepenz.markdown.compose.elements.MarkdownHighlightedCodeFence
-import com.mikepenz.markdown.m3.markdownColor
-import com.mikepenz.markdown.m3.markdownTypography
-import com.mikepenz.markdown.model.Input
-import com.mikepenz.markdown.model.ReferenceLinkHandlerImpl
-import com.mikepenz.markdown.model.State
-import com.mikepenz.markdown.model.markdownAnimations
-import com.mikepenz.markdown.model.markdownAnnotator
-import com.mikepenz.markdown.model.markdownDimens
-import com.mikepenz.markdown.model.markdownExtendedSpans
-import com.mikepenz.markdown.model.markdownPadding
 import dev.sasikanth.rss.reader.components.HorizontalPageIndicators
 import dev.sasikanth.rss.reader.components.PageIndicatorState
-import dev.sasikanth.rss.reader.components.image.FeedIcon
-import dev.sasikanth.rss.reader.core.model.local.PostWithMetadata
 import dev.sasikanth.rss.reader.data.repository.ReaderFont
-import dev.sasikanth.rss.reader.home.ui.FeaturedImage
-import dev.sasikanth.rss.reader.home.ui.PostMetadataConfig
-import dev.sasikanth.rss.reader.markdown.CoilMarkdownTransformer
-import dev.sasikanth.rss.reader.markdown.MarkdownStateImpl
-import dev.sasikanth.rss.reader.markdown.handleElement
 import dev.sasikanth.rss.reader.platform.LocalLinkHandler
 import dev.sasikanth.rss.reader.reader.ReaderEvent
 import dev.sasikanth.rss.reader.reader.ReaderPresenter
-import dev.sasikanth.rss.reader.resources.icons.ArticleShortcut
-import dev.sasikanth.rss.reader.resources.icons.Bookmark
-import dev.sasikanth.rss.reader.resources.icons.Bookmarked
-import dev.sasikanth.rss.reader.resources.icons.Comments
-import dev.sasikanth.rss.reader.resources.icons.OpenBrowser
-import dev.sasikanth.rss.reader.resources.icons.Settings
-import dev.sasikanth.rss.reader.resources.icons.Share
-import dev.sasikanth.rss.reader.resources.icons.TwineIcons
-import dev.sasikanth.rss.reader.share.LocalShareHandler
 import dev.sasikanth.rss.reader.ui.AppTheme
 import dev.sasikanth.rss.reader.ui.ComicNeueFontFamily
 import dev.sasikanth.rss.reader.ui.GolosFontFamily
@@ -162,40 +86,19 @@ import dev.sasikanth.rss.reader.ui.MerriWeatherFontFamily
 import dev.sasikanth.rss.reader.ui.RobotoSerifFontFamily
 import dev.sasikanth.rss.reader.ui.rememberDynamicColorState
 import dev.sasikanth.rss.reader.ui.typography
-import dev.sasikanth.rss.reader.util.readerDateTimestamp
 import dev.sasikanth.rss.reader.utils.Constants.EPSILON
-import dev.sasikanth.rss.reader.utils.LocalShowFeedFavIconSetting
 import dev.sasikanth.rss.reader.utils.getOffsetFractionForPage
 import dev.snipme.highlights.Highlights
 import dev.snipme.highlights.model.SyntaxThemes
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.Json
-import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
-import org.intellij.markdown.parser.MarkdownParser
-import org.jetbrains.compose.resources.stringResource
-import twine.shared.generated.resources.Res
-import twine.shared.generated.resources.bookmark
-import twine.shared.generated.resources.cdLoadFullArticle
-import twine.shared.generated.resources.comments
-import twine.shared.generated.resources.openWebsite
-import twine.shared.generated.resources.readerSettings
-import twine.shared.generated.resources.share
-import twine.shared.generated.resources.unBookmark
-
-private val json = Json {
-  ignoreUnknownKeys = true
-  isLenient = true
-  explicitNulls = false
-}
 
 @Composable
 internal fun ReaderScreen(
   darkTheme: Boolean,
   presenter: ReaderPresenter,
-  modifier: Modifier = Modifier
+  modifier: Modifier = Modifier,
 ) {
   val coroutineScope = rememberCoroutineScope()
   val state by presenter.state.collectAsState()
@@ -226,7 +129,7 @@ internal fun ReaderScreen(
         val settledPage = pagerState.settledPage
         try {
           pagerState.getOffsetFractionForPage(settledPage)
-        } catch (e: Throwable) {
+        } catch (_: Throwable) {
           0f
         }
       }
@@ -350,11 +253,11 @@ internal fun ReaderScreen(
           val readerPost =
             try {
               posts.peek(pagerState.settledPage)
-            } catch (e: IndexOutOfBoundsException) {
+            } catch (_: IndexOutOfBoundsException) {
               null
             }
           if (readerPost != null) {
-            BottomBar(
+            ReaderActionsPanel(
               darkTheme = darkTheme,
               loadFullArticle = state.canLoadFullPost(readerPost.id),
               showReaderCustomisations = state.showReaderCustomisations,
@@ -449,171 +352,9 @@ internal fun ReaderScreen(
   }
 }
 
-@Composable
-private fun ReaderPage(
-  readerPost: PostWithMetadata,
-  page: Int,
-  pagerState: PagerState,
-  highlightsBuilder: Highlights.Builder,
-  loadFullArticle: Boolean,
-  onBookmarkClick: () -> Unit,
-  modifier: Modifier = Modifier,
-  contentPaddingValues: PaddingValues = PaddingValues(),
-) {
-  var readerProcessingProgress by
-    remember(readerPost.id) { mutableStateOf(ReaderProcessingProgress.Loading) }
-  var parsedContent by remember(readerPost.id) { mutableStateOf(ReaderContent("", "")) }
-  val parsedMarkdownState =
-    remember(readerPost.id, parsedContent) {
-      val flavour = GFMFlavourDescriptor()
-      val input =
-        Input(
-          content = parsedContent.content.orEmpty(),
-          lookupLinks = true,
-          flavour = flavour,
-          parser = MarkdownParser(flavour),
-          referenceLinkHandler = ReferenceLinkHandlerImpl(),
-        )
-
-      MarkdownStateImpl(input)
-    }
-
-  LaunchedEffect(parsedMarkdownState) { parsedMarkdownState.parse() }
-
-  val markdownState by parsedMarkdownState.state.collectAsState()
-  val linkHandler = LocalLinkHandler.current
-  val sharedHandler = LocalShareHandler.current
-  val coroutineScope = rememberCoroutineScope()
-  val markdownComponents = remember {
-    markdownComponents(
-      codeBlock = { cm ->
-        MarkdownHighlightedCodeBlock(
-          content = cm.content,
-          node = cm.node,
-          highlights = highlightsBuilder
-        )
-      },
-      codeFence = { cm ->
-        MarkdownHighlightedCodeFence(
-          content = cm.content,
-          node = cm.node,
-          highlights = highlightsBuilder
-        )
-      },
-    )
-  }
-
-  SelectionContainer {
-    Box(modifier = modifier) {
-      // Dummy view to parse the reader content using JS
-      ReaderWebView(
-        modifier = Modifier.requiredSize(0.dp),
-        link = readerPost.link,
-        content = readerPost.rawContent ?: readerPost.description,
-        postImage = readerPost.imageUrl,
-        fetchFullArticle = loadFullArticle,
-        contentLoaded = {
-          readerProcessingProgress = ReaderProcessingProgress.Idle
-          parsedContent = json.decodeFromString(it)
-        },
-      )
-
-      CompositionLocalProvider(
-        LocalReferenceLinkHandler provides markdownState.referenceLinkHandler,
-        LocalMarkdownPadding provides markdownPadding(),
-        LocalMarkdownDimens provides markdownDimens(),
-        LocalImageTransformer provides CoilMarkdownTransformer,
-        LocalMarkdownAnnotator provides markdownAnnotator(),
-        LocalMarkdownExtendedSpans provides markdownExtendedSpans(),
-        LocalMarkdownAnimations provides markdownAnimations(),
-        LocalMarkdownColors provides markdownColor(),
-        LocalMarkdownTypography provides
-          markdownTypography(
-            h1 = MaterialTheme.typography.displaySmall,
-            h2 = MaterialTheme.typography.headlineLarge,
-            h3 = MaterialTheme.typography.headlineMedium,
-            h4 = MaterialTheme.typography.headlineSmall,
-            h5 = MaterialTheme.typography.titleLarge,
-            h6 = MaterialTheme.typography.titleMedium,
-          ),
-      ) {
-        LazyColumn(
-          modifier = Modifier.fillMaxSize(),
-          overscrollEffect = null,
-          contentPadding =
-            PaddingValues(
-              top = contentPaddingValues.calculateTopPadding(),
-              bottom = contentPaddingValues.calculateBottomPadding()
-            )
-        ) {
-          item(key = "reader-header") {
-            PostInfo(
-              readerPost = readerPost,
-              page = page,
-              pagerState = pagerState,
-              parsedContent = parsedContent,
-              onCommentsClick = {
-                coroutineScope.launch { linkHandler.openLink(readerPost.commentsLink) }
-              },
-              onShareClick = { sharedHandler.share(readerPost.link) },
-              onBookmarkClick = onBookmarkClick
-            )
-          }
-
-          item(key = "divider") {
-            HorizontalDivider(
-              modifier = Modifier.padding(horizontal = 32.dp).padding(top = 20.dp, bottom = 24.dp),
-              color = AppTheme.colorScheme.outlineVariant
-            )
-          }
-
-          if (readerProcessingProgress == ReaderProcessingProgress.Loading) {
-            item(key = "progress-indicator") { ProgressIndicator() }
-          }
-
-          if (
-            readerProcessingProgress == ReaderProcessingProgress.Idle || parsedContent.hasContent
-          ) {
-            if (parsedContent.hasContent) {
-              when (val state = markdownState) {
-                is State.Success -> {
-                  items(items = state.node.children) { node ->
-                    Box(modifier = Modifier.padding(horizontal = 32.dp)) {
-                      handleElement(
-                        node = node,
-                        components = markdownComponents,
-                        content = state.content,
-                        includeSpacer = true,
-                        skipLinkDefinition = state.linksLookedUp,
-                      )
-                    }
-                  }
-                }
-                else -> {
-                  // no-op
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}
-
-@Composable
-private fun ProgressIndicator() {
-  Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-    LinearProgressIndicator(
-      trackColor = AppTheme.colorScheme.tintedSurface,
-      color = AppTheme.colorScheme.tintedForeground,
-    )
-  }
-}
-
 @OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
-private fun BottomBar(
+private fun ReaderActionsPanel(
   darkTheme: Boolean,
   loadFullArticle: Boolean,
   showReaderCustomisations: Boolean,
@@ -689,7 +430,7 @@ private fun BottomBar(
             targetState = showReaderCustomisations,
           ) { targetState ->
             if (targetState) {
-              ReaderCustomisationsContent(
+              ReaderCustomizationsContent(
                 selectedFont = selectedFont,
                 fontScaleFactor = fontScaleFactor,
                 fontLineHeightFactor = fontLineHeightFactor,
@@ -698,419 +439,16 @@ private fun BottomBar(
                 onFontLineHeightFactorChange = onFontLineHeightFactorChange,
               )
             } else {
-              Row(
-                modifier =
-                  Modifier.wrapContentWidth().height(IntrinsicSize.Min).padding(horizontal = 12.dp),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalAlignment = Alignment.CenterVertically,
-              ) {
-                val transition = updateTransition(loadFullArticle)
-                val buttonMinWidth by
-                  transition.animateDp {
-                    if (it) {
-                      52.dp
-                    } else {
-                      56.dp
-                    }
-                  }
-                val readerViewToggleWidth by
-                  transition.animateDp(
-                    transitionSpec = {
-                      spring(
-                        stiffness = Spring.StiffnessMedium,
-                        dampingRatio = Spring.DampingRatioMediumBouncy
-                      )
-                    }
-                  ) {
-                    if (it) {
-                      88.dp
-                    } else {
-                      72.dp
-                    }
-                  }
-                val readerViewToggleVerticalPadding by
-                  transition.animateDp(
-                    transitionSpec = {
-                      spring(
-                        stiffness = Spring.StiffnessMedium,
-                        dampingRatio = Spring.DampingRatioMediumBouncy
-                      )
-                    }
-                  ) {
-                    if (it) {
-                      8.dp
-                    } else {
-                      12.dp
-                    }
-                  }
-                val readerViewToggleBackgroundColor by
-                  transition.animateColor {
-                    if (it) {
-                      AppTheme.colorScheme.primaryContainer
-                    } else {
-                      AppTheme.colorScheme.surfaceContainerHighest
-                    }
-                  }
-                val readerViewToggleContentColor by
-                  transition.animateColor {
-                    if (it) {
-                      AppTheme.colorScheme.onPrimaryContainer
-                    } else {
-                      AppTheme.colorScheme.onSurface
-                    }
-                  }
-
-                BottomBarIconButton(
-                  modifier = Modifier.padding(vertical = 12.dp),
-                  label = stringResource(Res.string.openWebsite),
-                  icon = TwineIcons.OpenBrowser,
-                  onClick = openInBrowserClick,
-                  minWidth = buttonMinWidth
-                )
-
-                BottomBarToggleIconButton(
-                  modifier =
-                    Modifier.fillMaxHeight().padding(vertical = readerViewToggleVerticalPadding),
-                  label = stringResource(Res.string.cdLoadFullArticle),
-                  icon = TwineIcons.ArticleShortcut,
-                  onClick = loadFullArticleClick,
-                  backgroundColor = readerViewToggleBackgroundColor,
-                  contentColor = readerViewToggleContentColor,
-                  minWidth = readerViewToggleWidth
-                )
-
-                BottomBarIconButton(
-                  modifier = Modifier.padding(vertical = 12.dp),
-                  label = stringResource(Res.string.readerSettings),
-                  icon = TwineIcons.Settings,
-                  onClick = openReaderViewSettings,
-                  minWidth = buttonMinWidth
-                )
-              }
+              ReaderViewBottomBar(
+                loadFullArticle,
+                openInBrowserClick,
+                loadFullArticleClick,
+                openReaderViewSettings
+              )
             }
           }
         }
       }
     }
   }
-}
-
-@Composable
-private fun BottomBarIconButton(
-  label: String,
-  icon: ImageVector,
-  onClick: () -> Unit,
-  modifier: Modifier = Modifier,
-  contentColor: Color = AppTheme.colorScheme.onSurfaceVariant,
-  minWidth: Dp = 56.dp,
-) {
-  Box(
-    modifier =
-      Modifier.then(modifier)
-        .requiredSizeIn(minWidth = minWidth)
-        .clip(RoundedCornerShape(50))
-        .semantics {
-          role = Role.Button
-          contentDescription = label
-        }
-        .clickable { onClick() },
-    contentAlignment = Alignment.Center,
-  ) {
-    Icon(
-      modifier = Modifier.padding(vertical = 10.dp).requiredSize(20.dp),
-      imageVector = icon,
-      contentDescription = null,
-      tint = contentColor,
-    )
-  }
-}
-
-@Composable
-private fun BottomBarToggleIconButton(
-  label: String,
-  icon: ImageVector,
-  onClick: () -> Unit,
-  modifier: Modifier = Modifier,
-  backgroundColor: Color = Color.Transparent,
-  contentColor: Color = AppTheme.colorScheme.onSurfaceVariant,
-  minWidth: Dp = 72.dp,
-) {
-  Box(
-    modifier =
-      Modifier.requiredSizeIn(minHeight = 40.dp, minWidth = minWidth)
-        .then(modifier)
-        .clip(RoundedCornerShape(50))
-        .background(backgroundColor, RoundedCornerShape(50))
-        .semantics {
-          role = Role.Button
-          contentDescription = label
-        }
-        .clickable { onClick() },
-    contentAlignment = Alignment.Center,
-  ) {
-    Icon(
-      modifier = Modifier.requiredSize(20.dp),
-      imageVector = icon,
-      contentDescription = null,
-      tint = contentColor,
-    )
-  }
-}
-
-@Composable
-private fun PostInfo(
-  readerPost: PostWithMetadata,
-  page: Int,
-  pagerState: PagerState,
-  parsedContent: ReaderContent,
-  onCommentsClick: () -> Unit,
-  onShareClick: () -> Unit,
-  onBookmarkClick: () -> Unit,
-  modifier: Modifier = Modifier,
-) {
-  Column(
-    modifier = Modifier.fillMaxWidth().padding(horizontal = 32.dp).then(modifier),
-  ) {
-    val title = readerPost.title
-    val description = readerPost.description
-    val postImage = readerPost.imageUrl
-
-    if (!postImage.isNullOrBlank()) {
-      FeaturedImage(
-        modifier =
-          Modifier.graphicsLayer {
-              translationX =
-                if (page in 0..pagerState.pageCount) {
-                  pagerState.getOffsetFractionForPage(page) * 250f
-                } else {
-                  0f
-                }
-              scaleX = 1.08f
-              scaleY = 1.08f
-            }
-            .align(Alignment.CenterHorizontally),
-        image = postImage
-      )
-
-      Spacer(modifier = Modifier.requiredHeight(8.dp))
-    }
-
-    DisableSelection {
-      Text(
-        modifier = Modifier.padding(top = 20.dp),
-        text = readerPost.date.readerDateTimestamp(),
-        style = MaterialTheme.typography.bodyMedium,
-        color = AppTheme.colorScheme.outline,
-        maxLines = 1,
-      )
-    }
-
-    Text(
-      modifier = Modifier.padding(top = 12.dp),
-      text = title.ifBlank { description },
-      style = MaterialTheme.typography.headlineSmall,
-      color = AppTheme.colorScheme.onSurface,
-      overflow = TextOverflow.Ellipsis,
-    )
-
-    if (!parsedContent.excerpt.isNullOrBlank()) {
-      Spacer(Modifier.requiredHeight(8.dp))
-
-      Text(
-        text = parsedContent.excerpt,
-        style = MaterialTheme.typography.bodyMedium,
-        color = AppTheme.colorScheme.secondary,
-        maxLines = 3,
-        overflow = TextOverflow.Ellipsis,
-      )
-    }
-
-    Spacer(Modifier.requiredHeight(12.dp))
-
-    Row(verticalAlignment = Alignment.CenterVertically) {
-      val showFeedFavIcon = LocalShowFeedFavIconSetting.current
-      val feedIconUrl = if (showFeedFavIcon) readerPost.feedHomepageLink else readerPost.feedIcon
-
-      DisableSelection {
-        PostSourcePill(
-          modifier = Modifier.weight(1f).clearAndSetSemantics {},
-          feedName = readerPost.feedName,
-          feedIcon = feedIconUrl,
-          config =
-            PostMetadataConfig(
-              showUnreadIndicator = false,
-              showToggleReadUnreadOption = true,
-              enablePostSource = false
-            ),
-          onSourceClick = {
-            // no-op
-          },
-        )
-      }
-
-      PostOptionsButtonRow(
-        postBookmarked = readerPost.bookmarked,
-        commentsLink = readerPost.commentsLink,
-        onCommentsClick = onCommentsClick,
-        onShareClick = onShareClick,
-        onBookmarkClick = onBookmarkClick,
-      )
-    }
-  }
-}
-
-@Composable
-private fun PostSourcePill(
-  feedIcon: String,
-  feedName: String,
-  config: PostMetadataConfig,
-  onSourceClick: () -> Unit,
-  modifier: Modifier = Modifier
-) {
-  Box(modifier = modifier) {
-    val postSourceTextColor =
-      if (config.enablePostSource) {
-        AppTheme.colorScheme.onSurface
-      } else {
-        AppTheme.colorScheme.onSurfaceVariant
-      }
-
-    Row(
-      modifier =
-        Modifier.background(
-            MaterialTheme.colorScheme.secondary.copy(alpha = 0.08f),
-            RoundedCornerShape(50)
-          )
-          .border(
-            1.dp,
-            MaterialTheme.colorScheme.secondary.copy(alpha = 0.16f),
-            RoundedCornerShape(50)
-          )
-          .clip(RoundedCornerShape(50))
-          .clickable(onClick = onSourceClick, enabled = config.enablePostSource)
-          .padding(vertical = 6.dp)
-          .padding(start = 8.dp, end = 12.dp),
-      verticalAlignment = Alignment.CenterVertically
-    ) {
-      FeedIcon(
-        modifier = Modifier.requiredSize(16.dp).clip(RoundedCornerShape(4.dp)),
-        url = feedIcon,
-        contentDescription = null,
-      )
-
-      Spacer(Modifier.requiredWidth(6.dp))
-
-      Text(
-        style = MaterialTheme.typography.labelMedium,
-        maxLines = 1,
-        text = feedName,
-        color = postSourceTextColor,
-        overflow = TextOverflow.Ellipsis
-      )
-    }
-  }
-}
-
-@Composable
-private fun PostOptionsButtonRow(
-  postBookmarked: Boolean,
-  commentsLink: String?,
-  onCommentsClick: () -> Unit,
-  onShareClick: () -> Unit,
-  onBookmarkClick: () -> Unit,
-) {
-  Row(modifier = Modifier.semantics { isTraversalGroup = true }) {
-    if (!commentsLink.isNullOrBlank()) {
-      val commentsLabel = stringResource(Res.string.comments)
-      PostOptionIconButton(
-        modifier =
-          Modifier.semantics {
-            role = Role.Button
-            contentDescription = commentsLabel
-          },
-        icon = TwineIcons.Comments,
-        iconTint = AppTheme.colorScheme.onSurfaceVariant,
-        onClick = onCommentsClick
-      )
-    }
-
-    val sharedLabel = stringResource(Res.string.share)
-    PostOptionIconButton(
-      modifier =
-        Modifier.semantics {
-          role = Role.Button
-          contentDescription = sharedLabel
-        },
-      icon = TwineIcons.Share,
-      iconTint = AppTheme.colorScheme.onSurfaceVariant,
-      onClick = onShareClick
-    )
-
-    val bookmarkLabel =
-      if (postBookmarked) {
-        stringResource(Res.string.unBookmark)
-      } else {
-        stringResource(Res.string.bookmark)
-      }
-    PostOptionIconButton(
-      modifier =
-        Modifier.semantics {
-          role = Role.Button
-          contentDescription = bookmarkLabel
-        },
-      icon =
-        if (postBookmarked) {
-          TwineIcons.Bookmarked
-        } else {
-          TwineIcons.Bookmark
-        },
-      iconTint =
-        if (postBookmarked) {
-          AppTheme.colorScheme.tintedForeground
-        } else {
-          AppTheme.colorScheme.onSurfaceVariant
-        },
-      onClick = onBookmarkClick
-    )
-  }
-}
-
-@Composable
-private fun PostOptionIconButton(
-  icon: ImageVector,
-  modifier: Modifier = Modifier,
-  iconTint: Color = AppTheme.colorScheme.textEmphasisHigh,
-  onClick: () -> Unit,
-) {
-  Box(
-    modifier =
-      Modifier.requiredSize(40.dp)
-        .clip(MaterialTheme.shapes.small)
-        .clickable(onClick = onClick)
-        .then(modifier),
-    contentAlignment = Alignment.Center
-  ) {
-    Icon(
-      imageVector = icon,
-      contentDescription = null,
-      tint = iconTint,
-      modifier = Modifier.size(20.dp)
-    )
-  }
-}
-
-@Serializable
-enum class ReaderProcessingProgress {
-  Loading,
-  Idle
-}
-
-@Serializable
-data class ReaderContent(
-  val excerpt: String?,
-  val content: String?,
-) {
-
-  val hasContent: Boolean
-    get() = !content.isNullOrBlank()
 }

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/reader/ui/ReaderViewBottomBar.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/reader/ui/ReaderViewBottomBar.kt
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2025 Sasikanth Miriyampalli
+ *
+ * Licensed under the GPL, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ */
+
+package dev.sasikanth.rss.reader.reader.ui
+
+import androidx.compose.animation.animateColor
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateDp
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.updateTransition
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.foundation.layout.requiredSizeIn
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import dev.sasikanth.rss.reader.resources.icons.ArticleShortcut
+import dev.sasikanth.rss.reader.resources.icons.OpenBrowser
+import dev.sasikanth.rss.reader.resources.icons.Settings
+import dev.sasikanth.rss.reader.resources.icons.TwineIcons
+import dev.sasikanth.rss.reader.ui.AppTheme
+import org.jetbrains.compose.resources.stringResource
+import twine.shared.generated.resources.Res
+import twine.shared.generated.resources.cdLoadFullArticle
+import twine.shared.generated.resources.openWebsite
+import twine.shared.generated.resources.readerSettings
+
+@Composable
+internal fun ReaderViewBottomBar(
+  loadFullArticle: Boolean,
+  openInBrowserClick: () -> Unit,
+  loadFullArticleClick: () -> Unit,
+  openReaderViewSettings: () -> Unit,
+) {
+  Row(
+    modifier = Modifier.wrapContentWidth().height(IntrinsicSize.Min).padding(horizontal = 12.dp),
+    horizontalArrangement = Arrangement.spacedBy(8.dp),
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    val transition = updateTransition(loadFullArticle)
+    val buttonMinWidth by
+      transition.animateDp {
+        if (it) {
+          52.dp
+        } else {
+          56.dp
+        }
+      }
+    val readerViewToggleWidth by
+      transition.animateDp(
+        transitionSpec = {
+          spring(stiffness = Spring.StiffnessMedium, dampingRatio = Spring.DampingRatioMediumBouncy)
+        }
+      ) {
+        if (it) {
+          88.dp
+        } else {
+          72.dp
+        }
+      }
+    val readerViewToggleVerticalPadding by
+      transition.animateDp(
+        transitionSpec = {
+          spring(stiffness = Spring.StiffnessMedium, dampingRatio = Spring.DampingRatioMediumBouncy)
+        }
+      ) {
+        if (it) {
+          8.dp
+        } else {
+          12.dp
+        }
+      }
+    val readerViewToggleBackgroundColor by
+      transition.animateColor {
+        if (it) {
+          AppTheme.colorScheme.primaryContainer
+        } else {
+          AppTheme.colorScheme.surfaceContainerHighest
+        }
+      }
+    val readerViewToggleContentColor by
+      transition.animateColor {
+        if (it) {
+          AppTheme.colorScheme.onPrimaryContainer
+        } else {
+          AppTheme.colorScheme.onSurface
+        }
+      }
+
+    BottomBarIconButton(
+      modifier = Modifier.padding(vertical = 12.dp),
+      label = stringResource(Res.string.openWebsite),
+      icon = TwineIcons.OpenBrowser,
+      onClick = openInBrowserClick,
+      minWidth = buttonMinWidth
+    )
+
+    BottomBarToggleIconButton(
+      modifier = Modifier.fillMaxHeight().padding(vertical = readerViewToggleVerticalPadding),
+      label = stringResource(Res.string.cdLoadFullArticle),
+      icon = TwineIcons.ArticleShortcut,
+      onClick = loadFullArticleClick,
+      backgroundColor = readerViewToggleBackgroundColor,
+      contentColor = readerViewToggleContentColor,
+      minWidth = readerViewToggleWidth
+    )
+
+    BottomBarIconButton(
+      modifier = Modifier.padding(vertical = 12.dp),
+      label = stringResource(Res.string.readerSettings),
+      icon = TwineIcons.Settings,
+      onClick = openReaderViewSettings,
+      minWidth = buttonMinWidth
+    )
+  }
+}
+
+@Composable
+private fun BottomBarIconButton(
+  label: String,
+  icon: ImageVector,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+  contentColor: Color = AppTheme.colorScheme.onSurfaceVariant,
+  minWidth: Dp = 56.dp,
+) {
+  Box(
+    modifier =
+      Modifier.then(modifier)
+        .requiredSizeIn(minWidth = minWidth)
+        .clip(RoundedCornerShape(50))
+        .semantics {
+          role = Role.Button
+          contentDescription = label
+        }
+        .clickable { onClick() },
+    contentAlignment = Alignment.Center,
+  ) {
+    Icon(
+      modifier = Modifier.padding(vertical = 10.dp).requiredSize(20.dp),
+      imageVector = icon,
+      contentDescription = null,
+      tint = contentColor,
+    )
+  }
+}
+
+@Composable
+private fun BottomBarToggleIconButton(
+  label: String,
+  icon: ImageVector,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+  backgroundColor: Color = Color.Transparent,
+  contentColor: Color = AppTheme.colorScheme.onSurfaceVariant,
+  minWidth: Dp = 72.dp,
+) {
+  Box(
+    modifier =
+      Modifier.requiredSizeIn(minHeight = 40.dp, minWidth = minWidth)
+        .then(modifier)
+        .clip(RoundedCornerShape(50))
+        .background(backgroundColor, RoundedCornerShape(50))
+        .semantics {
+          role = Role.Button
+          contentDescription = label
+        }
+        .clickable { onClick() },
+    contentAlignment = Alignment.Center,
+  ) {
+    Icon(
+      modifier = Modifier.requiredSize(20.dp),
+      imageVector = icon,
+      contentDescription = null,
+      tint = contentColor,
+    )
+  }
+}

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/reader/ui/ReaderWebView.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/reader/ui/ReaderWebView.kt
@@ -19,9 +19,9 @@ package dev.sasikanth.rss.reader.reader.ui
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 
-/** Need this to parse the HTML content of the post using Postlight parser using JS */
+/** Need this to parse the HTML content of the post using a custom reader parser in JS */
 @Composable
-expect fun ReaderWebView(
+internal expect fun ReaderWebView(
   link: String?,
   content: String?,
   postImage: String?,

--- a/shared/src/iosMain/kotlin/dev/sasikanth/rss/reader/reader/ui/ReaderWebView.ios.kt
+++ b/shared/src/iosMain/kotlin/dev/sasikanth/rss/reader/reader/ui/ReaderWebView.ios.kt
@@ -44,7 +44,7 @@ import platform.darwin.NSObject
 
 @OptIn(ExperimentalForeignApi::class)
 @Composable
-actual fun ReaderWebView(
+internal actual fun ReaderWebView(
   link: String?,
   content: String?,
   postImage: String?,


### PR DESCRIPTION
This commit extracts several components from `ReaderScreen.kt` into their own files:

- `ReaderPage.kt`: Contains the main content rendering logic for a single reader page.
- `ReaderViewBottomBar.kt`: Encapsulates the bottom action bar for the reader.
- `ReaderCustomizationsContent.kt`: Manages the UI for reader customization options (renamed from `ReaderCustomisations.kt`).

The `ReaderScreen.kt` has been updated to use these new components, and the original `ReaderCustomisations.kt` file has been removed.
