### PR TITLE
Uses the CocoaPods plugin to link RevenueCat frameworks for tests.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,7 @@ plugins {
   alias(libs.plugins.kotlin.serialization).apply(false)
   alias(libs.plugins.kotlin.compose).apply(false)
   alias(libs.plugins.bugsnag).apply(false)
+  alias(libs.plugins.kotlin.cocoapods).apply(false)
 }
 
 allprojects {

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,6 +8,7 @@ kotlin.mpp.stability.nowarn=true
 kotlin.mpp.enableCInteropCommonization=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
 kotlin.mpp.androidGradlePluginCompatibility.nowarn=true
+kotlin.apple.deprecated.allowUsingEmbedAndSignWithCocoaPodsDependencies=true
 #Compose
 org.jetbrains.compose.experimental.uikit.enabled=true
 #Android

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -56,6 +56,7 @@ leakcanary = "2.14"
 markdown = "0.35.0"
 shadow = "2.0.3"
 revenuecat = "1.8.4+13.37.0"
+revenuecat-common = "13.37.0"
 
 [libraries]
 compose_runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "compose" }
@@ -148,6 +149,7 @@ kotlin_android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin_parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
 kotlin_compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin_serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+kotlin_cocoapods = { id = "org.jetbrains.kotlin.native.cocoapods", version.ref = "kotlin" }
 compose = { id = "org.jetbrains.compose", version.ref = "compose" }
 sqldelight = { id = "app.cash.sqldelight", version.ref = "sqldelight" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -27,6 +27,7 @@ plugins {
   alias(libs.plugins.kotlin.parcelize)
   alias(libs.plugins.kotlin.serialization)
   alias(libs.plugins.kotlin.compose)
+  alias(libs.plugins.kotlin.cocoapods)
 }
 
 composeCompiler { featureFlags = setOf(ComposeFeatureFlag.StrongSkipping) }
@@ -143,6 +144,21 @@ kotlin {
     }
 
     iosMain.dependencies { implementation(libs.ktor.client.darwin) }
+  }
+
+  cocoapods {
+    noPodspec()
+    version = "1"
+    ios.deploymentTarget = "15"
+
+    pod("PurchasesHybridCommon") {
+      version = libs.versions.revenuecat.common.get()
+      extraOpts += listOf("-compiler-option", "-fmodules")
+    }
+    pod("PurchasesHybridCommonUI") {
+      version = libs.versions.revenuecat.common.get()
+      extraOpts += listOf("-compiler-option", "-fmodules")
+    }
   }
 }
 


### PR DESCRIPTION
## Description
This PR adds a workaround to fixing Kotlin tests for the iOS targets. It uses the CocoaPods plugin to link the RevenueCat iOS frameworks. This is only actually needed when running Kotlin tests for the iOS target. When running the iOS app (via Xcode), the frameworks are still linked via SPM.