### PR TITLE
Refactor bottom sheet UI with new design

### DIFF
--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/BottomSheetCollapsedContent.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/BottomSheetCollapsedContent.kt
@@ -53,6 +53,8 @@ internal fun BottomSheetCollapsedContent(
   numberOfFeeds: Int,
   activeSource: Source?,
   canShowUnreadPostsCount: Boolean,
+  homeItemBackgroundColor: Color,
+  homeItemShadowColors: Array<Pair<Float, Color>>,
   onSourceClick: (Source) -> Unit,
   onHomeSelected: () -> Unit,
   modifier: Modifier = Modifier
@@ -64,18 +66,12 @@ internal fun BottomSheetCollapsedContent(
       contentPadding = PaddingValues(end = 24.dp)
     ) {
       stickyHeader {
-        val shadowColors =
-          arrayOf(
-            0.85f to AppTheme.colorScheme.tintedBackground,
-            0.9f to AppTheme.colorScheme.tintedBackground.copy(alpha = 0.4f),
-            1f to Color.Transparent
-          )
-
         val allFeedsLabel = stringResource(Res.string.allFeeds)
 
         HomeBottomBarItem(
           selected = activeSource == null,
           onClick = onHomeSelected,
+          backgroundColor = homeItemBackgroundColor,
           modifier =
             Modifier.clearAndSetSemantics {
                 contentDescription = allFeedsLabel
@@ -85,7 +81,7 @@ internal fun BottomSheetCollapsedContent(
                 onDrawBehind {
                   val brush =
                     Brush.horizontalGradient(
-                      colorStops = shadowColors,
+                      colorStops = homeItemShadowColors,
                     )
                   drawRect(
                     brush = brush,

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/BottomSheetHandle.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/BottomSheetHandle.kt
@@ -27,31 +27,36 @@ import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.min
 import dev.sasikanth.rss.reader.ui.AppTheme
 
-private val COLLAPSED_HANDLE_SIZE = 32.dp
+private val COLLAPSED_HANDLE_SIZE = 24.dp
 private val EXPANDED_HANDLE_SIZE = 64.dp
 
 @Composable
-internal fun BottomSheetHandle(progress: Float) {
+internal fun BottomSheetHandle(
+  progress: Float,
+  modifier: Modifier = Modifier,
+) {
   val statusBarPadding = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
   val targetHandleSize =
     min(COLLAPSED_HANDLE_SIZE * progress + COLLAPSED_HANDLE_SIZE, EXPANDED_HANDLE_SIZE)
 
-  val collapsedTopPadding = 8.dp
+  val collapsedTopPadding = 12.dp
   val targetTopPadding =
     (collapsedTopPadding * (progress * 2) + collapsedTopPadding) + (statusBarPadding * progress)
 
-  Column(modifier = Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
+  Column(
+    modifier = Modifier.fillMaxWidth().then(modifier),
+    horizontalAlignment = Alignment.CenterHorizontally
+  ) {
     Spacer(Modifier.requiredHeight(targetTopPadding))
     Box(
       Modifier.background(AppTheme.colorScheme.tintedForeground, shape = RoundedCornerShape(50))
-        .requiredSize(width = targetHandleSize, height = 4.dp)
+        .requiredSize(width = targetHandleSize, height = 3.dp)
     )
     Spacer(Modifier.requiredHeight(8.dp))
   }

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/FeedBottomBarItem.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/FeedBottomBarItem.kt
@@ -60,7 +60,7 @@ internal fun FeedBottomBarItem(
         url = feedIcon,
         contentDescription = null,
         modifier =
-          Modifier.requiredSize(56.dp).clip(RoundedCornerShape(16.dp)).clickable(onClick = onClick)
+          Modifier.requiredSize(48.dp).clip(RoundedCornerShape(16.dp)).clickable(onClick = onClick)
       )
     }
 
@@ -99,7 +99,7 @@ internal fun SelectionIndicator(selected: Boolean, animationProgress: Float) {
   // Set alpha to 0 once the progress goes below this threshold
   val threshold = 0.89f
 
-  val size = (64.dp * animationProgress).coerceAtLeast(56.dp)
+  val size = (56.dp * animationProgress).coerceAtLeast(48.dp)
   val cornerRadius = (20.dp * animationProgress).coerceAtLeast(16.dp)
   val alpha = animationProgress.takeIf { it >= threshold } ?: 0f
 

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/FeedGroupBottomBarItem.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/FeedGroupBottomBarItem.kt
@@ -51,7 +51,7 @@ internal fun FeedGroupBottomBarItem(
       SelectionIndicator(selected = selected, animationProgress = 1f)
       Box(
         modifier =
-          Modifier.requiredSize(56.dp)
+          Modifier.requiredSize(48.dp)
             .clip(RoundedCornerShape(16.dp))
             .clickable { onClick() }
             .background(AppTheme.colorScheme.tintedSurface)

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/HomeBottomBarItem.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/HomeBottomBarItem.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import dev.sasikanth.rss.reader.resources.icons.All
@@ -34,6 +35,7 @@ import dev.sasikanth.rss.reader.ui.AppTheme
 
 @Composable
 internal fun HomeBottomBarItem(
+  backgroundColor: Color,
   selected: Boolean = false,
   modifier: Modifier = Modifier,
   onClick: () -> Unit
@@ -43,9 +45,9 @@ internal fun HomeBottomBarItem(
     Box(
       modifier =
         Modifier.clip(RoundedCornerShape(16.dp))
-          .background(color = AppTheme.colorScheme.tintedSurface)
+          .background(color = backgroundColor)
           .clickable(onClick = onClick, role = Role.Button)
-          .padding(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 16.dp)
+          .padding(12.dp)
           .align(Alignment.Center),
     ) {
       Icon(

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/expanded/BottomSheetExpandedContent.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/expanded/BottomSheetExpandedContent.kt
@@ -244,7 +244,7 @@ internal fun BottomSheetExpandedContent(
           bottom = if (imeBottomPadding > 0.dp) imeBottomPadding + 16.dp else 0.dp,
           // doing this so that the dividers in sticky headers can go below the search bar and
           // not overlap with each other
-          top = padding.calculateTopPadding() - 1.dp
+          top = padding.calculateTopPadding()
         ),
       state = lazyListState,
       pinnedSources = {

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/ui/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/ui/HomeScreen.kt
@@ -32,7 +32,6 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.KeyboardArrowUp
@@ -62,6 +61,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.coerceAtLeast
@@ -83,7 +83,6 @@ import dev.sasikanth.rss.reader.ui.AppTheme
 import dev.sasikanth.rss.reader.ui.LocalSeedColorExtractor
 import dev.sasikanth.rss.reader.utils.BackHandler
 import dev.sasikanth.rss.reader.utils.Constants
-import dev.sasikanth.rss.reader.utils.inverse
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
@@ -98,8 +97,7 @@ import twine.shared.generated.resources.noNewPosts
 import twine.shared.generated.resources.noNewPostsSubtitle
 import twine.shared.generated.resources.swipeUpGetStarted
 
-internal val BOTTOM_SHEET_PEEK_HEIGHT = 96.dp
-private val BOTTOM_SHEET_CORNER_SIZE = 32.dp
+internal val BOTTOM_SHEET_PEEK_HEIGHT = 116.dp
 
 @Composable
 internal fun HomeScreen(
@@ -308,7 +306,8 @@ internal fun HomeScreen(
       sheetContent = {
         FeedsBottomSheet(
           feedsPresenter = homePresenter.feedsPresenter,
-          bottomSheetProgress = bottomSheetProgress,
+          bottomSheetProgress = { bottomSheetProgress },
+          darkTheme = useDarkTheme,
           closeSheet = { coroutineScope.launch { bottomSheetState.partialExpand() } },
           selectedFeedChanged = {
             coroutineScope.launch {
@@ -319,16 +318,12 @@ internal fun HomeScreen(
         )
       },
       containerColor = Color.Transparent,
-      sheetContainerColor = AppTheme.colorScheme.tintedBackground,
-      sheetContentColor = AppTheme.colorScheme.tintedForeground,
+      sheetContainerColor = Color.Transparent,
+      sheetContentColor = Color.Unspecified,
       sheetShadowElevation = 0.dp,
       sheetTonalElevation = 0.dp,
       sheetPeekHeight = sheetPeekHeight,
-      sheetShape =
-        RoundedCornerShape(
-          topStart = BOTTOM_SHEET_CORNER_SIZE * bottomSheetProgress.inverse(),
-          topEnd = BOTTOM_SHEET_CORNER_SIZE * bottomSheetProgress.inverse()
-        ),
+      sheetShape = RectangleShape,
       sheetSwipeEnabled = !feedsState.isInMultiSelectMode,
       sheetDragHandle = null
     )


### PR DESCRIPTION
This commit introduces a new design for the bottom sheet component.

Key changes:
- Updated the visual appearance of the bottom sheet with a new layout and styling.
- The collapsed handle size is now 24.dp.
- Implemented a more dynamic bottom sheet expansion and collapse animation, including adjustments to corner radius and content alpha based on the sheet's progress.
- Removed the top padding offset in `BottomSheetExpandedContent` for a cleaner look when sticky headers are used.
- The background color, border color, and shadow of the bottom sheet now adapt based on the current theme (light/dark).
- The `FeedsBottomSheet` now takes a lambda for `bottomSheetProgress` for more flexible state management.
- Replaced the previous `RoundedCornerShape` for the `ModalBottomSheet` with `RectangleShape` to allow custom shape drawing based on progress.
