### PR TITLE
Adjust feeds bottom sheet collapsed content UI spacings/dimens

### DIFF
--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/BottomSheetCollapsedContent.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/BottomSheetCollapsedContent.kt
@@ -62,7 +62,7 @@ internal fun BottomSheetCollapsedContent(
   Box {
     LazyRow(
       modifier = modifier.fillMaxWidth().padding(start = 20.dp),
-      horizontalArrangement = Arrangement.spacedBy(8.dp),
+      horizontalArrangement = Arrangement.spacedBy(12.dp),
       contentPadding = PaddingValues(end = 24.dp)
     ) {
       stickyHeader {
@@ -88,7 +88,6 @@ internal fun BottomSheetCollapsedContent(
                   )
                 }
               }
-              .padding(end = 4.dp)
         )
       }
 

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/BottomSheetHandle.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/BottomSheetHandle.kt
@@ -55,9 +55,10 @@ internal fun BottomSheetHandle(
   ) {
     Spacer(Modifier.requiredHeight(targetTopPadding))
     Box(
-      Modifier.background(AppTheme.colorScheme.tintedForeground, shape = RoundedCornerShape(50))
+      Modifier.background(AppTheme.colorScheme.onSurfaceVariant, shape = RoundedCornerShape(50))
         .requiredSize(width = targetHandleSize, height = 3.dp)
     )
-    Spacer(Modifier.requiredHeight(8.dp))
+
+    Spacer(Modifier.requiredHeight(13.dp))
   }
 }

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/FeedGroupBottomBarItem.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/FeedGroupBottomBarItem.kt
@@ -62,9 +62,9 @@ internal fun FeedGroupBottomBarItem(
         val icons = if (showFeedFavIcon) feedGroup.feedHomepageLinks else feedGroup.feedIconLinks
         val iconSize =
           if (icons.size > 2) {
-            18.dp
+            16.dp
           } else {
-            20.dp
+            18.dp
           }
 
         val iconSpacing =

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/FeedsBottomSheet.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/FeedsBottomSheet.kt
@@ -18,6 +18,7 @@ package dev.sasikanth.rss.reader.feeds.ui
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -195,7 +196,8 @@ internal fun FeedsBottomSheet(
 
         BottomSheetCollapsedContent(
           modifier =
-            Modifier.layout { measurable, constraints ->
+            Modifier.padding(bottom = 24.dp)
+              .layout { measurable, constraints ->
                 val placeable = measurable.measure(constraints)
                 val height =
                   lerp(
@@ -212,7 +214,7 @@ internal fun FeedsBottomSheet(
           numberOfFeeds = state.numberOfFeeds,
           activeSource = state.activeSource,
           canShowUnreadPostsCount = state.canShowUnreadPostsCount,
-          homeItemBackgroundColor = collapsedContentBackgroundColor,
+          homeItemBackgroundColor = AppTheme.colorScheme.surfaceContainerLow,
           homeItemShadowColors = homeItemShadowColors,
           onSourceClick = { feed -> feedsPresenter.dispatch(FeedsEvent.OnSourceClick(feed)) },
           onHomeSelected = { feedsPresenter.dispatch(FeedsEvent.OnHomeSelected) }


### PR DESCRIPTION
- Increase horizontal spacing between feed items.
- Adjust padding for "All" button.
- Modify icon sizes and spacing in `FeedGroupBottomBarItem`.
- Update bottom sheet handle appearance:
    - Change background color.
    - Increase bottom spacer height.
- Adjust padding and background color of the collapsed content in `FeedsBottomSheet`.
