### PR TITLE
Ensure consistent background color in bottom sheets

### DIFF
--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/components/NewArticlesScrollToTopButton.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/components/NewArticlesScrollToTopButton.kt
@@ -71,38 +71,38 @@ internal fun BoxScope.NewArticlesScrollToTopButton(
   onScrollToTopClick: suspend () -> Unit,
 ) {
   if (unreadSinceLastSync != null) {
-    AppTheme(useDarkTheme = true) {
-      val coroutineScope = rememberCoroutineScope()
-      AnimatedVisibility(
-        visible = unreadSinceLastSync.hasNewArticles || canShowScrollToTop,
-        enter = slideInVertically { it },
-        exit = slideOutVertically { it },
-        modifier = Modifier.align(Alignment.BottomCenter)
+    val coroutineScope = rememberCoroutineScope()
+    AnimatedVisibility(
+      visible = unreadSinceLastSync.hasNewArticles || canShowScrollToTop,
+      enter = slideInVertically { it },
+      exit = slideOutVertically { it },
+      modifier = Modifier.align(Alignment.BottomCenter)
+    ) {
+      val buttonShape = RoundedCornerShape(50)
+      Box(
+        modifier =
+          modifier
+            .background(AppTheme.colorScheme.bottomSheet, buttonShape)
+            .border(1.dp, AppTheme.colorScheme.bottomSheetBorder, buttonShape)
+            .dropShadow(
+              shape = buttonShape,
+              color = Color.Black.copy(alpha = 0.4f),
+              offsetX = 0.dp,
+              offsetY = 16.dp,
+              blur = 32.dp,
+              spread = 0.dp,
+            )
+            .dropShadow(
+              shape = buttonShape,
+              color = Color.Black.copy(alpha = 0.016f),
+              offsetX = 0.dp,
+              offsetY = 4.dp,
+              blur = 8.dp,
+              spread = 0.dp,
+            )
+            .padding(4.dp),
       ) {
-        val buttonShape = RoundedCornerShape(50)
-        Box(
-          modifier =
-            modifier
-              .background(AppTheme.colorScheme.bottomSheet, buttonShape)
-              .border(1.dp, AppTheme.colorScheme.bottomSheetBorder, buttonShape)
-              .dropShadow(
-                shape = buttonShape,
-                color = Color.Black.copy(alpha = 0.4f),
-                offsetX = 0.dp,
-                offsetY = 16.dp,
-                blur = 32.dp,
-                spread = 0.dp,
-              )
-              .dropShadow(
-                shape = buttonShape,
-                color = Color.Black.copy(alpha = 0.016f),
-                offsetX = 0.dp,
-                offsetY = 4.dp,
-                blur = 8.dp,
-                spread = 0.dp,
-              )
-              .padding(4.dp),
-        ) {
+        AppTheme(useDarkTheme = true) {
           Row(modifier = Modifier.height(IntrinsicSize.Min)) {
             AnimatedVisibility(visible = unreadSinceLastSync.hasNewArticles) {
               Row {

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/reader/ui/ReaderCustomizationsContent.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/reader/ui/ReaderCustomizationsContent.kt
@@ -51,7 +51,11 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import dev.sasikanth.rss.reader.data.repository.ReaderFont
-import dev.sasikanth.rss.reader.data.repository.ReaderFont.*
+import dev.sasikanth.rss.reader.data.repository.ReaderFont.ComicNeue
+import dev.sasikanth.rss.reader.data.repository.ReaderFont.Golos
+import dev.sasikanth.rss.reader.data.repository.ReaderFont.Lora
+import dev.sasikanth.rss.reader.data.repository.ReaderFont.Merriweather
+import dev.sasikanth.rss.reader.data.repository.ReaderFont.RobotoSerif
 import dev.sasikanth.rss.reader.resources.icons.CustomTypography
 import dev.sasikanth.rss.reader.resources.icons.TwineIcons
 import dev.sasikanth.rss.reader.ui.AppTheme
@@ -74,7 +78,10 @@ internal fun ReaderCustomizationsContent(
   onFontScaleFactorChange: (Float) -> Unit,
   onFontLineHeightFactorChange: (Float) -> Unit,
 ) {
-  Column(modifier = Modifier.fillMaxWidth().padding(vertical = 16.dp)) {
+  Column(
+    modifier =
+      Modifier.fillMaxWidth().background(AppTheme.colorScheme.bottomSheet).padding(vertical = 16.dp)
+  ) {
     CustomisationsTypefaceHeader()
 
     val activeTypefaceIndex = ReaderFont.entries.indexOf(selectedFont)

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/reader/ui/ReaderScreen.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/reader/ui/ReaderScreen.kt
@@ -56,6 +56,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -403,29 +404,26 @@ private fun ReaderActionsPanel(
         } else {
           Pair(Color.Black.copy(alpha = 0.4f), Color.Black.copy(alpha = 0.16f))
         }
+      val backgroundShape = RoundedCornerShape(36.dp)
 
       Box(
         modifier =
           Modifier.padding(horizontal = 16.dp, vertical = 16.dp)
             .pointerInput(Unit) {}
-            .background(color = AppTheme.colorScheme.bottomSheet, shape = RoundedCornerShape(36.dp))
+            .clip(backgroundShape)
+            .background(color = AppTheme.colorScheme.bottomSheet, shape = backgroundShape)
             .border(
               width = 1.dp,
               color = AppTheme.colorScheme.bottomSheetBorder,
-              shape = RoundedCornerShape(36.dp)
+              shape = backgroundShape
             )
             .dropShadow(
-              shape = RoundedCornerShape(36.dp),
+              shape = backgroundShape,
               offsetY = 16.dp,
               blur = 32.dp,
               color = shadowColor1
             )
-            .dropShadow(
-              shape = RoundedCornerShape(36.dp),
-              offsetY = 4.dp,
-              blur = 8.dp,
-              color = shadowColor2
-            )
+            .dropShadow(shape = backgroundShape, offsetY = 4.dp, blur = 8.dp, color = shadowColor2)
             .graphicsLayer { clip = true }
       ) {
         AppTheme(useDarkTheme = true) {


### PR DESCRIPTION
The reader bottom sheet was using `AppTheme.colorScheme.bottomSheet` directly, which could lead to inconsistencies with the "new articles" button that was wrapped in `AppTheme(useDarkTheme = true)`.

This change ensures that both the reader bottom sheet and the "new articles" button use the same background color by applying `AppTheme(useDarkTheme = true)` at a higher level or by ensuring the `bottomSheet` color is appropriate for both contexts.

Additionally, the `clip` modifier is now applied before the `background` modifier on the reader bottom sheet to ensure the background respects the rounded corners.
