### PR TITLE
Update to JDK 21

### DIFF
--- a/.github/workflows/android_prod_release.yml
+++ b/.github/workflows/android_prod_release.yml
@@ -36,10 +36,10 @@ jobs:
           VERSION_CODE=${WORKFLOW_INPUT:-"1"}
           echo "ORG_GRADLE_PROJECT_VERSION_CODE=$VERSION_CODE" >> $GITHUB_ENV
 
-      - name: Setup JDK 20
+      - name: Setup JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: 20
+          java-version: 21
           distribution: zulu
           cache: 'gradle'
 

--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -17,10 +17,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup JDK 20
+      - name: Setup JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: 20
+          java-version: 21
           distribution: zulu
           cache: 'gradle'
 
@@ -32,10 +32,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup JDK 20
+      - name: Setup JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: 20
+          java-version: 21
           distribution: zulu
           cache: 'gradle'
 
@@ -49,10 +49,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup JDK 20
+      - name: Setup JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: 20
+          java-version: 21
           distribution: zulu
           cache: 'gradle'
 
@@ -71,10 +71,10 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
-      - name: Setup JDK 20
+      - name: Setup JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: 20
+          java-version: 21
           distribution: zulu
           cache: 'gradle'
 

--- a/.github/workflows/ios_prod_release.yml
+++ b/.github/workflows/ios_prod_release.yml
@@ -23,10 +23,10 @@ jobs:
         with:
           input: ${{ github.event.inputs.tramline-input }}
 
-      - name: Setup JDK 20
+      - name: Setup JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: 20
+          java-version: 21
           distribution: zulu
           cache: 'gradle'
 

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -24,7 +24,7 @@ plugins {
 }
 
 kotlin {
-  jvmToolchain(20)
+  jvmToolchain(21)
 
   androidTarget()
 

--- a/core/base/build.gradle.kts
+++ b/core/base/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
 }
 
 kotlin {
-  jvmToolchain(20)
+  jvmToolchain(21)
 
   androidTarget()
   listOf(iosArm64(), iosSimulatorArm64())

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -37,7 +37,7 @@ plugins {
 }
 
 kotlin {
-  jvmToolchain(20)
+  jvmToolchain(21)
 
   androidTarget()
   listOf(iosArm64(), iosSimulatorArm64())

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -24,7 +24,7 @@ plugins {
 }
 
 kotlin {
-  jvmToolchain(20)
+  jvmToolchain(21)
 
   @Suppress("OPT_IN_USAGE")
   androidTarget { instrumentedTestVariant.sourceSetTree.set(KotlinSourceSetTree.test) }

--- a/resources/icons/build.gradle.kts
+++ b/resources/icons/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
 }
 
 kotlin {
-  jvmToolchain(20)
+  jvmToolchain(21)
 
   androidTarget()
   jvm()

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -33,7 +33,7 @@ composeCompiler { featureFlags = setOf(ComposeFeatureFlag.StrongSkipping) }
 
 @OptIn(ExperimentalKotlinGradlePluginApi::class)
 kotlin {
-  jvmToolchain(20)
+  jvmToolchain(21)
 
   androidTarget { instrumentedTestVariant.sourceSetTree.set(KotlinSourceSetTree.test) }
 


### PR DESCRIPTION
It's easier to work with JDK 21 since Android Studio already ships with it.

I've update both the Gradle build scripts as well as Github Actions workflows to use JDK 21