### PR TITLE
Optimise featured section background rendering

### DIFF
--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/ui/FeaturedImage.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/ui/FeaturedImage.kt
@@ -24,6 +24,9 @@ import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.layer.GraphicsLayer
+import androidx.compose.ui.graphics.layer.drawLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -32,7 +35,11 @@ import dev.sasikanth.rss.reader.ui.AppTheme
 import dev.sasikanth.rss.reader.utils.LocalWindowSizeClass
 
 @Composable
-fun FeaturedImage(image: String?, modifier: Modifier = Modifier) {
+fun FeaturedImage(
+  image: String?,
+  modifier: Modifier = Modifier,
+  imageGraphicsLayer: GraphicsLayer? = null,
+) {
   val sizeClass = LocalWindowSizeClass.current.widthSizeClass
   val imageMaxHeight =
     when {
@@ -49,9 +56,17 @@ fun FeaturedImage(image: String?, modifier: Modifier = Modifier) {
     AsyncImage(
       url = image,
       modifier =
-        Modifier.clip(MaterialTheme.shapes.extraLarge)
+        Modifier.aspectRatio(16f / 9f)
           .heightIn(max = imageMaxHeight)
-          .aspectRatio(ratio = 16f / 9f)
+          .drawWithContent {
+            if (imageGraphicsLayer != null) {
+              imageGraphicsLayer.record { this@drawWithContent.drawContent() }
+              drawLayer(imageGraphicsLayer)
+            } else {
+              this.drawContent()
+            }
+          }
+          .clip(MaterialTheme.shapes.extraLarge)
           .background(AppTheme.colorScheme.surfaceContainerLowest)
           .then(modifier),
       contentDescription = null,

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/ui/FeaturedPostItem.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/ui/FeaturedPostItem.kt
@@ -35,11 +35,9 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -64,13 +62,13 @@ private val featuredItemPadding
 @Composable
 internal fun FeaturedPostItem(
   item: PostWithMetadata,
-  pageOffset: () -> Float,
   onClick: () -> Unit,
   onBookmarkClick: () -> Unit,
   onCommentsClick: () -> Unit,
   onSourceClick: () -> Unit,
   onTogglePostReadClick: () -> Unit,
   modifier: Modifier = Modifier,
+  featuredImage: @Composable () -> Unit,
 ) {
   Column(
     modifier =
@@ -83,16 +81,7 @@ internal fun FeaturedPostItem(
     val density = LocalDensity.current
     var descriptionBottomPadding by remember(item.link) { mutableStateOf(0.dp) }
 
-    FeaturedImage(
-      modifier =
-        Modifier.graphicsLayer {
-            translationX = pageOffset.invoke() * 350f
-            scaleX = 1.15f
-            scaleY = 1.15f
-          }
-          .align(Alignment.CenterHorizontally),
-      image = item.imageUrl,
-    )
+    featuredImage()
 
     Spacer(modifier = Modifier.requiredHeight(8.dp))
 


### PR DESCRIPTION
Use `GraphicsLayer` to capture the featured image and reuse it for the blurred background.

This avoids loading the same image twice (once for the foreground and once for the background), improving performance and memory usage. 

The parallax and blur effects are now applied more efficiently using the captured layer.
