### PR TITLE
Add setting to download full content during sync

### DIFF
--- a/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/repository/RssRepository.kt
+++ b/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/repository/RssRepository.kt
@@ -113,7 +113,7 @@ class RssRepository(
             id = postId,
             rawContent = postPayload.rawContent,
             rawContentLen = postPayload.rawContent.orEmpty().length.toLong(),
-            htmlContent = null,
+            htmlContent = postPayload.fullContent,
             createdAt = Clock.System.now(),
           )
         }

--- a/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/repository/SettingsRepository.kt
+++ b/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/repository/SettingsRepository.kt
@@ -49,6 +49,7 @@ class SettingsRepository(private val dataStore: DataStore<Preferences>) {
   private val readerFontStyleKey = stringPreferencesKey("reader_font_style")
   private val blockImagesKey = booleanPreferencesKey("block_images")
   private val enableNotificationsKey = booleanPreferencesKey("enable_notifications")
+  private val downloadFullContentKey = booleanPreferencesKey("download_full_content")
 
   val browserType: Flow<BrowserType> =
     dataStore.data.map { preferences ->
@@ -108,6 +109,9 @@ class SettingsRepository(private val dataStore: DataStore<Preferences>) {
 
   val enableNotifications: Flow<Boolean> =
     dataStore.data.map { preferences -> preferences[enableNotificationsKey] ?: false }
+
+  val downloadFullContent: Flow<Boolean> =
+    dataStore.data.map { preferences -> preferences[downloadFullContentKey] ?: false }
 
   suspend fun enableAutoSyncImmediate(): Boolean {
     return enableAutoSync.first()
@@ -183,6 +187,10 @@ class SettingsRepository(private val dataStore: DataStore<Preferences>) {
 
   suspend fun toggleNotifications(value: Boolean) {
     dataStore.edit { preferences -> preferences[enableNotificationsKey] = value }
+  }
+
+  suspend fun toggleDownloadFullContent(value: Boolean) {
+    dataStore.edit { preferences -> preferences[downloadFullContentKey] = value }
   }
 
   private fun mapToAppThemeMode(pref: String?): AppThemeMode? {

--- a/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/sync/LocalSyncCoordinator.kt
+++ b/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/sync/LocalSyncCoordinator.kt
@@ -137,7 +137,8 @@ class LocalSyncCoordinator(
 
   private suspend fun pullFeed(feed: Feed, now: Instant) {
     val initialPostCount = rssRepository.postsCountForFeed(feed.id)
-    val feedFetchResult = feedFetcher.fetch(feed.link)
+    val fetchFullContent = settingsRepository.downloadFullContent.first()
+    val feedFetchResult = feedFetcher.fetch(url = feed.link, fetchFullContent = fetchFullContent)
 
     if (feedFetchResult !is FeedFetchResult.Success) return
 

--- a/core/model/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/model/remote/PostPayload.kt
+++ b/core/model/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/model/remote/PostPayload.kt
@@ -20,6 +20,7 @@ data class PostPayload(
   val link: String,
   val description: String,
   val rawContent: String?,
+  val fullContent: String?,
   val imageUrl: String?,
   val date: Long,
   val commentsLink: String?,

--- a/core/network/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/network/parser/xml/AtomFeedParser.kt
+++ b/core/network/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/network/parser/xml/AtomFeedParser.kt
@@ -209,6 +209,7 @@ class AtomContentParser(
       link = XmlFeedParser.cleanText(link)!!,
       description = content.orEmpty().decodeHTMLString(),
       rawContent = rawContent,
+      fullContent = null,
       imageUrl = UrlUtils.safeUrl(hostLink, image),
       date = postPubDateInMillis ?: Clock.System.now().toEpochMilliseconds(),
       commentsLink = null,

--- a/core/network/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/network/parser/xml/RDFFeedParser.kt
+++ b/core/network/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/network/parser/xml/RDFFeedParser.kt
@@ -161,6 +161,7 @@ class RDFContentParser(
       link = XmlFeedParser.cleanText(link)!!,
       description = description.orEmpty().decodeHTMLString(),
       rawContent = rawContent,
+      fullContent = null,
       imageUrl = UrlUtils.safeUrl(hostLink, image),
       date = postPubDateInMillis ?: Clock.System.now().toEpochMilliseconds(),
       commentsLink = commentsLink?.trim(),

--- a/core/network/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/network/parser/xml/RssFeedParser.kt
+++ b/core/network/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/network/parser/xml/RssFeedParser.kt
@@ -210,6 +210,7 @@ class RSSContentParser(private val articleHtmlParser: ArticleHtmlParser) : XmlCo
       link = XmlFeedParser.cleanText(link)!!,
       description = description.orEmpty().decodeHTMLString(),
       rawContent = rawContent,
+      fullContent = null,
       imageUrl = UrlUtils.safeUrl(hostLink, image),
       date = postPubDateInMillis ?: Clock.System.now().toEpochMilliseconds(),
       commentsLink = commentsLink?.trim(),

--- a/core/network/src/commonTest/kotlin/dev/sasikanth/rss/reader/core/network/parser/JsonFeedParserTest.kt
+++ b/core/network/src/commonTest/kotlin/dev/sasikanth/rss/reader/core/network/parser/JsonFeedParserTest.kt
@@ -56,6 +56,7 @@ class JsonFeedParserTest {
                </html>
               """
                   .trimIndent(),
+              fullContent = null,
               imageUrl = "https://example.com/images/quantum-2025.jpg",
               date = 1740734100000,
               commentsLink = null,
@@ -76,6 +77,7 @@ class JsonFeedParserTest {
                   </html>
               """
                   .trimIndent(),
+              fullContent = null,
               imageUrl = null,
               date = 1739629800000,
               commentsLink = null,
@@ -88,6 +90,7 @@ class JsonFeedParserTest {
                 "Edge computing continues to grow as IoT devices proliferate. This shift is changing how we think about network architecture and data processing.\n\nIn this article, we explore the implications for businesses and consumers alike.",
               rawContent =
                 "Edge computing continues to grow as IoT devices proliferate. This shift is changing how we think about network architecture and data processing.\n\nIn this article, we explore the implications for businesses and consumers alike.",
+              fullContent = null,
               imageUrl = "https://example.com/images/edge-computing.jpg",
               date = 1738410300000,
               commentsLink = null,
@@ -108,6 +111,7 @@ class JsonFeedParserTest {
                   </html>
               """
                   .trimIndent(),
+              fullContent = null,
               imageUrl = null,
               date = 1737388800000,
               commentsLink = null,

--- a/core/network/src/commonTest/kotlin/dev/sasikanth/rss/reader/core/network/parser/XmlFeedParserTest.kt
+++ b/core/network/src/commonTest/kotlin/dev/sasikanth/rss/reader/core/network/parser/XmlFeedParserTest.kt
@@ -108,6 +108,7 @@ class XmlFeedParserTest {
                   </html>
               """
                   .trimIndent(),
+              fullContent = null,
               imageUrl = "https://example.com/first-post-media-url",
               date = 1685005200000,
               commentsLink = null,
@@ -124,6 +125,7 @@ class XmlFeedParserTest {
                   </html>
               """
                   .trimIndent(),
+              fullContent = null,
               imageUrl = "https://example.com/media/post-with-media-thumbnail",
               date = 1685005200000,
               commentsLink = null,
@@ -140,6 +142,7 @@ class XmlFeedParserTest {
                   </html>
               """
                   .trimIndent(),
+              fullContent = null,
               imageUrl = null,
               date = 1684999800000,
               commentsLink = null,
@@ -156,6 +159,7 @@ class XmlFeedParserTest {
                   </html>
               """
                   .trimIndent(),
+              fullContent = null,
               imageUrl = null,
               date = 1684924200000,
               commentsLink = null,
@@ -172,6 +176,7 @@ class XmlFeedParserTest {
                   </html>
               """
                   .trimIndent(),
+              fullContent = null,
               imageUrl = "https://example.com/enclosure-image",
               date = 1684924200000,
               commentsLink = null,
@@ -191,6 +196,7 @@ class XmlFeedParserTest {
                   </html>
                 """
                   .trimIndent(),
+              fullContent = null,
               imageUrl = "https://example.com/encoded-image",
               date = 1684924200000,
               commentsLink = null,
@@ -207,6 +213,7 @@ class XmlFeedParserTest {
                   </html>
               """
                   .trimIndent(),
+              fullContent = null,
               imageUrl = "http://example.com/relative-media-url",
               date = 1685005200000,
               commentsLink = null,
@@ -223,6 +230,7 @@ class XmlFeedParserTest {
                   </html>
               """
                   .trimIndent(),
+              fullContent = null,
               imageUrl = null,
               date = 1685005200000,
               commentsLink = "https://example/post-with-comments/comments",
@@ -239,6 +247,7 @@ class XmlFeedParserTest {
                   </html>
               """
                   .trimIndent(),
+              fullContent = null,
               imageUrl = "https://example.com/media/maxresdefault.jpg",
               date = 1685005200000,
               commentsLink = null,
@@ -278,6 +287,7 @@ class XmlFeedParserTest {
                   </html>
               """
                   .trimIndent(),
+              fullContent = null,
               imageUrl = null,
               date = 1685005200000,
               commentsLink = null,
@@ -297,6 +307,7 @@ class XmlFeedParserTest {
                   </html>
                 """
                   .trimIndent(),
+              fullContent = null,
               imageUrl = "https://example.com/encoded-image",
               date = 1684924200000,
               commentsLink = null,
@@ -339,6 +350,7 @@ class XmlFeedParserTest {
                   </html>
                 """
                   .trimIndent(),
+              fullContent = null,
               imageUrl = "https://example.com/image.jpg",
               date = 1685008800000,
               commentsLink = null,
@@ -357,6 +369,7 @@ class XmlFeedParserTest {
                   </html>
                 """
                   .trimIndent(),
+              fullContent = null,
               imageUrl = null,
               date = 1684917000000,
               commentsLink = null,
@@ -375,6 +388,7 @@ class XmlFeedParserTest {
                   </html>
                 """
                   .trimIndent(),
+              fullContent = null,
               imageUrl = null,
               date = 1684936800000,
               commentsLink = null,
@@ -394,6 +408,7 @@ class XmlFeedParserTest {
                   </html>
                 """
                   .trimIndent(),
+              fullContent = null,
               imageUrl = "http://example.com/resources/image.jpg",
               date = 1685008800000,
               commentsLink = null,
@@ -428,6 +443,7 @@ class XmlFeedParserTest {
               link = "https://www.youtube.com/watch?v=2QpWq3iQdC4",
               description = "Subscribe to watch more videos about Android development",
               rawContent = null,
+              fullContent = null,
               imageUrl = "https://i.ytimg.com/vi/2QpWq3iQdC4/maxresdefault.jpg",
               date = 1698260988000,
               commentsLink = null,
@@ -467,6 +483,7 @@ class XmlFeedParserTest {
                   </html>
                 """
                   .trimIndent(),
+              fullContent = null,
               imageUrl = "https://example.com/episode-1-image.jpg",
               date = 1685005200000,
               commentsLink = null,
@@ -506,6 +523,7 @@ class XmlFeedParserTest {
                   </html>
                 """
                   .trimIndent(),
+              fullContent = null,
               imageUrl = "https://example.com/episode-1-image.jpg",
               date = 1685008800000,
               commentsLink = null,

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -166,6 +166,9 @@
     <string name="screenHome">Home</string>
     <string name="settingsEnableNotificationsTitle">Enable notifications</string>
     <string name="settingsEnableNotificationsSubtitle">When turned on, you will receive notifications when new articles are found during background sync</string>
+    <string name="settingsDownloadFullContentTitle">Download full articles</string>
+    <string name="settingsDownloadFullContentSubtitle">When enabled, the app will try and download full articles during sync.</string>
+    <string name="settingsDownloadFullContentWarning">This can increase feed loading times, memory and storage consumption.</string>
 
     <!-- Plurals -->
     <plurals name="searchResultsCount">

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -168,7 +168,7 @@
     <string name="settingsEnableNotificationsSubtitle">When turned on, you will receive notifications when new articles are found during background sync</string>
     <string name="settingsDownloadFullContentTitle">Download full articles</string>
     <string name="settingsDownloadFullContentSubtitle">When enabled, the app will try and download full articles during sync.</string>
-    <string name="settingsDownloadFullContentWarning">This can increase feed loading times, memory and storage consumption.</string>
+    <string name="settingsDownloadFullContentWarning">Warning!: This can increase feed loading times, data, memory and storage consumption. It can potentially impact your user experience.</string>
 
     <!-- Plurals -->
     <plurals name="searchResultsCount">

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/SettingsEvent.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/SettingsEvent.kt
@@ -56,4 +56,6 @@ sealed interface SettingsEvent {
   data class ToggleBlockImages(val value: Boolean) : SettingsEvent
 
   data class ToggleNotifications(val value: Boolean) : SettingsEvent
+
+  data class ToggleDownloadFullContent(val value: Boolean) : SettingsEvent
 }

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/SettingsState.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/SettingsState.kt
@@ -44,6 +44,7 @@ data class SettingsState(
   val homeViewMode: HomeViewMode,
   val blockImages: Boolean,
   val enableNotifications: Boolean,
+  val downloadFullContent: Boolean,
 ) {
 
   companion object {
@@ -67,6 +68,7 @@ data class SettingsState(
         homeViewMode = HomeViewMode.Default,
         blockImages = false,
         enableNotifications = false,
+        downloadFullContent = false,
       )
   }
 }

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/SettingsViewModel.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/SettingsViewModel.kt
@@ -65,6 +65,7 @@ class SettingsViewModel(
         settingsRepository.homeViewMode,
         settingsRepository.blockImages,
         settingsRepository.enableNotifications,
+        settingsRepository.downloadFullContent,
       ) {
         browserType,
         showUnreadPostsCount,
@@ -77,7 +78,8 @@ class SettingsViewModel(
         markAsReadOn,
         homeViewMode,
         blockImages,
-        enableNotifications ->
+        enableNotifications,
+        downloadFullContent ->
         Settings(
           browserType = browserType,
           showUnreadPostsCount = showUnreadPostsCount,
@@ -91,6 +93,7 @@ class SettingsViewModel(
           homeViewMode = homeViewMode,
           blockImages = blockImages,
           enableNotifications = enableNotifications,
+          downloadFullContent = downloadFullContent,
         )
       }
       .onEach { settings ->
@@ -108,6 +111,7 @@ class SettingsViewModel(
             homeViewMode = settings.homeViewMode,
             blockImages = settings.blockImages,
             enableNotifications = settings.enableNotifications,
+            downloadFullContent = settings.downloadFullContent,
           )
         }
       }
@@ -144,7 +148,12 @@ class SettingsViewModel(
       is SettingsEvent.ChangeHomeViewMode -> changeHomeViewMode(event.homeViewMode)
       is SettingsEvent.ToggleBlockImages -> toggleBlockImages(event.value)
       is SettingsEvent.ToggleNotifications -> toggleNotifications(event.value)
+      is SettingsEvent.ToggleDownloadFullContent -> toggleDownloadFullContent(event.value)
     }
+  }
+
+  private fun toggleDownloadFullContent(value: Boolean) {
+    viewModelScope.launch { settingsRepository.toggleDownloadFullContent(value) }
   }
 
   private fun toggleNotifications(value: Boolean) {
@@ -241,4 +250,5 @@ private data class Settings(
   val homeViewMode: HomeViewMode,
   val blockImages: Boolean,
   val enableNotifications: Boolean,
+  val downloadFullContent: Boolean,
 )

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/SettingsScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.foundation.layout.requiredSize
@@ -135,6 +136,9 @@ import twine.shared.generated.resources.settingsBlockImagesSubtitle
 import twine.shared.generated.resources.settingsBlockImagesTitle
 import twine.shared.generated.resources.settingsBrowserTypeSubtitle
 import twine.shared.generated.resources.settingsBrowserTypeTitle
+import twine.shared.generated.resources.settingsDownloadFullContentSubtitle
+import twine.shared.generated.resources.settingsDownloadFullContentTitle
+import twine.shared.generated.resources.settingsDownloadFullContentWarning
 import twine.shared.generated.resources.settingsEnableNotificationsSubtitle
 import twine.shared.generated.resources.settingsEnableNotificationsTitle
 import twine.shared.generated.resources.settingsHeaderBehaviour
@@ -420,6 +424,17 @@ internal fun SettingsScreen(
               enableNotifications = state.enableNotifications,
               onValueChanged = { newValue ->
                 viewModel.dispatch(SettingsEvent.ToggleNotifications(newValue))
+              }
+            )
+          }
+
+          item { Divider(24.dp) }
+
+          item {
+            DownloadFullContentSettingItem(
+              downloadFullContent = state.downloadFullContent,
+              onValueChanged = { newValue ->
+                viewModel.dispatch(SettingsEvent.ToggleDownloadFullContent(newValue))
               }
             )
           }
@@ -1007,6 +1022,46 @@ private fun NotificationsSettingItem(
       Switch(
         checked = enableNotifications,
         onCheckedChange = onValueChanged,
+      )
+    }
+  }
+}
+
+@Composable
+private fun DownloadFullContentSettingItem(
+  downloadFullContent: Boolean,
+  onValueChanged: (Boolean) -> Unit
+) {
+  Box(modifier = Modifier.clickable { onValueChanged(!downloadFullContent) }) {
+    Row(
+      modifier = Modifier.padding(start = 24.dp, top = 16.dp, end = 24.dp, bottom = 20.dp),
+      verticalAlignment = Alignment.CenterVertically
+    ) {
+      Column(modifier = Modifier.weight(1f)) {
+        Text(
+          stringResource(Res.string.settingsDownloadFullContentTitle),
+          style = MaterialTheme.typography.titleMedium,
+          color = AppTheme.colorScheme.textEmphasisHigh
+        )
+        Text(
+          stringResource(Res.string.settingsDownloadFullContentSubtitle),
+          style = MaterialTheme.typography.labelLarge,
+          color = AppTheme.colorScheme.textEmphasisMed
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+          stringResource(Res.string.settingsDownloadFullContentWarning),
+          style = MaterialTheme.typography.labelLarge,
+          color = AppTheme.colorScheme.error
+        )
+      }
+
+      Spacer(Modifier.width(16.dp))
+
+      Switch(
+        checked = downloadFullContent,
+        onCheckedChange = { checked -> onValueChanged(checked) },
       )
     }
   }

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/utils/CoroutinesExt.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/utils/CoroutinesExt.kt
@@ -41,92 +41,7 @@ inline fun <T1, T2, T3, T4, T5, T6, R> combine(
   }
 }
 
-inline fun <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R> combine(
-  flow: Flow<T1>,
-  flow2: Flow<T2>,
-  flow3: Flow<T3>,
-  flow4: Flow<T4>,
-  flow5: Flow<T5>,
-  flow6: Flow<T6>,
-  flow7: Flow<T7>,
-  flow8: Flow<T8>,
-  flow9: Flow<T9>,
-  flow10: Flow<T10>,
-  crossinline transform: suspend (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) -> R
-): Flow<R> {
-  return kotlinx.coroutines.flow.combine(
-    flow,
-    flow2,
-    flow3,
-    flow4,
-    flow5,
-    flow6,
-    flow7,
-    flow8,
-    flow9,
-    flow10,
-  ) { args: Array<*> ->
-    @Suppress("UNCHECKED_CAST")
-    transform(
-      args[0] as T1,
-      args[1] as T2,
-      args[2] as T3,
-      args[3] as T4,
-      args[4] as T5,
-      args[5] as T6,
-      args[6] as T7,
-      args[7] as T8,
-      args[8] as T9,
-      args[9] as T10,
-    )
-  }
-}
-
-inline fun <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R> combine(
-  flow: Flow<T1>,
-  flow2: Flow<T2>,
-  flow3: Flow<T3>,
-  flow4: Flow<T4>,
-  flow5: Flow<T5>,
-  flow6: Flow<T6>,
-  flow7: Flow<T7>,
-  flow8: Flow<T8>,
-  flow9: Flow<T9>,
-  flow10: Flow<T10>,
-  flow11: Flow<T11>,
-  crossinline transform: suspend (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11) -> R
-): Flow<R> {
-  return kotlinx.coroutines.flow.combine(
-    flow,
-    flow2,
-    flow3,
-    flow4,
-    flow5,
-    flow6,
-    flow7,
-    flow8,
-    flow9,
-    flow10,
-    flow11,
-  ) { args: Array<*> ->
-    @Suppress("UNCHECKED_CAST")
-    transform(
-      args[0] as T1,
-      args[1] as T2,
-      args[2] as T3,
-      args[3] as T4,
-      args[4] as T5,
-      args[5] as T6,
-      args[6] as T7,
-      args[7] as T8,
-      args[8] as T9,
-      args[9] as T10,
-      args[10] as T11,
-    )
-  }
-}
-
-inline fun <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R> combine(
+inline fun <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R> combine(
   flow: Flow<T1>,
   flow2: Flow<T2>,
   flow3: Flow<T3>,
@@ -139,7 +54,8 @@ inline fun <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R> combine(
   flow10: Flow<T10>,
   flow11: Flow<T11>,
   flow12: Flow<T12>,
-  crossinline transform: suspend (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12) -> R
+  flow13: Flow<T13>,
+  crossinline transform: suspend (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13) -> R
 ): Flow<R> {
   return kotlinx.coroutines.flow.combine(
     flow,
@@ -154,6 +70,7 @@ inline fun <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R> combine(
     flow10,
     flow11,
     flow12,
+    flow13,
   ) { args: Array<*> ->
     @Suppress("UNCHECKED_CAST")
     transform(
@@ -169,6 +86,7 @@ inline fun <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R> combine(
       args[9] as T10,
       args[10] as T11,
       args[11] as T12,
+      args[12] as T13,
     )
   }
 }


### PR DESCRIPTION
fixes: #734

Note: This only downloads full content during sync or pull-to-refresh, not when adding a feed. Since that will be a bad user experience, especially when importing OPML file. It can impact the load time significantly.

