### PR TITLE
Add per feed setting to switch between feed icon or fav icon

### DIFF
--- a/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/repository/WidgetDataRepository.kt
+++ b/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/repository/WidgetDataRepository.kt
@@ -16,12 +16,14 @@ import app.cash.sqldelight.coroutines.asFlow
 import app.cash.sqldelight.coroutines.mapToList
 import app.cash.sqldelight.coroutines.mapToOne
 import app.cash.sqldelight.paging3.QueryPagingSource
+import dev.sasikanth.rss.reader.core.model.local.PostFlag
 import dev.sasikanth.rss.reader.core.model.local.PostWithMetadata
 import dev.sasikanth.rss.reader.core.model.local.PostsSortOrder
 import dev.sasikanth.rss.reader.core.model.local.WidgetPost
 import dev.sasikanth.rss.reader.data.database.PostQueries
 import dev.sasikanth.rss.reader.di.scopes.AppScope
 import dev.sasikanth.rss.reader.util.DispatchersProvider
+import kotlin.collections.Set
 import kotlin.time.Instant
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.withContext
@@ -70,21 +72,22 @@ class WidgetDataRepository(
         offset = 0,
         orderBy = PostsSortOrder.Latest.name,
         mapper = {
-          id,
-          sourceId,
-          title,
-          description,
-          imageUrl,
-          date,
-          createdAt,
-          link,
-          commentsLink,
-          flags,
-          feedName,
-          feedIcon,
-          feedHomepageLink,
-          alwaysFetchSourceArticle,
-          _ ->
+          id: String,
+          sourceId: String,
+          title: String,
+          description: String,
+          imageUrl: String?,
+          date: Instant,
+          createdAt: Instant,
+          link: String,
+          commentsLink: String?,
+          flags: Set<PostFlag>,
+          feedName: String,
+          feedIcon: String,
+          feedHomepageLink: String,
+          alwaysFetchSourceArticle: Boolean,
+          showFeedFavIcon: Boolean,
+          _: Long ->
           WidgetPost(
             id = id,
             title = title,
@@ -107,20 +110,21 @@ class WidgetDataRepository(
           numberOfPosts = numberOfPosts.toLong(),
           offset = 0,
           mapper = {
-            id,
-            sourceId,
-            title,
-            description,
-            imageUrl,
-            date,
-            createdAt,
-            link,
-            commentsLink,
-            flags,
-            feedName,
-            feedIcon,
-            feedHomepageLink,
-            alwaysFetchSourceArticle ->
+            id: String,
+            sourceId: String,
+            title: String,
+            description: String,
+            imageUrl: String?,
+            date: Instant,
+            createdAt: Instant,
+            link: String,
+            commentsLink: String?,
+            flags: Set<PostFlag>,
+            feedName: String,
+            feedIcon: String,
+            feedHomepageLink: String,
+            alwaysFetchSourceArticle: Boolean,
+            showFeedFavIcon: Boolean ->
             WidgetPost(
               id = id,
               title = title,
@@ -159,7 +163,8 @@ class WidgetDataRepository(
             feedName,
             feedIcon,
             feedHomepageLink,
-            alwaysFetchSourceArticle ->
+            alwaysFetchSourceArticle,
+            showFeedFavIcon: Boolean ->
             PostWithMetadata(
               id = id,
               sourceId = sourceId,
@@ -175,6 +180,7 @@ class WidgetDataRepository(
               feedIcon = feedIcon,
               feedHomepageLink = feedHomepageLink,
               alwaysFetchFullArticle = alwaysFetchSourceArticle,
+              showFeedFavIcon = showFeedFavIcon,
             )
           }
         )

--- a/core/data/src/commonMain/sqldelight/dev/sasikanth/rss/reader/data/database/Bookmark.sq
+++ b/core/data/src/commonMain/sqldelight/dev/sasikanth/rss/reader/data/database/Bookmark.sq
@@ -19,7 +19,8 @@ SELECT
   post.flags,
   feed.name AS feedName,
   feed.icon AS feedIcon,
-  feed.homepageLink AS feedHomepageLink
+  feed.homepageLink AS feedHomepageLink,
+  feed.showFeedFavIcon AS showFeedFavIcon
 FROM post
 INNER JOIN feed ON post.sourceId == feed.id
 WHERE (post.flags & 1) != 0

--- a/core/data/src/commonMain/sqldelight/dev/sasikanth/rss/reader/data/database/Feed.sq
+++ b/core/data/src/commonMain/sqldelight/dev/sasikanth/rss/reader/data/database/Feed.sq
@@ -82,6 +82,9 @@ UPDATE feed SET lastCleanUpAt = :lastCleanUpAt WHERE id = :id;
 updateAlwaysFetchSourceArticle:
 UPDATE feed SET alwaysFetchSourceArticle = :alwaysFetchSourceArticle WHERE id = :id;
 
+updateShowFeedFavIcon:
+UPDATE feed SET showFeedFavIcon = :showFeedFavIcon WHERE id = :id;
+
 feedsInGroupPaginatedCount:
 SELECT COUNT(*) FROM feed
 WHERE id IN :feedIds AND isDeleted = 0;

--- a/core/data/src/commonMain/sqldelight/dev/sasikanth/rss/reader/data/database/FeedGroup.sq
+++ b/core/data/src/commonMain/sqldelight/dev/sasikanth/rss/reader/data/database/FeedGroup.sq
@@ -36,6 +36,11 @@ SELECT
      JOIN feed f ON gf.feedId = f.id
      WHERE gf.feedGroupId = fg.id AND f.isDeleted = 0
      LIMIT 4), '') AS feedIconLinks,
+  COALESCE((SELECT GROUP_CONCAT(CASE WHEN f.showFeedFavIcon IS NULL THEN 'null' WHEN f.showFeedFavIcon = 1 THEN 'true' ELSE 'false' END)
+     FROM feedGroupFeed gf
+     JOIN feed f ON gf.feedId = f.id
+     WHERE gf.feedGroupId = fg.id AND f.isDeleted = 0
+     LIMIT 4), '') AS feedShowFavIconSettings,
   createdAt,
   updatedAt,
   pinnedAt,
@@ -63,6 +68,11 @@ SELECT
      JOIN feed f ON gf.feedId = f.id
      WHERE gf.feedGroupId = fg.id AND f.isDeleted = 0
      LIMIT 4), '') AS feedIconLinks,
+  COALESCE((SELECT GROUP_CONCAT(CASE WHEN f.showFeedFavIcon IS NULL THEN 'null' WHEN f.showFeedFavIcon = 1 THEN 'true' ELSE 'false' END)
+     FROM feedGroupFeed gf
+     JOIN feed f ON gf.feedId = f.id
+     WHERE gf.feedGroupId = fg.id AND f.isDeleted = 0
+     LIMIT 4), '') AS feedShowFavIconSettings,
   createdAt,
   updatedAt,
   pinnedAt,
@@ -95,6 +105,21 @@ SELECT
        FROM feedGroupFeed gf
        JOIN feed f ON gf.feedId = f.id
        WHERE gf.feedGroupId = fg.id AND f.isDeleted = 0) AS feedIds,
+  COALESCE((SELECT GROUP_CONCAT(f.homepageLink)
+     FROM feedGroupFeed gf
+     JOIN feed f ON gf.feedId = f.id
+     WHERE gf.feedGroupId = fg.id AND f.isDeleted = 0
+     LIMIT 4), '') AS feedHomepageLinks,
+  COALESCE((SELECT GROUP_CONCAT(f.icon)
+     FROM feedGroupFeed gf
+     JOIN feed f ON gf.feedId = f.id
+     WHERE gf.feedGroupId = fg.id AND f.isDeleted = 0
+     LIMIT 4), '') AS feedIconLinks,
+  COALESCE((SELECT GROUP_CONCAT(CASE WHEN f.showFeedFavIcon IS NULL THEN 'null' WHEN f.showFeedFavIcon = 1 THEN 'true' ELSE 'false' END)
+     FROM feedGroupFeed gf
+     JOIN feed f ON gf.feedId = f.id
+     WHERE gf.feedGroupId = fg.id AND f.isDeleted = 0
+     LIMIT 4), '') AS feedShowFavIconSettings,
   createdAt,
   updatedAt,
   pinnedAt,
@@ -121,6 +146,11 @@ SELECT
      JOIN feed f ON gf.feedId = f.id
      WHERE gf.feedGroupId = fg.id AND f.isDeleted = 0
      LIMIT 4), '') AS feedIconLinks,
+  COALESCE((SELECT GROUP_CONCAT(CASE WHEN f.showFeedFavIcon IS NULL THEN 'null' WHEN f.showFeedFavIcon = 1 THEN 'true' ELSE 'false' END)
+     FROM feedGroupFeed gf
+     JOIN feed f ON gf.feedId = f.id
+     WHERE gf.feedGroupId = fg.id AND f.isDeleted = 0
+     LIMIT 4), '') AS feedShowFavIconSettings,
   createdAt,
   updatedAt,
   pinnedAt
@@ -139,6 +169,21 @@ SELECT
        FROM feedGroupFeed gf
        JOIN feed f ON gf.feedId = f.id
        WHERE gf.feedGroupId = fg.id AND f.isDeleted = 0) AS feedIds,
+  COALESCE((SELECT GROUP_CONCAT(f.homepageLink)
+     FROM feedGroupFeed gf
+     JOIN feed f ON gf.feedId = f.id
+     WHERE gf.feedGroupId = fg.id AND f.isDeleted = 0
+     LIMIT 4), '') AS feedHomepageLinks,
+  COALESCE((SELECT GROUP_CONCAT(f.icon)
+     FROM feedGroupFeed gf
+     JOIN feed f ON gf.feedId = f.id
+     WHERE gf.feedGroupId = fg.id AND f.isDeleted = 0
+     LIMIT 4), '') AS feedIconLinks,
+  COALESCE((SELECT GROUP_CONCAT(CASE WHEN f.showFeedFavIcon IS NULL THEN 'null' WHEN f.showFeedFavIcon = 1 THEN 'true' ELSE 'false' END)
+     FROM feedGroupFeed gf
+     JOIN feed f ON gf.feedId = f.id
+     WHERE gf.feedGroupId = fg.id AND f.isDeleted = 0
+     LIMIT 4), '') AS feedShowFavIconSettings,
   createdAt,
   updatedAt,
   pinnedAt,

--- a/core/data/src/commonMain/sqldelight/dev/sasikanth/rss/reader/data/database/FeedSearchFTS.sq
+++ b/core/data/src/commonMain/sqldelight/dev/sasikanth/rss/reader/data/database/FeedSearchFTS.sq
@@ -43,7 +43,8 @@ SELECT
   f.createdAt,
   f.pinnedAt,
   f.lastCleanUpAt,
-  COUNT(CASE WHEN (p.flags & 2) == 0 THEN 1 ELSE NULL END) AS numberOfUnreadPosts
+  COUNT(CASE WHEN (p.flags & 2) == 0 THEN 1 ELSE NULL END) AS numberOfUnreadPosts,
+  f.showFeedFavIcon
 FROM feed_search fs
 INNER JOIN feed f ON f.id = fs.id
 LEFT JOIN post p ON p.sourceId = f.id AND p.postDate > :postsAfter

--- a/core/data/src/commonMain/sqldelight/dev/sasikanth/rss/reader/data/database/Post.sq
+++ b/core/data/src/commonMain/sqldelight/dev/sasikanth/rss/reader/data/database/Post.sq
@@ -109,7 +109,8 @@ WITH baseQuery AS (
     feed.name AS feedName,
     feed.icon AS feedIcon,
     feed.homepageLink AS feedHomepageLink,
-    feed.alwaysFetchSourceArticle AS alwaysFetchSourceArticle
+    feed.alwaysFetchSourceArticle AS alwaysFetchSourceArticle,
+    feed.showFeedFavIcon AS showFeedFavIcon
   FROM post
   INNER JOIN feed ON post.sourceId == feed.id
   WHERE
@@ -196,43 +197,6 @@ WHERE
   post.postDate > :after AND
   (:isSourceIdsEmpty OR post.sourceId IN :sourceIds);
 
-unreadSinceLastSync:
-WITH unreadPosts AS (
-  SELECT
-    feed.homepageLink,
-    feed.icon,
-    post.syncedAt
-  FROM post
-  INNER JOIN feed ON post.sourceId == feed.id
-  WHERE
-    ((:isSourceIdsEmpty) OR post.sourceId IN :sourceIds) AND
-    (post.flags & 4) == 0 AND
-    feed.isDeleted = 0 AND
-    (post.flags & 2) == 0 AND
-    post.postDate > :postsAfter AND
-    post.syncedAt > :lastSyncedAt
-)
-SELECT COUNT(*),
-(
-  SELECT GROUP_CONCAT(homepageLink, ',')
-  FROM (
-    SELECT DISTINCT homepageLink
-    FROM unreadPosts
-    ORDER BY syncedAt
-    LIMIT 3
-  )
-) AS feedHomepageLinks,
-(
-  SELECT GROUP_CONCAT(icon, ',')
-  FROM (
-    SELECT DISTINCT icon
-    FROM unreadPosts
-    ORDER BY syncedAt
-    LIMIT 3
-  )
-) AS feedIcons
-FROM unreadPosts;
-
 countPostsForFeed:
 SELECT COUNT(*) FROM post
 WHERE sourceId = :feedId;
@@ -261,7 +225,8 @@ SELECT
   feed.name AS feedName,
   feed.icon AS feedIcon,
   feed.homepageLink AS feedHomepageLink,
-  feed.alwaysFetchSourceArticle
+  feed.alwaysFetchSourceArticle,
+  feed.showFeedFavIcon
 FROM post
 INNER JOIN feed ON post.sourceId == feed.id
 WHERE
@@ -291,3 +256,54 @@ UPDATE SET
     syncedAt = excluded.syncedAt,
     flags = excluded.flags
 WHERE excluded.updatedAt > post.updatedAt;
+
+unreadSinceLastSync:
+WITH unreadPosts AS (
+  SELECT
+    f.id AS feedId,
+    f.homepageLink,
+    f.icon,
+    f.showFeedFavIcon,
+    p.syncedAt
+  FROM post p
+  INNER JOIN feed f ON p.sourceId = f.id
+  WHERE ((:isSourceIdsEmpty) OR p.sourceId IN :sourceIds)
+    AND (p.flags & 4) = 0
+    AND f.isDeleted = 0
+    AND (p.flags & 2) = 0
+    AND p.postDate > :postsAfter
+    AND p.syncedAt > :lastSyncedAt
+)
+SELECT
+  COUNT(*) AS count,
+  (
+    SELECT GROUP_CONCAT(homepageLink)
+    FROM (
+      SELECT homepageLink, MAX(syncedAt) AS maxSyncedAt
+      FROM unreadPosts
+      GROUP BY feedId
+      ORDER BY maxSyncedAt DESC
+      LIMIT 3
+    )
+  ) AS feedHomepageLinks,
+  (
+    SELECT GROUP_CONCAT(icon)
+    FROM (
+      SELECT icon, MAX(syncedAt) AS maxSyncedAt
+      FROM unreadPosts
+      GROUP BY feedId
+      ORDER BY maxSyncedAt DESC
+      LIMIT 3
+    )
+  ) AS feedIcons,
+  (
+    SELECT GROUP_CONCAT(CASE WHEN showFeedFavIcon IS NULL THEN 'null' WHEN showFeedFavIcon = 1 THEN 'true' ELSE 'false' END)
+    FROM (
+      SELECT showFeedFavIcon, MAX(syncedAt) AS maxSyncedAt
+      FROM unreadPosts
+      GROUP BY feedId
+      ORDER BY maxSyncedAt DESC
+      LIMIT 3
+    )
+  ) AS feedShowFavIconSettings
+FROM unreadPosts;

--- a/core/data/src/commonMain/sqldelight/dev/sasikanth/rss/reader/data/database/PostSearchFTS.sq
+++ b/core/data/src/commonMain/sqldelight/dev/sasikanth/rss/reader/data/database/PostSearchFTS.sq
@@ -45,7 +45,8 @@ SELECT
   feed.name AS feedName,
   feed.icon AS feedIcon,
   feed.homepageLink AS feedHomepageLink,
-  feed.alwaysFetchSourceArticle
+  feed.alwaysFetchSourceArticle,
+  feed.showFeedFavIcon
 FROM post_search
 INNER JOIN post ON post.id == post_search.id
 INNER JOIN feed ON post.sourceId == feed.id

--- a/core/data/src/commonMain/sqldelight/dev/sasikanth/rss/reader/data/database/Source.sq
+++ b/core/data/src/commonMain/sqldelight/dev/sasikanth/rss/reader/data/database/Source.sq
@@ -31,7 +31,14 @@ WITH feed_group_metadata AS (
       JOIN feed f ON gf.feedId = f.id
       WHERE gf.feedGroupId = distinct_groups.feedGroupId AND f.isDeleted = 0
       LIMIT 4
-    ), '') AS feedIcons
+    ), '') AS feedIcons,
+    COALESCE((
+      SELECT GROUP_CONCAT(CASE WHEN f.showFeedFavIcon IS NULL THEN 'null' WHEN f.showFeedFavIcon = 1 THEN 'true' ELSE 'false' END)
+      FROM feedGroupFeed gf
+      JOIN feed f ON gf.feedId = f.id
+      WHERE gf.feedGroupId = distinct_groups.feedGroupId AND f.isDeleted = 0
+      LIMIT 4
+    ), '') AS feedShowFavIconSettings
   FROM (SELECT DISTINCT feedGroupId FROM feedGroupFeed) AS distinct_groups
 )
 
@@ -50,8 +57,10 @@ SELECT
   feedIds,
   feedHomepageLinks,
   feedIcons,
+  feedShowFavIconSettings,
   updatedAt,
-  pinnedPosition
+  pinnedPosition,
+  showFeedFavIcon
 FROM (
   SELECT
     'feed' AS type,
@@ -66,10 +75,12 @@ FROM (
     NULL AS feedIds,
     NULL AS feedHomepageLinks,
     NULL AS feedIcons,
+    NULL AS feedShowFavIconSettings,
     f.createdAt,
     f.pinnedAt,
     NULL AS updatedAt,
-    f.pinnedPosition
+    f.pinnedPosition,
+    f.showFeedFavIcon
   FROM feed f
   LEFT JOIN post p ON f.id = p.sourceId AND p.postDate > :postsAfter AND p.syncedAt < :lastSyncedAt
   WHERE f.isDeleted = 0
@@ -90,10 +101,12 @@ FROM (
     fgm.feedIds,
     fgm.feedHomepageLinks,
     fgm.feedIcons,
+    fgm.feedShowFavIconSettings,
     fg.createdAt,
     fg.pinnedAt,
     fg.updatedAt,
-    fg.pinnedPosition
+    fg.pinnedPosition,
+    NULL AS showFeedFavIcon
   FROM feedGroup fg
   LEFT JOIN feedGroupFeed gf ON fg.id = gf.feedGroupId
   LEFT JOIN feed f ON gf.feedId = f.id AND f.isDeleted = 0
@@ -128,7 +141,14 @@ WITH feed_group_metadata AS (
       JOIN feed f ON gf.feedId = f.id
       WHERE gf.feedGroupId = distinct_groups.feedGroupId AND f.isDeleted = 0
       LIMIT 4
-    ), '') AS feedIcons
+    ), '') AS feedIcons,
+    COALESCE((
+      SELECT GROUP_CONCAT(CASE WHEN f.showFeedFavIcon IS NULL THEN 'null' WHEN f.showFeedFavIcon = 1 THEN 'true' ELSE 'false' END)
+      FROM feedGroupFeed gf
+      JOIN feed f ON gf.feedId = f.id
+      WHERE gf.feedGroupId = distinct_groups.feedGroupId AND f.isDeleted = 0
+      LIMIT 4
+    ), '') AS feedShowFavIconSettings
   FROM (SELECT DISTINCT feedGroupId FROM feedGroupFeed) AS distinct_groups
 )
 
@@ -147,7 +167,10 @@ SELECT
   feedIds,
   feedHomepageLinks,
   feedIcons,
-  updatedAt
+  feedShowFavIconSettings,
+  updatedAt,
+  pinnedPosition,
+  showFeedFavIcon
 FROM (
   SELECT
     'feed' AS type,
@@ -162,9 +185,12 @@ FROM (
     NULL AS feedIds,
     NULL AS feedHomepageLinks,
     NULL AS feedIcons,
+    NULL AS feedShowFavIconSettings,
     f.createdAt,
     f.pinnedAt,
-    NULL AS updatedAt
+    NULL AS updatedAt,
+    f.pinnedPosition,
+    f.showFeedFavIcon
   FROM feed f
   LEFT JOIN post p ON f.id = p.sourceId AND p.postDate > :postsAfter AND p.syncedAt < :lastSyncedAt
   WHERE f.isDeleted = 0
@@ -185,9 +211,12 @@ FROM (
     fgm.feedIds,
     fgm.feedHomepageLinks,
     fgm.feedIcons,
+    fgm.feedShowFavIconSettings,
     fg.createdAt,
     fg.pinnedAt,
-    fg.updatedAt
+    fg.updatedAt,
+    fg.pinnedPosition,
+    NULL AS showFeedFavIcon
   FROM feedGroup fg
   LEFT JOIN feedGroupFeed gf ON fg.id = gf.feedGroupId
   LEFT JOIN feed f ON gf.feedId = f.id AND f.isDeleted = 0
@@ -227,7 +256,14 @@ WITH feed_group_metadata AS (
       JOIN feed f ON gf.feedId = f.id
       WHERE gf.feedGroupId = distinct_groups.feedGroupId AND f.isDeleted = 0
       LIMIT 4
-    ), '') AS feedIcons
+    ), '') AS feedIcons,
+    COALESCE((
+      SELECT GROUP_CONCAT(CASE WHEN f.showFeedFavIcon IS NULL THEN 'null' WHEN f.showFeedFavIcon = 1 THEN 'true' ELSE 'false' END)
+      FROM feedGroupFeed gf
+      JOIN feed f ON gf.feedId = f.id
+      WHERE gf.feedGroupId = distinct_groups.feedGroupId AND f.isDeleted = 0
+      LIMIT 4
+    ), '') AS feedShowFavIconSettings
   FROM (SELECT DISTINCT feedGroupId FROM feedGroupFeed) AS distinct_groups
 )
 
@@ -246,7 +282,10 @@ SELECT
   feedIds,
   feedHomepageLinks,
   feedIcons,
-  updatedAt
+  feedShowFavIconSettings,
+  updatedAt,
+  pinnedPosition,
+  showFeedFavIcon
 FROM (
   SELECT
     'feed' AS type,
@@ -261,9 +300,12 @@ FROM (
     NULL AS feedIds,
     NULL AS feedHomepageLinks,
     NULL AS feedIcons,
+    NULL AS feedShowFavIconSettings,
     f.createdAt,
     f.pinnedAt,
-    NULL AS updatedAt
+    NULL AS updatedAt,
+    f.pinnedPosition,
+    f.showFeedFavIcon
   FROM feed f
   LEFT JOIN post p ON f.id = p.sourceId AND p.postDate > :postsAfter AND p.syncedAt < :lastSyncedAt
   WHERE f.id = :id AND f.isDeleted = 0
@@ -284,9 +326,12 @@ FROM (
     fgm.feedIds,
     fgm.feedHomepageLinks,
     fgm.feedIcons,
+    fgm.feedShowFavIconSettings,
     fg.createdAt,
     fg.pinnedAt,
-    fg.updatedAt
+    fg.updatedAt,
+    fg.pinnedPosition,
+    NULL AS showFeedFavIcon
   FROM feedGroup fg
   LEFT JOIN feedGroupFeed gf ON fg.id = gf.feedGroupId
   LEFT JOIN feed f ON gf.feedId = f.id AND f.isDeleted = 0

--- a/core/model/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/model/local/FeedGroup.kt
+++ b/core/model/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/model/local/FeedGroup.kt
@@ -24,6 +24,7 @@ data class FeedGroup(
   val feedIds: List<String>,
   val feedHomepageLinks: List<String>,
   val feedIconLinks: List<String>,
+  val feedShowFavIconSettings: List<Boolean>,
   val numberOfUnreadPosts: Long = 0,
   val createdAt: Instant,
   val updatedAt: Instant,

--- a/core/model/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/model/local/PostWithMetadata.kt
+++ b/core/model/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/model/local/PostWithMetadata.kt
@@ -36,6 +36,7 @@ data class PostWithMetadata(
   val feedIcon: String,
   val feedHomepageLink: String,
   val alwaysFetchFullArticle: Boolean,
+  val showFeedFavIcon: Boolean,
 ) {
   val bookmarked: Boolean
     get() = PostFlag.Bookmarked in flags

--- a/core/model/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/model/local/UnreadSinceLastSync.kt
+++ b/core/model/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/model/local/UnreadSinceLastSync.kt
@@ -24,4 +24,5 @@ data class UnreadSinceLastSync(
   val hasNewArticles: Boolean,
   val feedHomepageLinks: List<String>,
   val feedIcons: List<String>,
+  val feedShowFavIconSettings: List<Boolean>,
 )

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/components/NewArticlesScrollToTopButton.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/components/NewArticlesScrollToTopButton.kt
@@ -65,7 +65,6 @@ import dev.sasikanth.rss.reader.ui.LocalDynamicColorState
 import dev.sasikanth.rss.reader.ui.darkAppColorScheme
 import dev.sasikanth.rss.reader.ui.lightAppColorScheme
 import dev.sasikanth.rss.reader.ui.rememberDynamicColorState
-import dev.sasikanth.rss.reader.utils.LocalShowFeedFavIconSetting
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 import twine.shared.generated.resources.Res
@@ -131,12 +130,13 @@ internal fun BoxScope.NewArticlesScrollToTopButton(
                       bottom = 8.dp,
                     ),
                   content = {
-                    val showFeedFavIcon = LocalShowFeedFavIconSetting.current
-                    val icons =
-                      if (showFeedFavIcon) unreadSinceLastSync.feedHomepageLinks
-                      else unreadSinceLastSync.feedIcons
-
-                    OverlappedFeedIcons(icons = icons)
+                    unreadSinceLastSync.apply {
+                      OverlappedFeedIcons(
+                        feedHomepageLinks = feedHomepageLinks,
+                        feedIcons = feedIcons,
+                        feedShowFavIconSettings = feedShowFavIconSettings,
+                      )
+                    }
 
                     Spacer(modifier = Modifier.requiredWidth(12.dp))
 
@@ -190,24 +190,35 @@ internal fun BoxScope.NewArticlesScrollToTopButton(
 
 @Composable
 private fun OverlappedFeedIcons(
-  icons: List<String>,
+  feedHomepageLinks: List<String>,
+  feedIcons: List<String>,
+  feedShowFavIconSettings: List<Boolean>,
   modifier: Modifier = Modifier,
 ) {
   Layout(
     modifier = modifier,
     content = {
-      icons.forEach { icon ->
-        Box(
-          modifier =
-            Modifier.background(AppTheme.colorScheme.bottomSheet, MaterialTheme.shapes.extraSmall)
-              .padding(horizontal = 2.dp, vertical = 1.dp)
-        ) {
-          FeedIcon(
-            url = icon,
-            contentDescription = null,
-            shape = MaterialTheme.shapes.extraSmall,
-            modifier = Modifier.requiredSize(20.dp)
-          )
+      val iconsCount = maxOf(feedHomepageLinks.size, feedIcons.size)
+      for (index in 0 until iconsCount) {
+        val homepageLink = feedHomepageLinks.getOrNull(index)
+        val icon = feedIcons.getOrNull(index)
+        val showFeedFavIcon = feedShowFavIconSettings.getOrNull(index) ?: true
+
+        if (!homepageLink.isNullOrBlank() || !icon.isNullOrBlank()) {
+          Box(
+            modifier =
+              Modifier.background(AppTheme.colorScheme.bottomSheet, MaterialTheme.shapes.extraSmall)
+                .padding(horizontal = 2.dp, vertical = 1.dp)
+          ) {
+            FeedIcon(
+              icon = icon.orEmpty(),
+              homepageLink = homepageLink.orEmpty(),
+              showFeedFavIcon = showFeedFavIcon,
+              contentDescription = null,
+              shape = MaterialTheme.shapes.extraSmall,
+              modifier = Modifier.requiredSize(20.dp)
+            )
+          }
         }
       }
     }
@@ -250,7 +261,8 @@ internal fun NewArticlesScrollToTopButtonPreview_OnlyNewArticles() {
               newArticleCount = 0,
               hasNewArticles = true,
               feedHomepageLinks = listOf("https://theverge.com", "https://wired.com"),
-              feedIcons = listOf("https://icon.horse/theverge.com", "https://icon.horse/wired.com")
+              feedIcons = listOf("https://icon.horse/theverge.com", "https://icon.horse/wired.com"),
+              feedShowFavIconSettings = listOf(true, false)
             ),
           canShowScrollToTop = false,
           onLoadNewArticlesClick = {},
@@ -275,7 +287,8 @@ internal fun NewArticlesScrollToTopButtonPreview_OnlyScrollToTop() {
             newArticleCount = 0,
             hasNewArticles = false,
             feedHomepageLinks = emptyList(),
-            feedIcons = emptyList()
+            feedIcons = emptyList(),
+            feedShowFavIconSettings = emptyList()
           ),
         canShowScrollToTop = true,
         onLoadNewArticlesClick = {},
@@ -299,7 +312,8 @@ internal fun NewArticlesScrollToTopButtonPreview_Both() {
             newArticleCount = 0,
             hasNewArticles = true,
             feedHomepageLinks = listOf("https://theverge.com", "https://wired.com"),
-            feedIcons = listOf("https://icon.horse/theverge.com", "https://icon.horse/wired.com")
+            feedIcons = listOf("https://icon.horse/theverge.com", "https://icon.horse/wired.com"),
+            feedShowFavIconSettings = listOf(true, false)
           ),
         canShowScrollToTop = true,
         onLoadNewArticlesClick = {},

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/components/image/FeedIcon.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/components/image/FeedIcon.kt
@@ -38,19 +38,24 @@ import dev.sasikanth.rss.reader.utils.LocalShowFeedFavIconSetting
 
 @Composable
 internal fun FeedIcon(
-  url: String,
+  icon: String,
+  homepageLink: String,
+  showFeedFavIcon: Boolean,
   contentDescription: String?,
   shape: Shape,
   modifier: Modifier = Modifier,
   contentScale: ContentScale = ContentScale.Fit,
   size: Size = Size(Dimension.Undefined, 500)
 ) {
-  val showFeedFavIcon = LocalShowFeedFavIconSetting.current
+  val globalShowFeedFavIcon = LocalShowFeedFavIconSetting.current
+  val useFavIcon = showFeedFavIcon && globalShowFeedFavIcon
+
   Box(Modifier.clip(shape).then(modifier).background(Color.White, shape)) {
     val context = LocalPlatformContext.current
+    val url = if (useFavIcon) homepageLink else icon
     val imageRequest = ImageRequest.Builder(context).data(url).diskCacheKey(url).size(size).build()
     val imageLoader =
-      if (showFeedFavIcon) {
+      if (useFavIcon) {
         FavIconImageLoader.get(context)
       } else {
         SingletonImageLoader.get(context)

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feed/FeedEvent.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feed/FeedEvent.kt
@@ -25,5 +25,7 @@ sealed interface FeedEvent {
   data class OnAlwaysFetchSourceArticleChanged(val newValue: Boolean, val feedId: String) :
     FeedEvent
 
+  data class OnShowFeedFavIconChanged(val newValue: Boolean, val feedId: String) : FeedEvent
+
   data class OnMarkPostsAsRead(val feedId: String) : FeedEvent
 }

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feed/FeedViewModel.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feed/FeedViewModel.kt
@@ -66,6 +66,8 @@ class FeedViewModel(
       is FeedEvent.OnFeedNameChanged -> onFeedNameUpdated(event.newFeedName, event.feedId)
       is FeedEvent.OnAlwaysFetchSourceArticleChanged ->
         onAlwaysFetchSourceArticleChanged(event.newValue, event.feedId)
+      is FeedEvent.OnShowFeedFavIconChanged ->
+        onShowFeedFavIconChanged(event.newValue, event.feedId)
       is FeedEvent.OnMarkPostsAsRead -> onMarkPostsAsRead(event.feedId)
     }
   }
@@ -88,6 +90,10 @@ class FeedViewModel(
 
   private fun onAlwaysFetchSourceArticleChanged(newValue: Boolean, feedId: String) {
     viewModelScope.launch { rssRepository.updateFeedAlwaysFetchSource(feedId, newValue) }
+  }
+
+  private fun onShowFeedFavIconChanged(newValue: Boolean, feedId: String) {
+    viewModelScope.launch { rssRepository.updateFeedShowFavIcon(feedId, newValue) }
   }
 
   private fun onFeedNameUpdated(newFeedName: String, feedId: String) {

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/FeedGroupIconGrid.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/FeedGroupIconGrid.kt
@@ -38,37 +38,55 @@ import dev.sasikanth.rss.reader.ui.AppTheme
 
 @Composable
 internal fun FeedGroupIconGrid(
-  icons: List<String>,
+  feedHomepageLinks: List<String>,
+  feedIconLinks: List<String>,
+  feedShowFavIconSettings: List<Boolean>,
   iconSize: Dp = 16.dp,
   iconShape: Shape = CircleShape,
   horizontalArrangement: Arrangement.Horizontal = Arrangement.spacedBy(2.dp),
   verticalArrangement: Arrangement.Vertical = Arrangement.spacedBy(2.dp),
   modifier: Modifier = Modifier,
 ) {
-  if (icons.isNotEmpty()) {
+  val iconsCount = maxOf(feedHomepageLinks.size, feedIconLinks.size)
+
+  if (iconsCount == 2) {
+    Box(modifier = modifier) {
+      FeedIcon(
+        index = 0,
+        feedHomepageLinks = feedHomepageLinks,
+        feedIconLinks = feedIconLinks,
+        feedShowFavIconSettings = feedShowFavIconSettings,
+        iconSize = iconSize,
+        iconShape = iconShape,
+        modifier = Modifier.align(Alignment.TopStart)
+      )
+
+      FeedIcon(
+        index = 1,
+        feedHomepageLinks = feedHomepageLinks,
+        feedIconLinks = feedIconLinks,
+        feedShowFavIconSettings = feedShowFavIconSettings,
+        iconSize = iconSize,
+        iconShape = iconShape,
+        modifier = Modifier.align(Alignment.BottomEnd)
+      )
+    }
+  } else if (iconsCount > 0) {
     Column(modifier = modifier, verticalArrangement = verticalArrangement) {
-      val icon2 =
-        if (icons.size > 2) {
-          icons.elementAtOrNull(1)
-        } else {
-          null
-        }
-
-      val icon4 =
-        if (icons.size > 2) {
-          icons.elementAtOrNull(3)
-        } else {
-          icons.elementAtOrNull(1)
-        }
-
       Row(horizontalArrangement = horizontalArrangement) {
         FeedIcon(
-          icon = icons.elementAtOrNull(0),
+          index = 0,
+          feedHomepageLinks = feedHomepageLinks,
+          feedIconLinks = feedIconLinks,
+          feedShowFavIconSettings = feedShowFavIconSettings,
           iconSize = iconSize,
           iconShape = iconShape,
         )
         FeedIcon(
-          icon = icon2,
+          index = 2,
+          feedHomepageLinks = feedHomepageLinks,
+          feedIconLinks = feedIconLinks,
+          feedShowFavIconSettings = feedShowFavIconSettings,
           iconSize = iconSize,
           iconShape = iconShape,
         )
@@ -76,12 +94,18 @@ internal fun FeedGroupIconGrid(
 
       Row(horizontalArrangement = horizontalArrangement) {
         FeedIcon(
-          icon = icons.elementAtOrNull(2),
+          index = 3,
+          feedHomepageLinks = feedHomepageLinks,
+          feedIconLinks = feedIconLinks,
+          feedShowFavIconSettings = feedShowFavIconSettings,
           iconSize = iconSize,
           iconShape = iconShape,
         )
         FeedIcon(
-          icon = icon4,
+          index = 1,
+          feedHomepageLinks = feedHomepageLinks,
+          feedIconLinks = feedIconLinks,
+          feedShowFavIconSettings = feedShowFavIconSettings,
           iconSize = iconSize,
           iconShape = iconShape,
         )
@@ -100,10 +124,24 @@ internal fun FeedGroupIconGrid(
 }
 
 @Composable
-private fun FeedIcon(icon: String?, iconSize: Dp, iconShape: Shape, modifier: Modifier = Modifier) {
-  if (!icon.isNullOrBlank()) {
+private fun FeedIcon(
+  index: Int,
+  feedHomepageLinks: List<String>,
+  feedIconLinks: List<String>,
+  feedShowFavIconSettings: List<Boolean>,
+  iconSize: Dp,
+  iconShape: Shape,
+  modifier: Modifier = Modifier
+) {
+  val homepageLink = feedHomepageLinks.getOrNull(index)
+  val iconLink = feedIconLinks.getOrNull(index)
+  val showFavIconSetting = feedShowFavIconSettings.getOrNull(index) ?: true
+
+  if (!homepageLink.isNullOrBlank() || !iconLink.isNullOrBlank()) {
     FeedIcon(
-      url = icon,
+      icon = iconLink.orEmpty(),
+      homepageLink = homepageLink.orEmpty(),
+      showFeedFavIcon = showFavIconSetting,
       contentDescription = null,
       shape = iconShape,
       modifier = Modifier.requiredSize(iconSize).background(Color.White).then(modifier)

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/FeedGroupIconGrid.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/FeedGroupIconGrid.kt
@@ -49,29 +49,7 @@ internal fun FeedGroupIconGrid(
 ) {
   val iconsCount = maxOf(feedHomepageLinks.size, feedIconLinks.size)
 
-  if (iconsCount == 2) {
-    Box(modifier = modifier) {
-      FeedIcon(
-        index = 0,
-        feedHomepageLinks = feedHomepageLinks,
-        feedIconLinks = feedIconLinks,
-        feedShowFavIconSettings = feedShowFavIconSettings,
-        iconSize = iconSize,
-        iconShape = iconShape,
-        modifier = Modifier.align(Alignment.TopStart)
-      )
-
-      FeedIcon(
-        index = 1,
-        feedHomepageLinks = feedHomepageLinks,
-        feedIconLinks = feedIconLinks,
-        feedShowFavIconSettings = feedShowFavIconSettings,
-        iconSize = iconSize,
-        iconShape = iconShape,
-        modifier = Modifier.align(Alignment.BottomEnd)
-      )
-    }
-  } else if (iconsCount > 0) {
+  if (iconsCount > 0) {
     Column(modifier = modifier, verticalArrangement = verticalArrangement) {
       Row(horizontalArrangement = horizontalArrangement) {
         FeedIcon(

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/FeedGroupItem.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/FeedGroupItem.kt
@@ -52,7 +52,6 @@ import androidx.compose.ui.unit.dp
 import dev.sasikanth.rss.reader.core.model.local.FeedGroup
 import dev.sasikanth.rss.reader.ui.AppTheme
 import dev.sasikanth.rss.reader.ui.LocalTranslucentStyles
-import dev.sasikanth.rss.reader.utils.LocalShowFeedFavIconSetting
 import org.jetbrains.compose.resources.pluralStringResource
 import org.jetbrains.compose.resources.stringResource
 import twine.shared.generated.resources.Res
@@ -107,18 +106,17 @@ internal fun FeedGroupItem(
         .padding(8.dp)
   ) {
     Row(verticalAlignment = Alignment.CenterVertically) {
-      val showFeedFavIcon = LocalShowFeedFavIconSetting.current
-      val icons = if (showFeedFavIcon) feedGroup.feedHomepageLinks else feedGroup.feedIconLinks
+      val iconsCount = maxOf(feedGroup.feedHomepageLinks.size, feedGroup.feedIconLinks.size)
 
       val iconSize =
-        if (icons.size > 2) {
+        if (iconsCount > 2) {
           17.dp
         } else {
           19.dp
         }
 
       val iconSpacing =
-        if (icons.size > 2) {
+        if (iconsCount > 2) {
           2.dp
         } else {
           0.dp
@@ -126,7 +124,9 @@ internal fun FeedGroupItem(
 
       FeedGroupIconGrid(
         modifier = Modifier.requiredSize(36.dp),
-        icons = icons,
+        feedHomepageLinks = feedGroup.feedHomepageLinks,
+        feedIconLinks = feedGroup.feedIconLinks,
+        feedShowFavIconSettings = feedGroup.feedShowFavIconSettings,
         iconSize = iconSize,
         iconShape = CircleShape,
         verticalArrangement = Arrangement.spacedBy(iconSpacing),

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/FeedListItem.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/FeedListItem.kt
@@ -51,7 +51,6 @@ import dev.sasikanth.rss.reader.components.image.FeedIcon
 import dev.sasikanth.rss.reader.core.model.local.Feed
 import dev.sasikanth.rss.reader.ui.AppTheme
 import dev.sasikanth.rss.reader.ui.LocalTranslucentStyles
-import dev.sasikanth.rss.reader.utils.LocalShowFeedFavIconSetting
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -100,11 +99,10 @@ internal fun FeedListItem(
         )
   ) {
     Row(modifier = Modifier.padding(all = 8.dp), verticalAlignment = Alignment.CenterVertically) {
-      val showFeedFavIcon = LocalShowFeedFavIconSetting.current
-      val icon = if (showFeedFavIcon) feed.homepageLink else feed.icon
-
       FeedIcon(
-        url = icon,
+        icon = feed.icon,
+        homepageLink = feed.homepageLink,
+        showFeedFavIcon = feed.showFeedFavIcon,
         contentDescription = null,
         shape = MaterialTheme.shapes.medium,
         modifier = Modifier.requiredSize(36.dp),

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/sheet/collapsed/BottomSheetCollapsedContent.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/sheet/collapsed/BottomSheetCollapsedContent.kt
@@ -180,6 +180,7 @@ private fun SourceItem(
         badgeCount = source.numberOfUnreadPosts,
         homePageUrl = source.homepageLink,
         feedIconUrl = source.icon,
+        showFeedFavIcon = source.showFeedFavIcon,
         canShowUnreadPostsCount = canShowUnreadPostsCount,
         hasActiveSource = activeSource != null,
         selected = activeSource?.id == source.id,

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/sheet/collapsed/FeedBottomBarItem.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/sheet/collapsed/FeedBottomBarItem.kt
@@ -36,13 +36,13 @@ import androidx.compose.ui.unit.dp
 import dev.sasikanth.rss.reader.components.image.FeedIcon
 import dev.sasikanth.rss.reader.ui.AppTheme
 import dev.sasikanth.rss.reader.utils.Constants.BADGE_COUNT_TRIM_LIMIT
-import dev.sasikanth.rss.reader.utils.LocalShowFeedFavIconSetting
 
 @Composable
 internal fun FeedBottomBarItem(
   badgeCount: Long,
   homePageUrl: String,
   feedIconUrl: String,
+  showFeedFavIcon: Boolean,
   canShowUnreadPostsCount: Boolean,
   onClick: () -> Unit,
   modifier: Modifier = Modifier,
@@ -53,12 +53,12 @@ internal fun FeedBottomBarItem(
     modifier = modifier.graphicsLayer { alpha = if (selected || !hasActiveSource) 1f else 0.25f }
   ) {
     Box(modifier = Modifier.size(64.dp), contentAlignment = Alignment.Center) {
-      val showFeedFavIcon = LocalShowFeedFavIconSetting.current
-      val feedIcon = if (showFeedFavIcon) homePageUrl else feedIconUrl
       val shape = MaterialTheme.shapes.large
 
       FeedIcon(
-        url = feedIcon,
+        icon = feedIconUrl,
+        homepageLink = homePageUrl,
+        showFeedFavIcon = showFeedFavIcon,
         contentDescription = null,
         shape = shape,
         modifier = Modifier.requiredSize(48.dp).clickable(onClick = onClick)

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/sheet/collapsed/FeedGroupBottomBarItem.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/sheet/collapsed/FeedGroupBottomBarItem.kt
@@ -28,7 +28,6 @@ import androidx.compose.ui.unit.dp
 import dev.sasikanth.rss.reader.core.model.local.FeedGroup
 import dev.sasikanth.rss.reader.feeds.ui.FeedGroupIconGrid
 import dev.sasikanth.rss.reader.ui.AppTheme
-import dev.sasikanth.rss.reader.utils.LocalShowFeedFavIconSetting
 
 @Composable
 internal fun FeedGroupBottomBarItem(
@@ -52,24 +51,25 @@ internal fun FeedGroupBottomBarItem(
             .padding(8.dp),
         contentAlignment = Alignment.Center
       ) {
-        val showFeedFavIcon = LocalShowFeedFavIconSetting.current
-        val icons = if (showFeedFavIcon) feedGroup.feedHomepageLinks else feedGroup.feedIconLinks
+        val iconsCount = maxOf(feedGroup.feedHomepageLinks.size, feedGroup.feedIconLinks.size)
         val iconSize =
-          if (icons.size > 2) {
+          if (iconsCount > 2) {
             16.dp
           } else {
             18.dp
           }
 
         val iconSpacing =
-          if (icons.size > 2) {
+          if (iconsCount > 2) {
             2.dp
           } else {
             0.dp
           }
 
         FeedGroupIconGrid(
-          icons = icons,
+          feedHomepageLinks = feedGroup.feedHomepageLinks,
+          feedIconLinks = feedGroup.feedIconLinks,
+          feedShowFavIconSettings = feedGroup.feedShowFavIconSettings,
           iconSize = iconSize,
           iconShape = MaterialTheme.shapes.small,
           verticalArrangement = Arrangement.spacedBy(iconSpacing),

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/sheet/expanded/BottomSheetExpandedContent.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/sheet/expanded/BottomSheetExpandedContent.kt
@@ -265,6 +265,8 @@ internal fun BottomSheetExpandedContent(
                 icon = editIcon,
                 label = editLabel,
                 onClick = {
+                  viewModel.dispatch(FeedsEvent.CancelSourcesSelection)
+
                   val selectedSource = state.selectedSources.first()
                   when (selectedSource.sourceType) {
                     SourceType.Feed -> {

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/ui/FeaturedPostItem.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/ui/FeaturedPostItem.kt
@@ -48,7 +48,6 @@ import dev.sasikanth.rss.reader.core.model.local.PostWithMetadata
 import dev.sasikanth.rss.reader.ui.AppTheme
 import dev.sasikanth.rss.reader.util.relativeDurationString
 import dev.sasikanth.rss.reader.utils.Constants
-import dev.sasikanth.rss.reader.utils.LocalShowFeedFavIconSetting
 import dev.sasikanth.rss.reader.utils.LocalWindowSizeClass
 
 private val featuredItemPadding
@@ -136,12 +135,11 @@ internal fun FeaturedPostItem(
 
     Spacer(Modifier.requiredHeight(descriptionBottomPadding + 4.dp))
 
-    val showFeedFavIcon = LocalShowFeedFavIconSetting.current
-    val feedIconUrl = if (showFeedFavIcon) item.feedHomepageLink else item.feedIcon
-
     PostActionBar(
       feedName = item.feedName,
-      feedIcon = feedIconUrl,
+      feedIcon = item.feedIcon,
+      feedHomepageLink = item.feedHomepageLink,
+      showFeedFavIcon = item.showFeedFavIcon,
       postRead = readStatus,
       postRelativeTimestamp = item.date.relativeDurationString(),
       postLink = item.link,

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/ui/PostActionBar.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/ui/PostActionBar.kt
@@ -87,6 +87,8 @@ import twine.shared.generated.resources.unBookmark
 internal fun PostActionBar(
   feedName: String,
   feedIcon: String,
+  feedHomepageLink: String,
+  showFeedFavIcon: Boolean,
   postRead: Boolean,
   postRelativeTimestamp: String,
   postLink: String,
@@ -114,6 +116,8 @@ internal fun PostActionBar(
       modifier = Modifier.weight(1f).clearAndSetSemantics {},
       feedName = feedName,
       feedIcon = feedIcon,
+      feedHomepageLink = feedHomepageLink,
+      showFeedFavIcon = showFeedFavIcon,
       config = config,
       onSourceClick = onSourceClick,
     )
@@ -146,6 +150,8 @@ internal fun PostActionBar(
 @Composable
 private fun PostSourcePill(
   feedIcon: String,
+  feedHomepageLink: String,
+  showFeedFavIcon: Boolean,
   feedName: String,
   config: PostMetadataConfig,
   onSourceClick: () -> Unit,
@@ -178,7 +184,9 @@ private fun PostSourcePill(
     ) {
       FeedIcon(
         modifier = Modifier.requiredSize(16.dp),
-        url = feedIcon,
+        icon = feedIcon,
+        homepageLink = feedHomepageLink,
+        showFeedFavIcon = showFeedFavIcon,
         shape = MaterialTheme.shapes.extraSmall,
         contentDescription = null,
       )

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/ui/PostListItem.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/ui/PostListItem.kt
@@ -62,7 +62,6 @@ import dev.sasikanth.rss.reader.core.model.local.PostWithMetadata
 import dev.sasikanth.rss.reader.ui.AppTheme
 import dev.sasikanth.rss.reader.util.relativeDurationString
 import dev.sasikanth.rss.reader.utils.Constants
-import dev.sasikanth.rss.reader.utils.LocalShowFeedFavIconSetting
 import dev.sasikanth.rss.reader.utils.LocalWindowSizeClass
 
 private val postListPadding
@@ -142,12 +141,11 @@ internal fun PostListItem(
       }
     }
 
-    val showFeedFavIcon = LocalShowFeedFavIconSetting.current
-    val feedIconUrl = if (showFeedFavIcon) item.feedHomepageLink else item.feedIcon
-
     PostActionBar(
       feedName = item.feedName,
-      feedIcon = feedIconUrl,
+      feedIcon = item.feedIcon,
+      feedHomepageLink = item.feedHomepageLink,
+      showFeedFavIcon = item.showFeedFavIcon,
       postRead = readStatus,
       postRelativeTimestamp = item.date.relativeDurationString(),
       postLink = item.link,
@@ -180,8 +178,6 @@ internal fun CompactPostListItem(
   reduceReadItemAlpha: Boolean = false,
   postMetadataConfig: PostMetadataConfig = PostMetadataConfig.DEFAULT,
 ) {
-  val showFeedFavIcon = LocalShowFeedFavIconSetting.current
-  val feedIconUrl = if (showFeedFavIcon) item.feedHomepageLink else item.feedIcon
   var readStatus by remember(item.read) { mutableStateOf(item.read) }
   val alpha by
     animateFloatAsState(
@@ -204,7 +200,9 @@ internal fun CompactPostListItem(
           .graphicsLayer { this.alpha = alpha }
     ) {
       FeedIcon(
-        url = feedIconUrl,
+        icon = item.feedIcon,
+        homepageLink = item.feedHomepageLink,
+        showFeedFavIcon = item.showFeedFavIcon,
         contentDescription = null,
         shape = MaterialTheme.shapes.extraSmall,
         modifier = Modifier.requiredSize(16.dp),

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/reader/page/ui/ReaderPage.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/reader/page/ui/ReaderPage.kt
@@ -106,7 +106,6 @@ import dev.sasikanth.rss.reader.ui.AppTheme
 import dev.sasikanth.rss.reader.ui.GolosFontFamily
 import dev.sasikanth.rss.reader.util.readerDateTimestamp
 import dev.sasikanth.rss.reader.utils.LocalBlockImage
-import dev.sasikanth.rss.reader.utils.LocalShowFeedFavIconSetting
 import dev.sasikanth.rss.reader.utils.ParallaxAlignment
 import dev.sasikanth.rss.reader.utils.getOffsetFractionForPage
 import kotlinx.coroutines.launch
@@ -381,14 +380,13 @@ private fun PostHeader(
       Spacer(Modifier.requiredHeight(12.dp))
 
       Row(verticalAlignment = Alignment.CenterVertically) {
-        val showFeedFavIcon = LocalShowFeedFavIconSetting.current
-        val feedIconUrl = if (showFeedFavIcon) readerPost.feedHomepageLink else readerPost.feedIcon
-
         DisableSelection {
           PostSourcePill(
             modifier = Modifier.weight(1f).clearAndSetSemantics {},
             feedName = readerPost.feedName,
-            feedIcon = feedIconUrl,
+            feedIcon = readerPost.feedIcon,
+            feedHomepageLink = readerPost.feedHomepageLink,
+            showFeedFavIcon = readerPost.showFeedFavIcon,
             config =
               PostMetadataConfig(
                 showUnreadIndicator = false,
@@ -417,6 +415,8 @@ private fun PostHeader(
 @Composable
 private fun PostSourcePill(
   feedIcon: String,
+  feedHomepageLink: String,
+  showFeedFavIcon: Boolean,
   feedName: String,
   config: PostMetadataConfig,
   onSourceClick: () -> Unit,
@@ -449,7 +449,9 @@ private fun PostSourcePill(
     ) {
       FeedIcon(
         modifier = Modifier.requiredSize(16.dp),
-        url = feedIcon,
+        icon = feedIcon,
+        homepageLink = feedHomepageLink,
+        showFeedFavIcon = showFeedFavIcon,
         shape = MaterialTheme.shapes.extraSmall,
         contentDescription = null,
       )


### PR DESCRIPTION
- **Support per-feed favicon setting in data layer**
- **Propagate per-feed favicon setting through UI components**
- **Add UI to toggle favicon visibility per feed**
- **Restore diagonal layout for 2-feed groups and add favicon setting support**
- **Cancel source selection when navigating to feed settings**
