### PR TITLE
Maintain global sync progress for cloud sync

### DIFF
--- a/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/repository/SettingsRepository.kt
+++ b/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/repository/SettingsRepository.kt
@@ -68,6 +68,7 @@ class SettingsRepository(
   private val appIconKey = stringPreferencesKey("app_icon")
   private val isOnboardingDoneKey = booleanPreferencesKey("is_onboarding_done")
   private val dynamicColorEnabledKey = booleanPreferencesKey("dynamic_color_enabled")
+  private val lastSyncProgressKey = stringPreferencesKey("last_sync_progress")
 
   val browserType: Flow<BrowserType> =
     dataStore.data.map { preferences ->
@@ -111,6 +112,9 @@ class SettingsRepository(
 
   val dynamicColorEnabled: Flow<Boolean> =
     dataStore.data.map { preferences -> preferences[dynamicColorEnabledKey] ?: true }
+
+  val lastSyncProgress: Flow<String?> =
+    dataStore.data.map { preferences -> preferences[lastSyncProgressKey] }
 
   val enableAutoSync: Flow<Boolean> =
     dataStore.data.map { preferences -> preferences[enableAutoSyncKey] ?: true }
@@ -298,6 +302,16 @@ class SettingsRepository(
 
   suspend fun updateLastSyncedAt(value: Instant) {
     dataStore.edit { preferences -> preferences[lastSyncedAtKey] = value.toEpochMilliseconds() }
+  }
+
+  suspend fun updateLastSyncProgress(value: String?) {
+    dataStore.edit { preferences ->
+      if (value != null) {
+        preferences[lastSyncProgressKey] = value
+      } else {
+        preferences.remove(lastSyncProgressKey)
+      }
+    }
   }
 
   suspend fun updateInstallDate(value: Instant) {

--- a/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/sync/CloudSyncService.kt
+++ b/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/sync/CloudSyncService.kt
@@ -46,6 +46,7 @@ class CloudSyncService(
   suspend fun sync(provider: CloudSyncProvider): Boolean {
     try {
       appConfigQueries.updateLastSyncStatus("SYNCING")
+      settingsRepository.updateLastSyncProgress("SYNCING")
       val config = appConfigQueries.getSyncConfig().executeAsOneOrNull()
       val currentSyncVersion = config?.syncFormatVersion?.toInt() ?: 1
 
@@ -170,6 +171,7 @@ class CloudSyncService(
         appConfigQueries.updateLastSyncedFormatVersion(currentSyncVersion.toLong())
         appConfigQueries.updateLastSyncStatus("SUCCESS")
         settingsRepository.updateLastSyncedAt(Clock.System.now())
+        settingsRepository.updateLastSyncProgress("SUCCESS")
 
         val allFiles = provider.listFiles("/twine_")
         val activeFiles = postChunks + metadataFileName
@@ -183,6 +185,7 @@ class CloudSyncService(
     } catch (e: Exception) {
       Logger.e(e) { "Failed to sync with ${provider.name}" }
       appConfigQueries.updateLastSyncStatus("FAILURE")
+      settingsRepository.updateLastSyncProgress("FAILURE")
       return false
     }
   }


### PR DESCRIPTION
This PR introduces a persistent global sync progress for cloud sync (Dropbox). The progress is now stored in SettingsRepository and updated by CloudSyncService, allowing it to be tracked even when exiting the settings screen or restarting the app.