### PR TITLE
Add option to delete app data in Settings

### DIFF
--- a/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/repository/SettingsRepository.kt
+++ b/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/repository/SettingsRepository.kt
@@ -266,6 +266,10 @@ class SettingsRepository(
     }
   }
 
+  suspend fun clear() {
+    dataStore.edit { it.clear() }
+  }
+
   private fun mapToAppThemeMode(pref: String?): AppThemeMode? {
     if (pref.isNullOrBlank()) return null
     return AppThemeMode.valueOf(pref)

--- a/iosApp/iosApp/AppDelegate.swift
+++ b/iosApp/iosApp/AppDelegate.swift
@@ -104,7 +104,7 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
                     return
                 }
                 
-                let hasLastUpdatedAtExpired = try await applicationComponent.lastRefreshedAt.hasExpired().boolValue
+                let hasLastUpdatedAtExpired = try await applicationComponent.refreshPolicy.hasExpired().boolValue
                 if hasLastUpdatedAtExpired {
                     try await applicationComponent.syncCoordinator.pull()
 

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -110,6 +110,12 @@
     <string name="tagSaveButton">Save</string>
     <string name="deleteTagTitle">Delete tag?</string>
     <string name="deleteTagDesc">Tag will be deleted and removed from all the assigned feeds. Your feeds won't be deleted</string>
+    <string name="settingsHeaderData">Data</string>
+    <string name="settingsDeleteAppDataTitle">Delete app data</string>
+    <string name="settingsDeleteAppDataSubtitle">Clear all your feeds, settings and image cache</string>
+    <string name="settingsDeleteAppDataDialogTitle">Delete app data?</string>
+    <string name="settingsDeleteAppDataDialogDesc">This action will clear all your feeds, settings, and image cache. This cannot be undone.</string>
+    <string name="settingsDeleteAppDataButton">Delete</string>
     <string name="feedOptionShare">Share</string>
     <string name="feedOptionCopyLink">Copy Link</string>
     <string name="feedOptionWebsite">Website</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -112,9 +112,9 @@
     <string name="deleteTagDesc">Tag will be deleted and removed from all the assigned feeds. Your feeds won't be deleted</string>
     <string name="settingsHeaderData">Data</string>
     <string name="settingsDeleteAppDataTitle">Delete app data</string>
-    <string name="settingsDeleteAppDataSubtitle">Clear all your feeds, settings and image cache</string>
+    <string name="settingsDeleteAppDataSubtitle">Clear all your feeds, settings and image cache. You will be logged out as well.</string>
     <string name="settingsDeleteAppDataDialogTitle">Delete app data?</string>
-    <string name="settingsDeleteAppDataDialogDesc">This action will clear all your feeds, settings, and image cache. This cannot be undone.</string>
+    <string name="settingsDeleteAppDataDialogDesc">This action will clear all your feeds, settings, and image cache. This action cannot be undone.</string>
     <string name="settingsDeleteAppDataButton">Delete</string>
     <string name="feedOptionShare">Share</string>
     <string name="feedOptionCopyLink">Copy Link</string>

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/SettingsEvent.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/SettingsEvent.kt
@@ -76,4 +76,6 @@ sealed interface SettingsEvent {
   data object CloseAppIconSelectionSheet : SettingsEvent
 
   data class OnAppIconChanged(val appIcon: AppIcon) : SettingsEvent
+
+  data object DeleteAppData : SettingsEvent
 }

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/SettingsViewModel.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/SettingsViewModel.kt
@@ -17,6 +17,7 @@ package dev.sasikanth.rss.reader.settings
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import coil3.ImageLoader
 import dev.sasikanth.rss.reader.app.AppIcon
 import dev.sasikanth.rss.reader.app.AppIconManager
 import dev.sasikanth.rss.reader.app.AppInfo
@@ -47,7 +48,7 @@ import me.tatarka.inject.annotations.Inject
 
 @Inject
 class SettingsViewModel(
-  rssRepository: RssRepository,
+  private val rssRepository: RssRepository,
   val appInfo: AppInfo,
   private val settingsRepository: SettingsRepository,
   private val userRepository: UserRepository,
@@ -58,6 +59,7 @@ class SettingsViewModel(
   private val oAuthManager: OAuthManager,
   private val appIconManager: AppIconManager,
   private val refreshPolicy: RefreshPolicy,
+  private val imageLoader: ImageLoader,
   val availableProviders: Set<CloudServiceProvider>
 ) : ViewModel() {
 
@@ -202,6 +204,16 @@ class SettingsViewModel(
       SettingsEvent.CloseAppIconSelectionSheet -> {
         _state.update { it.copy(showAppIconSelectionSheet = false) }
       }
+      SettingsEvent.DeleteAppData -> deleteAppData()
+    }
+  }
+
+  private fun deleteAppData() {
+    viewModelScope.launch {
+      rssRepository.deleteAllLocalData()
+      settingsRepository.clear()
+      imageLoader.diskCache?.clear()
+      imageLoader.memoryCache?.clear()
     }
   }
 

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/SettingsViewModel.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/SettingsViewModel.kt
@@ -214,6 +214,7 @@ class SettingsViewModel(
       settingsRepository.clear()
       imageLoader.diskCache?.clear()
       imageLoader.memoryCache?.clear()
+      settingsRepository.completeOnboarding()
     }
   }
 

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/SettingsScreen.kt
@@ -152,6 +152,7 @@ import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import twine.shared.generated.resources.Res
 import twine.shared.generated.resources.blockedWords
+import twine.shared.generated.resources.buttonCancel
 import twine.shared.generated.resources.buttonGoBack
 import twine.shared.generated.resources.enableAutoSyncDesc
 import twine.shared.generated.resources.enableAutoSyncTitle
@@ -175,6 +176,11 @@ import twine.shared.generated.resources.settingsBlockImagesTitle
 import twine.shared.generated.resources.settingsBrowserTypeSubtitle
 import twine.shared.generated.resources.settingsBrowserTypeTitle
 import twine.shared.generated.resources.settingsCustomisations
+import twine.shared.generated.resources.settingsDeleteAppDataButton
+import twine.shared.generated.resources.settingsDeleteAppDataDialogDesc
+import twine.shared.generated.resources.settingsDeleteAppDataDialogTitle
+import twine.shared.generated.resources.settingsDeleteAppDataSubtitle
+import twine.shared.generated.resources.settingsDeleteAppDataTitle
 import twine.shared.generated.resources.settingsDownloadFullContentSubtitle
 import twine.shared.generated.resources.settingsDownloadFullContentTitle
 import twine.shared.generated.resources.settingsDownloadFullContentWarning
@@ -183,6 +189,7 @@ import twine.shared.generated.resources.settingsDynamicColorTitle
 import twine.shared.generated.resources.settingsEnableNotificationsSubtitle
 import twine.shared.generated.resources.settingsEnableNotificationsTitle
 import twine.shared.generated.resources.settingsHeaderBehaviour
+import twine.shared.generated.resources.settingsHeaderData
 import twine.shared.generated.resources.settingsHeaderFeedback
 import twine.shared.generated.resources.settingsHeaderOpml
 import twine.shared.generated.resources.settingsHeaderSync
@@ -249,6 +256,8 @@ internal fun SettingsScreen(
   val layoutDirection = LocalLayoutDirection.current
   val linkHandler = LocalLinkHandler.current
 
+  var showDeleteAppDataConfirmation by remember { mutableStateOf(false) }
+
   LaunchedEffect(state.authUrlToOpen) {
     state.authUrlToOpen?.let { url ->
       linkHandler.openLink(url, useInAppBrowser = true)
@@ -265,6 +274,16 @@ internal fun SettingsScreen(
 
   LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
     viewModel.dispatch(SettingsEvent.LoadSubscriptionStatus)
+  }
+
+  if (showDeleteAppDataConfirmation) {
+    DeleteAppDataConfirmationDialog(
+      onConfirm = {
+        showDeleteAppDataConfirmation = false
+        viewModel.dispatch(SettingsEvent.DeleteAppData)
+      },
+      onDismiss = { showDeleteAppDataConfirmation = false }
+    )
   }
 
   Scaffold(
@@ -619,6 +638,10 @@ internal fun SettingsScreen(
             }
           )
         }
+
+        item { Divider() }
+
+        item { DeleteAppDataSettingItem { showDeleteAppDataConfirmation = true } }
 
         item { Divider() }
 
@@ -1710,6 +1733,76 @@ private fun ReportIssueItem(appInfo: AppInfo, onClick: () -> Unit) {
       }
     }
   }
+}
+
+@Composable
+private fun DeleteAppDataSettingItem(onClick: () -> Unit) {
+  Box(modifier = Modifier.clickable(onClick = onClick)) {
+    Column {
+      SubHeader(text = stringResource(Res.string.settingsHeaderData))
+
+      Row(
+        modifier = Modifier.padding(start = 24.dp, top = 16.dp, end = 24.dp, bottom = 20.dp),
+        verticalAlignment = Alignment.CenterVertically
+      ) {
+        Column(modifier = Modifier.weight(1f)) {
+          Text(
+            stringResource(Res.string.settingsDeleteAppDataTitle),
+            style = MaterialTheme.typography.titleMedium,
+            color = AppTheme.colorScheme.error
+          )
+          Text(
+            stringResource(Res.string.settingsDeleteAppDataSubtitle),
+            style = MaterialTheme.typography.labelLarge,
+            color = AppTheme.colorScheme.textEmphasisMed
+          )
+        }
+      }
+
+      HorizontalDivider(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp),
+        color = AppTheme.colorScheme.surfaceContainer
+      )
+    }
+  }
+}
+
+@Composable
+private fun DeleteAppDataConfirmationDialog(onConfirm: () -> Unit, onDismiss: () -> Unit) {
+  androidx.compose.material3.AlertDialog(
+    onDismissRequest = onDismiss,
+    confirmButton = {
+      TextButton(onClick = onConfirm) {
+        Text(
+          text = stringResource(Res.string.settingsDeleteAppDataButton),
+          color = AppTheme.colorScheme.error
+        )
+      }
+    },
+    dismissButton = {
+      TextButton(onClick = onDismiss) {
+        Text(
+          text = stringResource(Res.string.buttonCancel),
+          color = AppTheme.colorScheme.textEmphasisMed
+        )
+      }
+    },
+    title = {
+      Text(
+        text = stringResource(Res.string.settingsDeleteAppDataDialogTitle),
+        color = AppTheme.colorScheme.textEmphasisHigh
+      )
+    },
+    text = {
+      Text(
+        text = stringResource(Res.string.settingsDeleteAppDataDialogDesc),
+        color = AppTheme.colorScheme.textEmphasisMed
+      )
+    },
+    containerColor = AppTheme.colorScheme.surfaceContainerLowest,
+    titleContentColor = AppTheme.colorScheme.textEmphasisHigh,
+    textContentColor = AppTheme.colorScheme.textEmphasisMed,
+  )
 }
 
 @Composable

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/SettingsScreen.kt
@@ -53,6 +53,7 @@ import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.rounded.WorkspacePremium
 import androidx.compose.material.minimumInteractiveComponentSize
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.HorizontalDivider
@@ -1737,39 +1738,34 @@ private fun ReportIssueItem(appInfo: AppInfo, onClick: () -> Unit) {
 
 @Composable
 private fun DeleteAppDataSettingItem(onClick: () -> Unit) {
-  Box(modifier = Modifier.clickable(onClick = onClick)) {
-    Column {
-      SubHeader(text = stringResource(Res.string.settingsHeaderData))
+  Column {
+    SubHeader(text = stringResource(Res.string.settingsHeaderData))
 
-      Row(
-        modifier = Modifier.padding(start = 24.dp, top = 16.dp, end = 24.dp, bottom = 20.dp),
-        verticalAlignment = Alignment.CenterVertically
-      ) {
-        Column(modifier = Modifier.weight(1f)) {
-          Text(
-            stringResource(Res.string.settingsDeleteAppDataTitle),
-            style = MaterialTheme.typography.titleMedium,
-            color = AppTheme.colorScheme.error
-          )
-          Text(
-            stringResource(Res.string.settingsDeleteAppDataSubtitle),
-            style = MaterialTheme.typography.labelLarge,
-            color = AppTheme.colorScheme.textEmphasisMed
-          )
-        }
+    Row(
+      modifier =
+        Modifier.clickable(onClick = onClick)
+          .padding(start = 24.dp, top = 16.dp, end = 24.dp, bottom = 20.dp),
+      verticalAlignment = Alignment.CenterVertically
+    ) {
+      Column(modifier = Modifier.weight(1f)) {
+        Text(
+          stringResource(Res.string.settingsDeleteAppDataTitle),
+          style = MaterialTheme.typography.titleMedium,
+          color = AppTheme.colorScheme.error
+        )
+        Text(
+          stringResource(Res.string.settingsDeleteAppDataSubtitle),
+          style = MaterialTheme.typography.labelLarge,
+          color = AppTheme.colorScheme.textEmphasisMed
+        )
       }
-
-      HorizontalDivider(
-        modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp),
-        color = AppTheme.colorScheme.surfaceContainer
-      )
     }
   }
 }
 
 @Composable
 private fun DeleteAppDataConfirmationDialog(onConfirm: () -> Unit, onDismiss: () -> Unit) {
-  androidx.compose.material3.AlertDialog(
+  AlertDialog(
     onDismissRequest = onDismiss,
     confirmButton = {
       TextButton(onClick = onConfirm) {


### PR DESCRIPTION
This PR adds a new section in the Settings screen to delete all app data, including feeds, settings, and image cache. It includes a confirmation dialog to prevent accidental deletion.