### PR TITLE
Implement reading statistics feature

### DIFF
--- a/.idea/copyright/Sasikanth_Miriyampalli__GPL_3_0_.xml
+++ b/.idea/copyright/Sasikanth_Miriyampalli__GPL_3_0_.xml
@@ -1,6 +1,6 @@
 <component name="CopyrightManager">
   <copyright>
-    <option name="notice" value="Copyright &amp;#36;today.year Sasikanth Miriyampalli&#10;&#10;Licensed under the GPL, Version 3.0 (the &quot;License&quot;);&#10;you may not use this file except in compliance with the License.&#10;You may obtain a copy of the License at&#10;&#10;    https://www.gnu.org/licenses/gpl-3.0.en.html&#10;" />
+    <option name="notice" value="Copyright &amp;#36;today.year Sasikanth Miriyampalli&#10;&#10;Licensed under the GPL, Version 3.0 (the &quot;License&quot;);&#10;you may not use this file except in compliance with the License.&#10;You may obtain a copy of the License at&#10;&#10;    https://www.gnu.org/licenses/gpl-3.0.en.html&#10;&#10;Unless required by applicable law or agreed to in writing, software&#10;distributed under the License is distributed on an &quot;AS IS&quot; BASIS,&#10;WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#10;See the License for the specific language governing permissions and&#10;limitations under the License.&#10;" />
     <option name="myName" value="Sasikanth Miriyampalli (GPL 3.0)" />
   </copyright>
 </component>

--- a/.idea/copyright/profiles_settings.xml
+++ b/.idea/copyright/profiles_settings.xml
@@ -1,7 +1,3 @@
 <component name="CopyrightManager">
-  <settings default="Sasikanth Miriyampalli (GPL 3.0)">
-    <module2copyright>
-      <element module="Project Files" copyright="Sasikanth Miriyampalli (GPL 3.0)" />
-    </module2copyright>
-  </settings>
+  <settings default="Sasikanth Miriyampalli (GPL 3.0)" />
 </component>

--- a/core/data/src/commonMain/sqldelight/dev/sasikanth/rss/reader/data/database/Post.sq
+++ b/core/data/src/commonMain/sqldelight/dev/sasikanth/rss/reader/data/database/Post.sq
@@ -337,3 +337,41 @@ SELECT
     )
   ) AS feedShowFavIconSettings
 FROM unreadPosts;
+
+totalReadPostsCount:
+SELECT COUNT(*) FROM post
+INNER JOIN feed ON post.sourceId == feed.id
+WHERE
+  (post.flags & 2) != 0 AND
+  (post.flags & 4) == 0 AND
+  feed.isDeleted = 0;
+
+readPostsByFeed:
+SELECT
+  feed.id AS feedId,
+  feed.name AS feedName,
+  feed.icon AS feedIcon,
+  feed.homepageLink AS feedHomepageLink,
+  COUNT(post.id) AS readCount
+FROM post
+INNER JOIN feed ON post.sourceId == feed.id
+WHERE
+  (post.flags & 2) != 0 AND
+  (post.flags & 4) == 0 AND
+  feed.isDeleted = 0
+GROUP BY feed.id, feed.name, feed.icon
+ORDER BY readCount DESC;
+
+readPostsOverTime:
+SELECT
+  DATE(postDate / 1000, 'unixepoch') AS date,
+  COUNT(*) AS count
+FROM post
+INNER JOIN feed ON post.sourceId == feed.id
+WHERE
+  (post.flags & 2) != 0 AND
+  (post.flags & 4) == 0 AND
+  feed.isDeleted = 0 AND
+  postDate >= :startDate
+GROUP BY date
+ORDER BY date DESC;

--- a/core/model/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/model/local/ReadingStatistics.kt
+++ b/core/model/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/model/local/ReadingStatistics.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024 Sasikanth Miriyampalli
+ *
+ * Licensed under the GPL, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ */
+
+package dev.sasikanth.rss.reader.core.model.local
+
+import androidx.compose.runtime.Immutable
+
+@Immutable
+data class FeedReadCount(
+  val feedId: String,
+  val feedName: String,
+  val feedIcon: String,
+  val homepageLink: String,
+  val readCount: Long
+)
+
+@Immutable data class ReadingTrend(val date: String, val count: Long)
+
+@Immutable
+data class ReadingStatistics(
+  val totalReadCount: Long,
+  val topFeeds: List<FeedReadCount>,
+  val readingTrends: List<ReadingTrend>
+)

--- a/shared/src/androidMain/kotlin/dev/sasikanth/rss/reader/utils/DateExt.android.kt
+++ b/shared/src/androidMain/kotlin/dev/sasikanth/rss/reader/utils/DateExt.android.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2024 Sasikanth Miriyampalli
+ *
+ * Licensed under the GPL, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ */
+
+package dev.sasikanth.rss.reader.utils
+
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+actual fun String.formatReadingTrendDate(): String {
+  return try {
+    val date = LocalDate.parse(this, DateTimeFormatter.ISO_LOCAL_DATE)
+    date.format(DateTimeFormatter.ofPattern("dd-MMM-yy", Locale.getDefault()))
+  } catch (_: Exception) {
+    this
+  }
+}

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -241,4 +241,12 @@
         <item quantity="one">%1$d feed</item>
         <item quantity="other">%1$d feeds</item>
     </plurals>
+    <!-- Statistics -->
+    <string name="statistics">Statistics</string>
+    <string name="statisticsNoData">No reading data available yet</string>
+    <string name="statisticsTotalRead">Total Articles Read</string>
+    <string name="statisticsTopFeeds">Top 10 Feeds</string>
+    <string name="statisticsReadingTrends">Reading Trends (Last 30 Days)</string>
+    <string name="settingsStatisticsTitle">Statistics</string>
+    <string name="settingsStatisticsSubtitle">View your reading habits and insights</string>
 </resources>

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/app/App.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/app/App.kt
@@ -95,6 +95,8 @@ import dev.sasikanth.rss.reader.settings.SettingsViewModel
 import dev.sasikanth.rss.reader.settings.ui.SettingsScreen
 import dev.sasikanth.rss.reader.share.LocalShareHandler
 import dev.sasikanth.rss.reader.share.ShareHandler
+import dev.sasikanth.rss.reader.statistics.StatisticsViewModel
+import dev.sasikanth.rss.reader.statistics.ui.StatisticsScreen
 import dev.sasikanth.rss.reader.ui.AppTheme
 import dev.sasikanth.rss.reader.ui.LocalDynamicColorState
 import dev.sasikanth.rss.reader.ui.LocalSeedColorExtractor
@@ -154,6 +156,7 @@ fun App(
   groupViewModel: (SavedStateHandle) -> GroupViewModel,
   blockedWordsViewModel: () -> BlockedWordsViewModel,
   premiumPaywallViewModel: () -> PremiumPaywallViewModel,
+  statisticsViewModel: () -> StatisticsViewModel,
   @Assisted onThemeChange: (useDarkTheme: Boolean) -> Unit,
   @Assisted toggleLightStatusBar: (isLightStatusBar: Boolean) -> Unit,
   @Assisted toggleLightNavBar: (isLightNavBar: Boolean) -> Unit,
@@ -409,6 +412,7 @@ fun App(
                 viewModel = viewModel,
                 goBack = goBack,
                 openAbout = { navController.navigate(Screen.About) },
+                openStatistics = { navController.navigate(Screen.Statistics) },
                 openBlockedWords = { navController.navigate(Screen.BlockedWords) },
                 openPaywall = { navController.navigate(Screen.Paywall) },
                 openFreshRssLogin = { navController.navigate(Screen.FreshRssLogin) },
@@ -511,6 +515,15 @@ fun App(
         composable<Screen.About> {
           AboutScreen(
             modifier = roundedCornerScreenModifier,
+            goBack = { navController.popBackStack() }
+          )
+        }
+
+        composable<Screen.Statistics> {
+          val viewModel = viewModel { statisticsViewModel() }
+          StatisticsScreen(
+            modifier = roundedCornerScreenModifier,
+            viewModel = viewModel,
             goBack = { navController.popBackStack() }
           )
         }

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/app/Screens.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/app/Screens.kt
@@ -49,6 +49,8 @@ sealed interface Screen {
 
   @Serializable data object About : Screen
 
+  @Serializable data object Statistics : Screen
+
   @Serializable
   data object AddFeed : Screen {
 

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/SettingsScreen.kt
@@ -213,6 +213,8 @@ import twine.shared.generated.resources.settingsShowReaderViewSubtitle
 import twine.shared.generated.resources.settingsShowReaderViewTitle
 import twine.shared.generated.resources.settingsShowUnreadCountSubtitle
 import twine.shared.generated.resources.settingsShowUnreadCountTitle
+import twine.shared.generated.resources.settingsStatisticsSubtitle
+import twine.shared.generated.resources.settingsStatisticsTitle
 import twine.shared.generated.resources.settingsSyncDropbox
 import twine.shared.generated.resources.settingsSyncFreshRSS
 import twine.shared.generated.resources.settingsSyncMiniflux
@@ -245,6 +247,7 @@ internal fun SettingsScreen(
   viewModel: SettingsViewModel,
   goBack: () -> Unit,
   openAbout: () -> Unit,
+  openStatistics: () -> Unit,
   openBlockedWords: () -> Unit,
   openPaywall: () -> Unit,
   openFreshRssLogin: () -> Unit,
@@ -643,6 +646,10 @@ internal fun SettingsScreen(
         item { Divider() }
 
         item { DeleteAppDataSettingItem { showDeleteAppDataConfirmation = true } }
+
+        item { Divider() }
+
+        item { StatisticsItem { openStatistics() } }
 
         item { Divider() }
 
@@ -1799,6 +1806,29 @@ private fun DeleteAppDataConfirmationDialog(onConfirm: () -> Unit, onDismiss: ()
     titleContentColor = AppTheme.colorScheme.textEmphasisHigh,
     textContentColor = AppTheme.colorScheme.textEmphasisMed,
   )
+}
+
+@Composable
+private fun StatisticsItem(onClick: () -> Unit) {
+  Box(modifier = Modifier.clickable(onClick = onClick)) {
+    Row(
+      modifier = Modifier.padding(start = 24.dp, top = 16.dp, end = 24.dp, bottom = 20.dp),
+      verticalAlignment = Alignment.CenterVertically
+    ) {
+      Column(modifier = Modifier.weight(1f)) {
+        Text(
+          stringResource(Res.string.settingsStatisticsTitle),
+          style = MaterialTheme.typography.titleMedium,
+          color = AppTheme.colorScheme.textEmphasisHigh
+        )
+        Text(
+          stringResource(Res.string.settingsStatisticsSubtitle),
+          style = MaterialTheme.typography.labelLarge,
+          color = AppTheme.colorScheme.textEmphasisMed
+        )
+      }
+    }
+  }
 }
 
 @Composable

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/statistics/StatisticsEvent.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/statistics/StatisticsEvent.kt
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2024 Sasikanth Miriyampalli
+ *
+ * Licensed under the GPL, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ */
+
+package dev.sasikanth.rss.reader.statistics
+
+sealed interface StatisticsEvent {
+  data object LoadStatistics : StatisticsEvent
+}

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/statistics/StatisticsState.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/statistics/StatisticsState.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2024 Sasikanth Miriyampalli
+ *
+ * Licensed under the GPL, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ */
+
+package dev.sasikanth.rss.reader.statistics
+
+import androidx.compose.runtime.Immutable
+import dev.sasikanth.rss.reader.core.model.local.ReadingStatistics
+
+@Immutable
+data class StatisticsState(
+  val statistics: ReadingStatistics? = null,
+  val isLoading: Boolean = true
+)

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/statistics/StatisticsViewModel.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/statistics/StatisticsViewModel.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024 Sasikanth Miriyampalli
+ *
+ * Licensed under the GPL, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ */
+
+package dev.sasikanth.rss.reader.statistics
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dev.sasikanth.rss.reader.data.repository.RssRepository
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.days
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import me.tatarka.inject.annotations.Inject
+
+@Inject
+class StatisticsViewModel(private val rssRepository: RssRepository) : ViewModel() {
+
+  private val _state = MutableStateFlow(StatisticsState())
+  val state: StateFlow<StatisticsState>
+    get() = _state
+
+  init {
+    dispatch(StatisticsEvent.LoadStatistics)
+  }
+
+  fun dispatch(event: StatisticsEvent) {
+    when (event) {
+      StatisticsEvent.LoadStatistics -> loadStatistics()
+    }
+  }
+
+  private fun loadStatistics() {
+    viewModelScope.launch {
+      _state.update { it.copy(isLoading = true) }
+
+      val startDate = Clock.System.now() - 30.days
+
+      rssRepository
+        .getReadingStatistics(startDate)
+        .onEach { statistics ->
+          _state.update { it.copy(statistics = statistics, isLoading = false) }
+        }
+        .launchIn(this)
+    }
+  }
+}

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/statistics/ui/StatisticsScreen.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/statistics/ui/StatisticsScreen.kt
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2024 Sasikanth Miriyampalli
+ *
+ * Licensed under the GPL, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ */
+
+package dev.sasikanth.rss.reader.statistics.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import dev.sasikanth.rss.reader.components.CircularIconButton
+import dev.sasikanth.rss.reader.components.SubHeader
+import dev.sasikanth.rss.reader.components.image.FeedIcon
+import dev.sasikanth.rss.reader.core.model.local.FeedReadCount
+import dev.sasikanth.rss.reader.core.model.local.ReadingTrend
+import dev.sasikanth.rss.reader.resources.icons.ArrowBack
+import dev.sasikanth.rss.reader.resources.icons.TwineIcons
+import dev.sasikanth.rss.reader.statistics.StatisticsViewModel
+import dev.sasikanth.rss.reader.ui.AppTheme
+import dev.sasikanth.rss.reader.utils.formatReadingTrendDate
+import org.jetbrains.compose.resources.stringResource
+import twine.shared.generated.resources.Res
+import twine.shared.generated.resources.buttonGoBack
+import twine.shared.generated.resources.statistics
+import twine.shared.generated.resources.statisticsNoData
+import twine.shared.generated.resources.statisticsReadingTrends
+import twine.shared.generated.resources.statisticsTopFeeds
+import twine.shared.generated.resources.statisticsTotalRead
+
+@Composable
+fun StatisticsScreen(
+  viewModel: StatisticsViewModel,
+  goBack: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  val state by viewModel.state.collectAsState()
+  val layoutDirection = LocalLayoutDirection.current
+
+  Scaffold(
+    modifier = modifier,
+    topBar = {
+      Box {
+        CenterAlignedTopAppBar(
+          title = {
+            Text(
+              text = stringResource(Res.string.statistics),
+              color = AppTheme.colorScheme.onSurface,
+              style = MaterialTheme.typography.titleMedium,
+            )
+          },
+          navigationIcon = {
+            CircularIconButton(
+              modifier = Modifier.padding(start = 12.dp),
+              icon = TwineIcons.ArrowBack,
+              label = stringResource(Res.string.buttonGoBack),
+              onClick = goBack
+            )
+          },
+          colors =
+            TopAppBarDefaults.topAppBarColors(
+              containerColor = AppTheme.colorScheme.surface,
+              navigationIconContentColor = AppTheme.colorScheme.onSurface,
+              titleContentColor = AppTheme.colorScheme.onSurface,
+              actionIconContentColor = AppTheme.colorScheme.onSurface
+            )
+        )
+
+        HorizontalDivider(
+          modifier = Modifier.fillMaxWidth().align(Alignment.BottomStart),
+          color = AppTheme.colorScheme.surfaceContainer
+        )
+      }
+    },
+    containerColor = AppTheme.colorScheme.surfaceContainerLowest,
+  ) { padding ->
+    if (state.isLoading) {
+      Box(modifier = Modifier.fillMaxSize().padding(padding), contentAlignment = Alignment.Center) {
+        CircularProgressIndicator()
+      }
+    } else {
+      val statistics = state.statistics
+      if (statistics == null || statistics.totalReadCount == 0L) {
+        Box(
+          modifier = Modifier.fillMaxSize().padding(padding),
+          contentAlignment = Alignment.Center
+        ) {
+          Text(
+            text = stringResource(Res.string.statisticsNoData),
+            style = MaterialTheme.typography.bodyLarge,
+            color = AppTheme.colorScheme.onSurfaceVariant
+          )
+        }
+      } else {
+        LazyColumn(
+          modifier = Modifier.fillMaxSize(),
+          contentPadding =
+            PaddingValues(
+              start = padding.calculateStartPadding(layoutDirection),
+              end = padding.calculateEndPadding(layoutDirection),
+              top = padding.calculateTopPadding(),
+              bottom = padding.calculateBottomPadding() + 80.dp
+            )
+        ) {
+          item {
+            StatisticCard(
+              title = stringResource(Res.string.statisticsTotalRead),
+              value = statistics.totalReadCount.toString(),
+            )
+          }
+
+          item { Spacer(modifier = Modifier.height(24.dp)) }
+
+          if (statistics.topFeeds.isNotEmpty()) {
+            item { SubHeader(text = stringResource(Res.string.statisticsTopFeeds)) }
+
+            items(statistics.topFeeds.take(10)) { feedReadCount ->
+              FeedReadCountItem(
+                feedReadCount = feedReadCount,
+                modifier = Modifier.padding(horizontal = 24.dp, vertical = 12.dp)
+              )
+            }
+
+            item { Spacer(modifier = Modifier.height(24.dp)) }
+          }
+
+          if (statistics.readingTrends.isNotEmpty()) {
+            item { SubHeader(text = stringResource(Res.string.statisticsReadingTrends)) }
+
+            items(statistics.readingTrends.take(30)) { trend ->
+              ReadingTrendItem(
+                trend = trend,
+                modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp)
+              )
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun StatisticCard(title: String, value: String, modifier: Modifier = Modifier) {
+  Column(
+    modifier =
+      modifier
+        .fillMaxWidth()
+        .clip(MaterialTheme.shapes.large)
+        .background(AppTheme.colorScheme.surface)
+        .padding(horizontal = 16.dp, vertical = 20.dp),
+    horizontalAlignment = Alignment.CenterHorizontally
+  ) {
+    Text(
+      text = title,
+      style = MaterialTheme.typography.titleMedium,
+      color = AppTheme.colorScheme.onSurfaceVariant
+    )
+    Spacer(modifier = Modifier.height(8.dp))
+    Text(
+      text = value,
+      style = MaterialTheme.typography.displayMedium,
+      fontWeight = FontWeight.Bold,
+      color = AppTheme.colorScheme.primary
+    )
+  }
+}
+
+@Composable
+private fun FeedReadCountItem(feedReadCount: FeedReadCount, modifier: Modifier = Modifier) {
+  Row(modifier = modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+    val shape = RoundedCornerShape(16.dp)
+
+    FeedIcon(
+      icon = feedReadCount.feedIcon,
+      homepageLink = feedReadCount.homepageLink,
+      showFeedFavIcon = true,
+      shape = shape,
+      contentDescription = null,
+      modifier = Modifier.requiredSize(32.dp),
+    )
+    Spacer(modifier = Modifier.width(12.dp))
+    Column(modifier = Modifier.weight(1f)) {
+      Text(
+        text = feedReadCount.feedName,
+        style = MaterialTheme.typography.bodyLarge,
+        fontWeight = FontWeight.Medium,
+        color = AppTheme.colorScheme.textEmphasisHigh,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+      )
+    }
+    Spacer(modifier = Modifier.width(12.dp))
+    Text(
+      text = feedReadCount.readCount.toString(),
+      style = MaterialTheme.typography.titleMedium,
+      fontWeight = FontWeight.Bold,
+      color = AppTheme.colorScheme.primary
+    )
+  }
+}
+
+@Composable
+private fun ReadingTrendItem(trend: ReadingTrend, modifier: Modifier = Modifier) {
+  Row(
+    modifier = modifier.fillMaxWidth(),
+    horizontalArrangement = Arrangement.SpaceBetween,
+    verticalAlignment = Alignment.CenterVertically
+  ) {
+    Text(
+      text = trend.date.formatReadingTrendDate(),
+      style = MaterialTheme.typography.bodyMedium,
+      color = AppTheme.colorScheme.textEmphasisHigh
+    )
+    Text(
+      text = trend.count.toString(),
+      style = MaterialTheme.typography.bodyMedium,
+      fontWeight = FontWeight.Medium,
+      color = AppTheme.colorScheme.textEmphasisHigh
+    )
+  }
+}

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/utils/DateExt.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/utils/DateExt.kt
@@ -26,6 +26,8 @@ import kotlinx.datetime.atStartOfDayIn
 import kotlinx.datetime.minus
 import kotlinx.datetime.todayIn
 
+expect fun String.formatReadingTrendDate(): String
+
 fun Period.calculateInstantBeforePeriod(): Instant {
   if (this == Period.NEVER) return Instant.DISTANT_PAST
 

--- a/shared/src/iosMain/kotlin/dev/sasikanth/rss/reader/utils/DateExt.ios.kt
+++ b/shared/src/iosMain/kotlin/dev/sasikanth/rss/reader/utils/DateExt.ios.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2024 Sasikanth Miriyampalli
+ *
+ * Licensed under the GPL, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ */
+
+package dev.sasikanth.rss.reader.utils
+
+import platform.Foundation.NSDateFormatter
+import platform.Foundation.NSLocale
+
+actual fun String.formatReadingTrendDate(): String {
+  val formatter = NSDateFormatter()
+  formatter.locale = NSLocale.currentLocale()
+  formatter.dateFormat = "yyyy-MM-dd"
+  val parsedDate = formatter.dateFromString(this) ?: return this
+  formatter.dateFormat = "dd-MMM-yy"
+  return formatter.stringFromDate(parsedDate)
+}


### PR DESCRIPTION
fixes: #1122 

This PR adds a new Reading Statistics feature to Twine, allowing users to track their reading habits.

### Changes:

1. **Add reading statistics models and database queries**: Added ReadingStatistics models and implemented SQLDelight queries in Post.sq to fetch total read count, top feeds by read count, and reading trends over time.
2. **Add getReadingStatistics to RssRepository**: Integrated the new database queries into RssRepository to provide a unified flow of reading statistics.
3. **Add date formatting utilities for reading trends**: Implemented platform-specific date formatting for reading trends in DateExt.kt (common, Android, and iOS).
4. **Implement Statistics feature presentation layer**: Added StatisticsViewModel, StatisticsState, and StatisticsEvent to manage the UI state of the statistics feature.
5. **Add Statistics screen and integrate it into the app**: Implemented the StatisticsScreen UI using Compose Multiplatform, added it to the app navigation, and linked it from the Settings screen.

All changes were formatted using ./gradlew spotlessApply.