### PR TITLE
Reduce sync memory usage

### DIFF
--- a/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/sync/local/LocalSyncCoordinator.kt
+++ b/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/sync/local/LocalSyncCoordinator.kt
@@ -61,7 +61,7 @@ class LocalSyncCoordinator(
 ) : SyncCoordinator {
 
   companion object {
-    private const val SYNC_CHUNK_SIZE = 6
+    private const val SYNC_CHUNK_SIZE = 3
   }
 
   private val syncMutex = Mutex()

--- a/core/data/src/commonMain/sqldelight/dev/sasikanth/rss/reader/data/database/Post.sq
+++ b/core/data/src/commonMain/sqldelight/dev/sasikanth/rss/reader/data/database/Post.sq
@@ -206,11 +206,29 @@ UPDATE post SET syncedAt = :syncedAt WHERE id = :id;
 postsWithRemoteId:
 SELECT * FROM post WHERE remoteId IS NOT NULL;
 
+postsWithRemoteIdPaged:
+SELECT * FROM post
+WHERE remoteId IS NOT NULL
+ORDER BY id
+LIMIT :limit OFFSET :offset;
+
 postsWithLocalChanges:
 SELECT * FROM post WHERE updatedAt > syncedAt AND remoteId IS NOT NULL;
 
+postsWithLocalChangesPaged:
+SELECT * FROM post
+WHERE updatedAt > syncedAt AND remoteId IS NOT NULL
+ORDER BY id
+LIMIT :limit OFFSET :offset;
+
 postsWithLocalChangesForFeed:
 SELECT * FROM post WHERE updatedAt > syncedAt AND remoteId IS NOT NULL AND sourceId = :feedId;
+
+postsWithLocalChangesForFeedPaged:
+SELECT * FROM post
+WHERE updatedAt > syncedAt AND remoteId IS NOT NULL AND sourceId = :feedId
+ORDER BY id
+LIMIT :limit OFFSET :offset;
 
 unreadPostsCountInSource:
 SELECT COUNT(*) FROM post

--- a/core/network/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/network/fetcher/FeedFetcher.kt
+++ b/core/network/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/network/fetcher/FeedFetcher.kt
@@ -42,6 +42,7 @@ import io.ktor.http.contentType
 import io.ktor.http.isRelativePath
 import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.asSource
+import io.ktor.utils.io.readBuffer
 import korlibs.io.lang.Charset
 import korlibs.io.lang.Charsets
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -180,7 +181,7 @@ class FeedFetcher(
         return FeedFetchResult.Success(feedPayload)
       }
       ContentType.Application.Json -> {
-        val jsonSource = responseChannel.asSource()
+        val jsonSource = responseChannel.readBuffer()
         var feedPayload =
           jsonFeedParser.parse(
             content = jsonSource,


### PR DESCRIPTION
## Summary

- stream feed post upserts in batches and add paged post queries
- batch FreshRSS/Miniflux status syncs and reduce local sync concurrency
- limit feed fetcher concurrency and avoid buffering JSON feeds