### PR TITLE
Add search filters for bookmarked and unread posts

### DIFF
--- a/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/repository/RssRepository.kt
+++ b/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/repository/RssRepository.kt
@@ -694,17 +694,34 @@ class RssRepository(
     }
   }
 
-  fun search(searchQuery: String, sortOrder: SearchSortOrder): PagingSource<Int, ResolvedPost> {
+  fun search(
+    searchQuery: String,
+    sortOrder: SearchSortOrder,
+    sourceIds: List<String> = emptyList(),
+    onlyBookmarked: Boolean = false,
+    onlyUnread: Boolean = false,
+  ): PagingSource<Int, ResolvedPost> {
     val sanitizedSearchQuery = sanitizeSearchQuery(searchQuery)
 
     return QueryPagingSource(
-      countQuery = postSearchFTSQueries.countSearchResults(sanitizedSearchQuery),
+      countQuery =
+        postSearchFTSQueries.countSearchResults(
+          searchQuery = sanitizedSearchQuery,
+          isSourceIdsEmpty = sourceIds.isEmpty(),
+          sourceIds = sourceIds,
+          onlyBookmarked = if (onlyBookmarked) 1L else 0L,
+          onlyUnread = if (onlyUnread) 1L else 0L,
+        ),
       transacter = postSearchFTSQueries,
       context = dispatchersProvider.databaseRead,
       queryProvider = { limit, offset ->
         postSearchFTSQueries.search(
           searchQuery = sanitizedSearchQuery,
           sortOrder = sortOrder.value,
+          isSourceIdsEmpty = sourceIds.isEmpty(),
+          sourceIds = sourceIds,
+          onlyBookmarked = if (onlyBookmarked) 1L else 0L,
+          onlyUnread = if (onlyUnread) 1L else 0L,
           limit = limit,
           offset = offset,
           mapper = {

--- a/core/data/src/commonMain/sqldelight/dev/sasikanth/rss/reader/data/database/PostSearchFTS.sq
+++ b/core/data/src/commonMain/sqldelight/dev/sasikanth/rss/reader/data/database/PostSearchFTS.sq
@@ -28,7 +28,12 @@ countSearchResults:
 SELECT COUNT(*) FROM post_search ps
 INNER JOIN post p ON p.id = ps.id
 INNER JOIN feed f ON p.sourceId = f.id
-WHERE ps.post_search MATCH :searchQuery AND f.isDeleted = 0 AND (p.flags & 4) == 0;
+WHERE ps.post_search MATCH :searchQuery 
+  AND f.isDeleted = 0 
+  AND (p.flags & 4) == 0
+  AND (:isSourceIdsEmpty OR p.sourceId IN :sourceIds)
+  AND (:onlyBookmarked = 0 OR (p.flags & 1) != 0)
+  AND (:onlyUnread = 0 OR (p.flags & 2) == 0);
 
 search:
 SELECT
@@ -54,7 +59,12 @@ FROM post_search
 INNER JOIN post ON post.id == post_search.id
 INNER JOIN feed ON post.sourceId == feed.id
 LEFT JOIN postContent pc ON post.id == pc.id
-WHERE post_search MATCH :searchQuery AND feed.isDeleted = 0 AND (post.flags & 4) == 0
+WHERE post_search MATCH :searchQuery 
+  AND feed.isDeleted = 0 
+  AND (post.flags & 4) == 0
+  AND (:isSourceIdsEmpty OR post.sourceId IN :sourceIds)
+  AND (:onlyBookmarked = 0 OR (post.flags & 1) != 0)
+  AND (:onlyUnread = 0 OR (post.flags & 2) == 0)
 ORDER BY
   CASE WHEN :sortOrder = 'oldest' THEN post.postDate END ASC,
   CASE WHEN :sortOrder = 'newest' THEN post.postDate END DESC

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/search/SearchEvent.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/search/SearchEvent.kt
@@ -19,20 +19,33 @@ package dev.sasikanth.rss.reader.search
 import androidx.compose.ui.text.input.TextFieldValue
 import dev.sasikanth.rss.reader.core.model.local.ResolvedPost
 import dev.sasikanth.rss.reader.core.model.local.SearchSortOrder
+import dev.sasikanth.rss.reader.core.model.local.Source
 
 sealed interface SearchEvent {
 
   data class SearchQueryChanged(val query: TextFieldValue) : SearchEvent
 
-  data class SearchPosts(val query: String, val searchSortOrder: SearchSortOrder) : SearchEvent
+  data class SearchPosts(
+    val query: String,
+    val searchSortOrder: SearchSortOrder,
+    val sourceIds: List<String> = emptyList(),
+    val onlyBookmarked: Boolean = false,
+    val onlyUnread: Boolean = false,
+  ) : SearchEvent
 
   data object ClearSearchResults : SearchEvent
 
   data class SearchSortOrderChanged(val searchSortOrder: SearchSortOrder) : SearchEvent
+
+  data class OnOnlyBookmarkedChanged(val onlyBookmarked: Boolean) : SearchEvent
+
+  data class OnOnlyUnreadChanged(val onlyUnread: Boolean) : SearchEvent
 
   data object ClearSearchQuery : SearchEvent
 
   data class OnPostBookmarkClick(val post: ResolvedPost) : SearchEvent
 
   data class UpdatePostReadStatus(val postId: String, val updatedReadStatus: Boolean) : SearchEvent
+
+  data class OnSourceChanged(val source: Source?) : SearchEvent
 }

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/search/SearchState.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/search/SearchState.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.Immutable
 import app.cash.paging.PagingData
 import dev.sasikanth.rss.reader.core.model.local.ResolvedPost
 import dev.sasikanth.rss.reader.core.model.local.SearchSortOrder
+import dev.sasikanth.rss.reader.core.model.local.Source
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 
@@ -28,6 +29,9 @@ data class SearchState(
   val searchResults: Flow<PagingData<ResolvedPost>>,
   val searchInProgress: Boolean,
   val searchSortOrder: SearchSortOrder,
+  val selectedSource: Source?,
+  val onlyBookmarked: Boolean,
+  val onlyUnread: Boolean,
 ) {
 
   companion object {
@@ -36,6 +40,9 @@ data class SearchState(
         searchResults = emptyFlow(),
         searchInProgress = false,
         searchSortOrder = SearchSortOrder.Newest,
+        selectedSource = null,
+        onlyBookmarked = false,
+        onlyUnread = false,
       )
   }
 
@@ -44,5 +51,8 @@ data class SearchState(
       searchResults = emptyFlow(),
       searchInProgress = false,
       searchSortOrder = SearchSortOrder.Newest,
+      selectedSource = null,
+      onlyBookmarked = false,
+      onlyUnread = false,
     )
 }

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/search/ui/SearchScreen.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/search/ui/SearchScreen.kt
@@ -105,6 +105,7 @@ import dev.sasikanth.rss.reader.core.model.local.SearchSortOrder.Oldest
 import dev.sasikanth.rss.reader.core.model.local.Source
 import dev.sasikanth.rss.reader.feeds.ui.FeedGroupIconGrid
 import dev.sasikanth.rss.reader.home.ui.PostListItem
+import dev.sasikanth.rss.reader.home.ui.PostListKey
 import dev.sasikanth.rss.reader.home.ui.PostMetadataConfig
 import dev.sasikanth.rss.reader.platform.LocalLinkHandler
 import dev.sasikanth.rss.reader.resources.icons.All
@@ -231,10 +232,21 @@ internal fun SearchScreen(
             }
           }
 
-          items(count = searchResults.itemCount) { index ->
+          items(
+            count = searchResults.itemCount,
+            key = { index ->
+              val post = searchResults[index]
+              if (post != null) {
+                PostListKey.from(post)
+              } else {
+                index
+              }
+            },
+          ) { index ->
             val post = searchResults[index]
             if (post != null) {
               PostListItem(
+                modifier = Modifier.animateItem(),
                 item = post,
                 onClick = {
                   openPost(


### PR DESCRIPTION
This PR adds support for filtering search results by bookmarked and unread status. 

### Changes:
- **Data Layer:** Updated SQL queries and repository to support  and  filters.
- **ViewModel/State:** Added filter states and handled corresponding events to trigger filtered searches.
- **UI:** Introduced filter chips for Bookmarks and Unread status in the search screen.

fixes: #1120 