### PR TITLE
Allow reader customizations for all users and lock premium fonts

### DIFF
--- a/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/repository/SettingsRepository.kt
+++ b/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/repository/SettingsRepository.kt
@@ -374,17 +374,18 @@ enum class HomeViewMode {
 
 enum class ReaderFont(val value: String) {
   ComicNeue("Comic Neue"),
-  GoogleSans("Google Sans"),
   Golos("Golos Text"),
+  RobotoSerif("Roboto Serif"),
+  GoogleSans("Google Sans"),
   Lora("Lora"),
   Merriweather("Merriweather"),
-  RobotoSerif("Roboto Serif"),
 }
 
 val ReaderFont.isPremium: Boolean
   get() =
     when (this) {
+      ReaderFont.Lora -> true
+      ReaderFont.Merriweather -> true
       ReaderFont.GoogleSans -> true
-      ReaderFont.RobotoSerif -> true
       else -> false
     }

--- a/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/repository/SettingsRepository.kt
+++ b/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/repository/SettingsRepository.kt
@@ -380,3 +380,11 @@ enum class ReaderFont(val value: String) {
   Merriweather("Merriweather"),
   RobotoSerif("Roboto Serif"),
 }
+
+val ReaderFont.isPremium: Boolean
+  get() =
+    when (this) {
+      ReaderFont.GoogleSans -> true
+      ReaderFont.RobotoSerif -> true
+      else -> false
+    }

--- a/resources/icons/src/commonMain/kotlin/dev/sasikanth/rss/reader/resources/icons/StarShine.kt
+++ b/resources/icons/src/commonMain/kotlin/dev/sasikanth/rss/reader/resources/icons/StarShine.kt
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2026 Sasikanth Miriyampalli
+ *
+ * Licensed under the GPL, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package dev.sasikanth.rss.reader.resources.icons
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType.Companion.NonZero
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap.Companion.Butt
+import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.group
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+
+public val TwineIcons.StarShine: ImageVector
+  get() {
+    if (_starShine != null) {
+      return _starShine!!
+    }
+    _starShine =
+      ImageVector.Builder(
+          name = "StarShine",
+          defaultWidth = 24.0.dp,
+          defaultHeight = 24.0.dp,
+          viewportWidth = 960.0f,
+          viewportHeight = 960.0f,
+        )
+        .apply {
+          group(translationX = -0.0f, translationY = 960.0f) {
+            path(
+              fill = SolidColor(Color(0xFF000000)),
+              stroke = null,
+              strokeLineWidth = 0.0f,
+              strokeLineCap = Butt,
+              strokeLineJoin = Miter,
+              strokeLineMiter = 4.0f,
+              pathFillType = NonZero,
+            ) {
+              /* pathData = "M788.5-372q16.5 0 28.5 12l63 64q12 12 12 28t-12 28q-12 12-28 12t-28-12l-64-63q-12-12-12-28.5t12-28.5q12-12 28.5-12ZM812-811.5q0 16.5-12 28.5l-63 63q-12 12-28.5 12T680-720q-12-12-12-28.5t12-28.5l64-63q12-12 28-12t28 12q12 12 12 28.5ZM188.5-852q16.5 0 28.5 12l63 64q12 12 12 28t-12 28q-12 12-28.5 12T223-720l-63-63q-12-12-12-28.5t12-28.5q12-12 28.5-12ZM212-331.5q0 16.5-12 28.5l-63 63q-12 12-28.5 12T80-240q-12-12-12-28.5T80-297l64-63q12-12 28-12t28 12q12 12 12 28.5ZM354-287l126-76 126 77-33-144 111-96-146-13-58-136-58 135-146 13 111 97-33 143Zm126-194Zm0 212L314-169q-11 7-23 6t-21-8q-9-7-14-17.5t-2-23.5l44-189-147-127q-10-9-12.5-20.5T140-571q4-11 12-18t22-9l194-17 75-178q5-12 15.5-18t21.5-6q11 0 21.5 6t15.5 18l75 178 194 17q14 2 22 9t12 18q4 11 1.5 22.5T809-528L662-401l44 189q3 13-2 23.5T690-171q-9 7-21 8t-23-6L480-269Z" */
+              moveTo(788.5f, -372.0f)
+              quadToRelative(16.5f, 0.0f, 28.5f, 12.0f)
+              lineToRelative(63.0f, 64.0f)
+              quadToRelative(12.0f, 12.0f, 12.0f, 28.0f)
+              reflectiveQuadToRelative(-12.0f, 28.0f)
+              quadToRelative(-12.0f, 12.0f, -28.0f, 12.0f)
+              reflectiveQuadToRelative(-28.0f, -12.0f)
+              lineToRelative(-64.0f, -63.0f)
+              quadToRelative(-12.0f, -12.0f, -12.0f, -28.5f)
+              reflectiveQuadToRelative(12.0f, -28.5f)
+              quadToRelative(12.0f, -12.0f, 28.5f, -12.0f)
+              close()
+              moveTo(812.0f, -811.5f)
+              quadToRelative(0.0f, 16.5f, -12.0f, 28.5f)
+              lineToRelative(-63.0f, 63.0f)
+              quadToRelative(-12.0f, 12.0f, -28.5f, 12.0f)
+              reflectiveQuadTo(680.0f, -720.0f)
+              quadToRelative(-12.0f, -12.0f, -12.0f, -28.5f)
+              reflectiveQuadToRelative(12.0f, -28.5f)
+              lineToRelative(64.0f, -63.0f)
+              quadToRelative(12.0f, -12.0f, 28.0f, -12.0f)
+              reflectiveQuadToRelative(28.0f, 12.0f)
+              quadToRelative(12.0f, 12.0f, 12.0f, 28.5f)
+              close()
+              moveTo(188.5f, -852.0f)
+              quadToRelative(16.5f, 0.0f, 28.5f, 12.0f)
+              lineToRelative(63.0f, 64.0f)
+              quadToRelative(12.0f, 12.0f, 12.0f, 28.0f)
+              reflectiveQuadToRelative(-12.0f, 28.0f)
+              quadToRelative(-12.0f, 12.0f, -28.5f, 12.0f)
+              reflectiveQuadTo(223.0f, -720.0f)
+              lineToRelative(-63.0f, -63.0f)
+              quadToRelative(-12.0f, -12.0f, -12.0f, -28.5f)
+              reflectiveQuadToRelative(12.0f, -28.5f)
+              quadToRelative(12.0f, -12.0f, 28.5f, -12.0f)
+              close()
+              moveTo(212.0f, -331.5f)
+              quadToRelative(0.0f, 16.5f, -12.0f, 28.5f)
+              lineToRelative(-63.0f, 63.0f)
+              quadToRelative(-12.0f, 12.0f, -28.5f, 12.0f)
+              reflectiveQuadTo(80.0f, -240.0f)
+              quadToRelative(-12.0f, -12.0f, -12.0f, -28.5f)
+              reflectiveQuadTo(80.0f, -297.0f)
+              lineToRelative(64.0f, -63.0f)
+              quadToRelative(12.0f, -12.0f, 28.0f, -12.0f)
+              reflectiveQuadToRelative(28.0f, 12.0f)
+              quadToRelative(12.0f, 12.0f, 12.0f, 28.5f)
+              close()
+              moveTo(354.0f, -287.0f)
+              lineToRelative(126.0f, -76.0f)
+              lineToRelative(126.0f, 77.0f)
+              lineToRelative(-33.0f, -144.0f)
+              lineToRelative(111.0f, -96.0f)
+              lineToRelative(-146.0f, -13.0f)
+              lineToRelative(-58.0f, -136.0f)
+              lineToRelative(-58.0f, 135.0f)
+              lineToRelative(-146.0f, 13.0f)
+              lineToRelative(111.0f, 97.0f)
+              lineToRelative(-33.0f, 143.0f)
+              close()
+              moveToRelative(126.0f, -194.0f)
+              close()
+              moveToRelative(0.0f, 212.0f)
+              lineTo(314.0f, -169.0f)
+              quadToRelative(-11.0f, 7.0f, -23.0f, 6.0f)
+              reflectiveQuadToRelative(-21.0f, -8.0f)
+              quadToRelative(-9.0f, -7.0f, -14.0f, -17.5f)
+              reflectiveQuadToRelative(-2.0f, -23.5f)
+              lineToRelative(44.0f, -189.0f)
+              lineToRelative(-147.0f, -127.0f)
+              quadToRelative(-10.0f, -9.0f, -12.5f, -20.5f)
+              reflectiveQuadTo(140.0f, -571.0f)
+              quadToRelative(4.0f, -11.0f, 12.0f, -18.0f)
+              reflectiveQuadToRelative(22.0f, -9.0f)
+              lineToRelative(194.0f, -17.0f)
+              lineToRelative(75.0f, -178.0f)
+              quadToRelative(5.0f, -12.0f, 15.5f, -18.0f)
+              reflectiveQuadToRelative(21.5f, -6.0f)
+              quadToRelative(11.0f, 0.0f, 21.5f, 6.0f)
+              reflectiveQuadToRelative(15.5f, 18.0f)
+              lineToRelative(75.0f, 178.0f)
+              lineToRelative(194.0f, 17.0f)
+              quadToRelative(14.0f, 2.0f, 22.0f, 9.0f)
+              reflectiveQuadToRelative(12.0f, 18.0f)
+              quadToRelative(4.0f, 11.0f, 1.5f, 22.5f)
+              reflectiveQuadTo(809.0f, -528.0f)
+              lineTo(662.0f, -401.0f)
+              lineToRelative(44.0f, 189.0f)
+              quadToRelative(3.0f, 13.0f, -2.0f, 23.5f)
+              reflectiveQuadTo(690.0f, -171.0f)
+              quadToRelative(-9.0f, 7.0f, -21.0f, 8.0f)
+              reflectiveQuadToRelative(-23.0f, -6.0f)
+              lineTo(480.0f, -269.0f)
+              close()
+            }
+          }
+        }
+        .build()
+    return _starShine!!
+  }
+
+private var _starShine: ImageVector? = null

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/reader/ReaderState.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/reader/ReaderState.kt
@@ -34,6 +34,7 @@ data class ReaderState(
   val readerFontScaleFactor: Float,
   val readerLineHeightScaleFactor: Float,
   val openPaywall: Boolean,
+  val isSubscribed: Boolean,
 ) {
 
   companion object {
@@ -48,6 +49,7 @@ data class ReaderState(
         readerFontScaleFactor = 1f,
         readerLineHeightScaleFactor = 1f,
         openPaywall = false,
+        isSubscribed = false,
       )
     }
   }

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/reader/ui/ReaderCustomizationsContent.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/reader/ui/ReaderCustomizationsContent.kt
@@ -41,7 +41,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.FormatLineSpacing
 import androidx.compose.material.icons.rounded.FormatSize
-import androidx.compose.material.icons.rounded.Lock
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Slider
@@ -66,6 +65,7 @@ import dev.sasikanth.rss.reader.data.repository.ReaderFont.Merriweather
 import dev.sasikanth.rss.reader.data.repository.ReaderFont.RobotoSerif
 import dev.sasikanth.rss.reader.data.repository.isPremium
 import dev.sasikanth.rss.reader.resources.icons.CustomTypography
+import dev.sasikanth.rss.reader.resources.icons.StarShine
 import dev.sasikanth.rss.reader.resources.icons.TwineIcons
 import dev.sasikanth.rss.reader.ui.AppTheme
 import dev.sasikanth.rss.reader.ui.ComicNeueFontFamily
@@ -315,7 +315,7 @@ private fun TypefaceChip(
       if (isPremium && !isSubscribed) {
         Icon(
           modifier = Modifier.requiredSize(16.dp),
-          imageVector = Icons.Rounded.Lock,
+          imageVector = TwineIcons.StarShine,
           contentDescription = null,
           tint = contentColor,
         )

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/reader/ui/ReaderCustomizationsContent.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/reader/ui/ReaderCustomizationsContent.kt
@@ -41,6 +41,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.FormatLineSpacing
 import androidx.compose.material.icons.rounded.FormatSize
+import androidx.compose.material.icons.rounded.Lock
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Slider
@@ -63,6 +64,7 @@ import dev.sasikanth.rss.reader.data.repository.ReaderFont.GoogleSans
 import dev.sasikanth.rss.reader.data.repository.ReaderFont.Lora
 import dev.sasikanth.rss.reader.data.repository.ReaderFont.Merriweather
 import dev.sasikanth.rss.reader.data.repository.ReaderFont.RobotoSerif
+import dev.sasikanth.rss.reader.data.repository.isPremium
 import dev.sasikanth.rss.reader.resources.icons.CustomTypography
 import dev.sasikanth.rss.reader.resources.icons.TwineIcons
 import dev.sasikanth.rss.reader.ui.AppTheme
@@ -83,6 +85,7 @@ internal fun ReaderCustomizationsContent(
   selectedFont: ReaderFont,
   fontScaleFactor: Float,
   fontLineHeightFactor: Float,
+  isSubscribed: Boolean,
   onFontChange: (ReaderFont) -> Unit,
   onFontScaleFactorChange: (Float) -> Unit,
   onFontLineHeightFactorChange: (Float) -> Unit,
@@ -118,6 +121,8 @@ internal fun ReaderCustomizationsContent(
           selected = fontStyle == selectedFont,
           label = fontStyle.value,
           fontFamily = fontFamily,
+          isPremium = fontStyle.isPremium,
+          isSubscribed = isSubscribed,
           onClick = { onFontChange(fontStyle) },
         )
       }
@@ -271,6 +276,8 @@ private fun CustomisationsTypefaceHeader() {
 private fun TypefaceChip(
   selected: Boolean,
   label: String,
+  isPremium: Boolean,
+  isSubscribed: Boolean,
   modifier: Modifier = Modifier,
   onClick: () -> Unit,
   fontFamily: FontFamily = FontFamily.Default,
@@ -296,12 +303,23 @@ private fun TypefaceChip(
         if (selected) AppTheme.colorScheme.inverseOnSurface else AppTheme.colorScheme.onSurface
       )
 
-    Box(
+    Row(
       modifier =
         Modifier.background(background, RoundedCornerShape(50))
-          .padding(horizontal = 20.dp, vertical = 8.dp)
+          .padding(horizontal = 20.dp, vertical = 8.dp),
+      verticalAlignment = Alignment.CenterVertically,
+      horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
       Text(text = label, color = contentColor, fontFamily = fontFamily)
+
+      if (isPremium && !isSubscribed) {
+        Icon(
+          modifier = Modifier.requiredSize(16.dp),
+          imageVector = Icons.Rounded.Lock,
+          contentDescription = null,
+          tint = contentColor,
+        )
+      }
     }
   }
 }

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/reader/ui/ReaderScreen.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/reader/ui/ReaderScreen.kt
@@ -330,6 +330,7 @@ internal fun ReaderScreen(
               selectedFont = state.selectedReaderFont,
               fontScaleFactor = state.readerFontScaleFactor,
               fontLineHeightFactor = state.readerLineHeightScaleFactor,
+              isSubscribed = state.isSubscribed,
               openInBrowserClick = {
                 coroutineScope.launch { linkHandler.openLink(readerPost.link) }
               },
@@ -463,6 +464,7 @@ private fun ReaderActionsPanel(
   selectedFont: ReaderFont,
   fontScaleFactor: Float,
   fontLineHeightFactor: Float,
+  isSubscribed: Boolean,
   openInBrowserClick: () -> Unit,
   loadFullArticleClick: () -> Unit,
   openReaderViewSettings: () -> Unit,
@@ -543,6 +545,7 @@ private fun ReaderActionsPanel(
                 selectedFont = selectedFont,
                 fontScaleFactor = fontScaleFactor,
                 fontLineHeightFactor = fontLineHeightFactor,
+                isSubscribed = isSubscribed,
                 onFontChange = onFontChange,
                 onFontScaleFactorChange = onFontScaleFactorChange,
                 onFontLineHeightFactorChange = onFontLineHeightFactorChange,

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/items/AppIconSettingItem.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/items/AppIconSettingItem.kt
@@ -37,7 +37,6 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CheckCircle
-import androidx.compose.material.icons.rounded.WorkspacePremium
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
@@ -56,6 +55,8 @@ import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import dev.sasikanth.rss.reader.app.AppIcon
+import dev.sasikanth.rss.reader.resources.icons.StarShine
+import dev.sasikanth.rss.reader.resources.icons.TwineIcons
 import dev.sasikanth.rss.reader.ui.AppTheme
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
@@ -93,7 +94,7 @@ internal fun AppIconSettingItem(
 
           Icon(
             modifier = Modifier.size(16.dp),
-            imageVector = Icons.Rounded.WorkspacePremium,
+            imageVector = TwineIcons.StarShine,
             contentDescription = null,
             tint = AppTheme.colorScheme.primary,
           )

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/items/CloudSyncSettingItem.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/items/CloudSyncSettingItem.kt
@@ -29,8 +29,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.WorkspacePremium
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -50,6 +48,7 @@ import dev.sasikanth.rss.reader.data.sync.CloudServiceProvider
 import dev.sasikanth.rss.reader.resources.icons.Dropbox
 import dev.sasikanth.rss.reader.resources.icons.Freshrss
 import dev.sasikanth.rss.reader.resources.icons.Miniflux
+import dev.sasikanth.rss.reader.resources.icons.StarShine
 import dev.sasikanth.rss.reader.resources.icons.TwineIcons
 import dev.sasikanth.rss.reader.settings.SettingsState
 import dev.sasikanth.rss.reader.ui.AppTheme
@@ -127,7 +126,7 @@ internal fun CloudSyncSettingItem(
 
               Icon(
                 modifier = Modifier.size(16.dp),
-                imageVector = Icons.Rounded.WorkspacePremium,
+                imageVector = TwineIcons.StarShine,
                 contentDescription = null,
                 tint = AppTheme.colorScheme.primary,
               )

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/items/TwinePremiumBanner.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/items/TwinePremiumBanner.kt
@@ -24,8 +24,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredSize
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.WorkspacePremium
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -34,6 +32,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import dev.sasikanth.rss.reader.billing.SubscriptionResult
+import dev.sasikanth.rss.reader.resources.icons.StarShine
+import dev.sasikanth.rss.reader.resources.icons.TwineIcons
 import dev.sasikanth.rss.reader.ui.AppTheme
 import org.jetbrains.compose.resources.stringResource
 import twine.shared.generated.resources.Res
@@ -55,7 +55,7 @@ internal fun TwinePremiumBanner(
   ) {
     Icon(
       modifier = Modifier.requiredSize(32.dp),
-      imageVector = Icons.Rounded.WorkspacePremium,
+      imageVector = TwineIcons.StarShine,
       contentDescription = null,
       tint = AppTheme.colorScheme.primary,
     )


### PR DESCRIPTION
This PR enables reader customizations for all users while locking specific fonts (Google Sans and Roboto Serif) as premium features.

Key changes:
- Removed subscription check for opening reader customizations.
- Added 'isSubscribed' state to ReaderState.
- Marked Google Sans and Roboto Serif as premium fonts.
- Added lock icon for premium fonts in the customizations UI.
- Selection of premium fonts now triggers the paywall for non-subscribed users.