### PR TITLE
Add account selection step to onboarding

### DIFF
--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -283,6 +283,12 @@
   <string name="discoveryAdded">Added</string>
   <string name="discoveryRefresh">Refresh</string>
 
+  <string name="accountSelectionTitle">Choose your account</string>
+  <string name="accountSelectionSubtitle">Select where you want to store your feeds and bookmarks.</string>
+  <string name="accountSelectionLocal">Local</string>
+  <string name="accountSelectionLocalAccount">On Device</string>
+  <string name="accountSelectionCloudSync">Cloud Sync</string>
+
   <!-- Plurals -->
   <plurals name="searchResultsCount">
     <item quantity="one">%1$d result</item>

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/accountselection/AccountSelectionEffect.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/accountselection/AccountSelectionEffect.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 Sasikanth Miriyampalli
+ *
+ * Licensed under the GPL, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package dev.sasikanth.rss.reader.accountselection
+
+sealed interface AccountSelectionEffect {
+
+  data object NavigateToDiscovery : AccountSelectionEffect
+
+  data object OpenPaywall : AccountSelectionEffect
+
+  data object OpenFreshRssLogin : AccountSelectionEffect
+
+  data object OpenMinifluxLogin : AccountSelectionEffect
+}

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/accountselection/AccountSelectionEvent.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/accountselection/AccountSelectionEvent.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Sasikanth Miriyampalli
+ *
+ * Licensed under the GPL, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package dev.sasikanth.rss.reader.accountselection
+
+import dev.sasikanth.rss.reader.data.sync.CloudServiceProvider
+
+sealed interface AccountSelectionEvent {
+  data object LocalAccountClicked : AccountSelectionEvent
+
+  data class CloudServiceClicked(val provider: CloudServiceProvider) : AccountSelectionEvent
+
+  data object ClearAuthUrl : AccountSelectionEvent
+}

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/accountselection/AccountSelectionState.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/accountselection/AccountSelectionState.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 Sasikanth Miriyampalli
+ *
+ * Licensed under the GPL, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package dev.sasikanth.rss.reader.accountselection
+
+import androidx.compose.runtime.Immutable
+import dev.sasikanth.rss.reader.core.model.local.User
+
+@Immutable
+data class AccountSelectionState(
+  val isSubscribed: Boolean,
+  val authUrlToOpen: String?,
+  val user: User?,
+) {
+  companion object {
+    val DEFAULT = AccountSelectionState(isSubscribed = false, authUrlToOpen = null, user = null)
+  }
+}

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/accountselection/AccountSelectionViewModel.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/accountselection/AccountSelectionViewModel.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026 Sasikanth Miriyampalli
+ *
+ * Licensed under the GPL, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package dev.sasikanth.rss.reader.accountselection
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dev.sasikanth.rss.reader.billing.BillingHandler
+import dev.sasikanth.rss.reader.core.model.local.ServiceType
+import dev.sasikanth.rss.reader.data.repository.RssRepository
+import dev.sasikanth.rss.reader.data.repository.SettingsRepository
+import dev.sasikanth.rss.reader.data.repository.UserRepository
+import dev.sasikanth.rss.reader.data.sync.APIServiceProvider
+import dev.sasikanth.rss.reader.data.sync.CloudServiceProvider
+import dev.sasikanth.rss.reader.data.sync.SyncCoordinator
+import dev.sasikanth.rss.reader.data.sync.auth.OAuthManager
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import me.tatarka.inject.annotations.Inject
+
+@Inject
+class AccountSelectionViewModel(
+  private val rssRepository: RssRepository,
+  private val settingsRepository: SettingsRepository,
+  private val userRepository: UserRepository,
+  private val syncCoordinator: SyncCoordinator,
+  private val oAuthManager: OAuthManager,
+  private val billingHandler: BillingHandler,
+  val availableProviders: Set<CloudServiceProvider>,
+) : ViewModel() {
+
+  private val _state = MutableStateFlow(AccountSelectionState.DEFAULT)
+  val state: StateFlow<AccountSelectionState> = _state.asStateFlow()
+
+  private val _effects = MutableSharedFlow<AccountSelectionEffect>()
+  val effects = _effects.asSharedFlow()
+
+  init {
+    viewModelScope.launch {
+      val isSubscribed = billingHandler.isSubscribed()
+      _state.update { it.copy(isSubscribed = isSubscribed) }
+    }
+
+    userRepository
+      .user()
+      .onEach { user ->
+        _state.update { it.copy(user = user) }
+        if (user != null) {
+          settingsRepository.completeOnboarding()
+        }
+      }
+      .launchIn(viewModelScope)
+  }
+
+  fun dispatch(event: AccountSelectionEvent) {
+    when (event) {
+      AccountSelectionEvent.LocalAccountClicked -> localAccountClicked()
+      is AccountSelectionEvent.CloudServiceClicked -> cloudServiceClicked(event.provider)
+      AccountSelectionEvent.ClearAuthUrl -> _state.update { it.copy(authUrlToOpen = null) }
+    }
+  }
+
+  private fun localAccountClicked() {
+    viewModelScope.launch {
+      settingsRepository.completeOnboarding()
+      _effects.emit(AccountSelectionEffect.NavigateToDiscovery)
+    }
+  }
+
+  private fun cloudServiceClicked(provider: CloudServiceProvider) {
+    viewModelScope.launch {
+      if (provider.isPremium && !_state.value.isSubscribed) {
+        _effects.emit(AccountSelectionEffect.OpenPaywall)
+        return@launch
+      }
+
+      if (provider is APIServiceProvider) {
+        when (provider.cloudService) {
+          ServiceType.FRESH_RSS -> _effects.emit(AccountSelectionEffect.OpenFreshRssLogin)
+          ServiceType.MINIFLUX -> _effects.emit(AccountSelectionEffect.OpenMinifluxLogin)
+          else -> {
+            throw IllegalStateException("Unknown cloud service type: ${provider.cloudService}")
+          }
+        }
+      } else {
+        oAuthManager.setPendingProvider(provider.cloudService)
+        val authUrl = oAuthManager.getAuthUrl(provider.cloudService)
+        _state.update { it.copy(authUrlToOpen = authUrl) }
+      }
+    }
+  }
+}

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/accountselection/ui/AccountSelectionScreen.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/accountselection/ui/AccountSelectionScreen.kt
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2026 Sasikanth Miriyampalli
+ *
+ * Licensed under the GPL, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package dev.sasikanth.rss.reader.accountselection.ui
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import dev.sasikanth.rss.reader.accountselection.AccountSelectionEffect
+import dev.sasikanth.rss.reader.accountselection.AccountSelectionEvent
+import dev.sasikanth.rss.reader.accountselection.AccountSelectionViewModel
+import dev.sasikanth.rss.reader.components.SubHeader
+import dev.sasikanth.rss.reader.core.model.local.ServiceType
+import dev.sasikanth.rss.reader.platform.LocalLinkHandler
+import dev.sasikanth.rss.reader.resources.icons.Dropbox
+import dev.sasikanth.rss.reader.resources.icons.Freshrss
+import dev.sasikanth.rss.reader.resources.icons.Home
+import dev.sasikanth.rss.reader.resources.icons.Miniflux
+import dev.sasikanth.rss.reader.resources.icons.StarShine
+import dev.sasikanth.rss.reader.resources.icons.TwineIcons
+import dev.sasikanth.rss.reader.ui.AppTheme
+import org.jetbrains.compose.resources.stringResource
+import twine.shared.generated.resources.Res
+import twine.shared.generated.resources.accountSelectionCloudSync
+import twine.shared.generated.resources.accountSelectionLocal
+import twine.shared.generated.resources.accountSelectionLocalAccount
+import twine.shared.generated.resources.accountSelectionSubtitle
+import twine.shared.generated.resources.accountSelectionTitle
+import twine.shared.generated.resources.settingsSyncDropbox
+import twine.shared.generated.resources.settingsSyncFreshRSS
+import twine.shared.generated.resources.settingsSyncMiniflux
+
+@Composable
+internal fun AccountSelectionScreen(
+  viewModel: AccountSelectionViewModel,
+  onNavigateToHome: () -> Unit,
+  onNavigateToDiscovery: () -> Unit,
+  openPaywall: () -> Unit,
+  openFreshRssLogin: () -> Unit,
+  openMinifluxLogin: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  val state by viewModel.state.collectAsStateWithLifecycle()
+  val linkHandler = LocalLinkHandler.current
+
+  LaunchedEffect(Unit) {
+    viewModel.effects.collect { effect ->
+      when (effect) {
+        AccountSelectionEffect.NavigateToDiscovery -> onNavigateToDiscovery()
+        AccountSelectionEffect.OpenPaywall -> openPaywall()
+        AccountSelectionEffect.OpenFreshRssLogin -> openFreshRssLogin()
+        AccountSelectionEffect.OpenMinifluxLogin -> openMinifluxLogin()
+      }
+    }
+  }
+
+  LaunchedEffect(state.authUrlToOpen) {
+    state.authUrlToOpen?.let { url ->
+      linkHandler.openLink(url, useInAppBrowser = true)
+      viewModel.dispatch(AccountSelectionEvent.ClearAuthUrl)
+    }
+  }
+
+  LaunchedEffect(state.user) {
+    if (state.user != null) {
+      onNavigateToHome()
+    }
+  }
+
+  Scaffold(
+    modifier = modifier,
+    containerColor = AppTheme.colorScheme.backdrop,
+    contentColor = Color.Unspecified,
+    topBar = {
+      Column(modifier = Modifier.fillMaxWidth().statusBarsPadding().padding(vertical = 16.dp)) {
+        Text(
+          modifier = Modifier.padding(horizontal = 24.dp),
+          text = stringResource(Res.string.accountSelectionTitle),
+          style = MaterialTheme.typography.headlineSmall,
+          color = AppTheme.colorScheme.onSurface,
+        )
+
+        Spacer(Modifier.size(8.dp))
+
+        Text(
+          modifier = Modifier.padding(horizontal = 24.dp),
+          text = stringResource(Res.string.accountSelectionSubtitle),
+          style = MaterialTheme.typography.bodyMedium,
+          color = AppTheme.colorScheme.onSurfaceVariant,
+        )
+      }
+    },
+  ) { padding ->
+    LazyColumn(modifier = Modifier.fillMaxSize().padding(padding)) {
+      item { SubHeader(text = stringResource(Res.string.accountSelectionLocal)) }
+
+      item {
+        AccountItem(
+          label = stringResource(Res.string.accountSelectionLocalAccount),
+          icon = TwineIcons.Home,
+          onClick = { viewModel.dispatch(AccountSelectionEvent.LocalAccountClicked) },
+        )
+      }
+
+      item {
+        HorizontalDivider(
+          modifier = Modifier.padding(vertical = 8.dp),
+          color = AppTheme.colorScheme.outlineVariant,
+        )
+      }
+
+      item { SubHeader(text = stringResource(Res.string.accountSelectionCloudSync)) }
+
+      items(viewModel.availableProviders.toList()) { provider ->
+        val label =
+          when (provider.cloudService) {
+            ServiceType.DROPBOX -> stringResource(Res.string.settingsSyncDropbox)
+            ServiceType.FRESH_RSS -> stringResource(Res.string.settingsSyncFreshRSS)
+            ServiceType.MINIFLUX -> stringResource(Res.string.settingsSyncMiniflux)
+          }
+
+        val icon =
+          when (provider.cloudService) {
+            ServiceType.DROPBOX -> TwineIcons.Dropbox
+            ServiceType.FRESH_RSS -> TwineIcons.Freshrss
+            ServiceType.MINIFLUX -> TwineIcons.Miniflux
+          }
+
+        AccountItem(
+          label = label,
+          icon = icon,
+          isPremium = provider.isPremium,
+          isSubscribed = state.isSubscribed,
+          onClick = { viewModel.dispatch(AccountSelectionEvent.CloudServiceClicked(provider)) },
+        )
+      }
+    }
+  }
+}
+
+@Composable
+private fun AccountItem(
+  label: String,
+  icon: androidx.compose.ui.graphics.vector.ImageVector,
+  onClick: () -> Unit,
+  isPremium: Boolean = false,
+  isSubscribed: Boolean = false,
+) {
+  Box(
+    modifier =
+      Modifier.clickable(onClick = onClick)
+        .fillMaxWidth()
+        .padding(horizontal = 24.dp, vertical = 16.dp)
+  ) {
+    Row(
+      horizontalArrangement = Arrangement.spacedBy(16.dp),
+      verticalAlignment = Alignment.CenterVertically,
+    ) {
+      Icon(imageVector = icon, contentDescription = null, tint = AppTheme.colorScheme.onSurface)
+
+      Row(verticalAlignment = Alignment.CenterVertically) {
+        Text(
+          text = label,
+          style = MaterialTheme.typography.titleMedium,
+          color = AppTheme.colorScheme.onSurface,
+        )
+
+        if (isPremium && !isSubscribed) {
+          Spacer(Modifier.width(8.dp))
+
+          Icon(
+            modifier = Modifier.size(16.dp),
+            imageVector = TwineIcons.StarShine,
+            contentDescription = null,
+            tint = AppTheme.colorScheme.primary,
+          )
+        }
+      }
+    }
+  }
+}

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/app/Screens.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/app/Screens.kt
@@ -26,7 +26,7 @@ sealed interface Screen {
 
   @Serializable data object Onboarding : Screen
 
-  @Serializable data object Main : Screen
+  @Serializable data class Main(val triggerSync: Boolean = false) : Screen
 
   @Serializable data object Home : Screen
 
@@ -47,6 +47,8 @@ sealed interface Screen {
   @Serializable data object Bookmarks : Screen
 
   @Serializable data object Settings : Screen
+
+  @Serializable data object AccountSelection : Screen
 
   @Serializable data class Discovery(val isFromOnboarding: Boolean = false) : Screen
 

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/ui/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/ui/HomeScreen.kt
@@ -125,6 +125,7 @@ import twine.shared.generated.resources.swipeUpGetStarted
 internal fun HomeScreen(
   viewModel: HomeViewModel,
   feedsViewModel: FeedsViewModel,
+  triggerSync: Boolean,
   openPost: (Int, ResolvedPost) -> Unit,
   openGroupSelectionSheet: () -> Unit,
   openFeedInfoSheet: (feedId: String) -> Unit,
@@ -193,6 +194,12 @@ internal fun HomeScreen(
     rememberBottomSheetScaffoldState(bottomSheetState = bottomSheetState)
   val showScrollToTop by remember { derivedStateOf { postsListState.firstVisibleItemIndex > 0 } }
   val unreadSinceLastSync = state.unreadSinceLastSync
+
+  LaunchedEffect(triggerSync) {
+    if (triggerSync) {
+      viewModel.dispatch(HomeEvent.OnSwipeToRefresh)
+    }
+  }
 
   LaunchedEffect(state.activeSource) {
     if (state.activeSource != state.prevActiveSource) {

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/onboarding/OnboardingEffect.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/onboarding/OnboardingEffect.kt
@@ -21,4 +21,6 @@ sealed interface OnboardingEffect {
   data object NavigateToHome : OnboardingEffect
 
   data object NavigateToDiscovery : OnboardingEffect
+
+  data object NavigateToAccountSelection : OnboardingEffect
 }

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/onboarding/OnboardingViewModel.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/onboarding/OnboardingViewModel.kt
@@ -27,7 +27,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import me.tatarka.inject.annotations.Inject
 
 @Inject
@@ -49,9 +48,6 @@ class OnboardingViewModel(
   }
 
   private fun getStartedClicked() {
-    viewModelScope.launch {
-      withContext(dispatchersProvider.io) { settingsRepository.completeOnboarding() }
-      _effects.emit(OnboardingEffect.NavigateToDiscovery)
-    }
+    viewModelScope.launch { _effects.emit(OnboardingEffect.NavigateToAccountSelection) }
   }
 }

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/onboarding/ui/OnboardingScreen.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/onboarding/ui/OnboardingScreen.kt
@@ -68,6 +68,7 @@ internal fun OnboardingScreen(
   viewModel: OnboardingViewModel,
   onOnboardingDone: () -> Unit,
   onNavigateToDiscovery: () -> Unit,
+  onNavigateToAccountSelection: () -> Unit,
   modifier: Modifier = Modifier,
 ) {
   val state by viewModel.state.collectAsStateWithLifecycle()
@@ -78,6 +79,7 @@ internal fun OnboardingScreen(
       when (effect) {
         OnboardingEffect.NavigateToHome -> onOnboardingDone()
         OnboardingEffect.NavigateToDiscovery -> onNavigateToDiscovery()
+        OnboardingEffect.NavigateToAccountSelection -> onNavigateToAccountSelection()
       }
     }
   }


### PR DESCRIPTION
Adds a new account selection step to the onboarding flow, allowing users to choose between a local account or cloud providers (Dropbox, FreshRSS, Miniflux). Includes automatic navigation to the home screen after cloud sign-in and an optional sync trigger on navigation.