### PR TITLE
Extract function to map source in RssRepository

### DIFF
--- a/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/repository/RssRepository.kt
+++ b/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/repository/RssRepository.kt
@@ -909,6 +909,67 @@ class RssRepository(
       .orEmpty()
   }
 
+  private fun mapToSource(
+    type: String,
+    id: String,
+    name: String,
+    icon: String?,
+    description: String?,
+    link: String?,
+    homepageLink: String?,
+    createdAt: Instant,
+    pinnedAt: Instant?,
+    lastCleanUpAt: Instant?,
+    numberOfUnreadPosts: Long,
+    feedIds: String?,
+    feedHomepageLinks: String?,
+    feedIcons: String?,
+    feedShowFavIconSettings: String?,
+    updatedAt: Instant?,
+    pinnedPosition: Double,
+    showFeedFavIcon: Boolean?,
+    remoteId: String?,
+  ): Source {
+    return if (type == "group") {
+      FeedGroup(
+        id = id,
+        name = name,
+        feedIds =
+          feedIds.orEmpty().split(Constants.GROUP_CONCAT_SEPARATOR).filterNot { it.isBlank() },
+        feedHomepageLinks =
+          feedHomepageLinks
+            ?.split(Constants.GROUP_CONCAT_SEPARATOR)
+            ?.filterNot { it.isBlank() }
+            .orEmpty(),
+        feedIconLinks =
+          feedIcons?.split(Constants.GROUP_CONCAT_SEPARATOR)?.filterNot { it.isBlank() }.orEmpty(),
+        feedShowFavIconSettings = mapToFeedShowFavIconSettings(feedShowFavIconSettings),
+        createdAt = createdAt,
+        updatedAt = updatedAt!!,
+        pinnedAt = pinnedAt,
+        numberOfUnreadPosts = numberOfUnreadPosts,
+        pinnedPosition = pinnedPosition,
+        remoteId = remoteId,
+      )
+    } else {
+      Feed(
+        id = id,
+        name = name,
+        icon = icon!!,
+        description = description!!,
+        link = link!!,
+        homepageLink = homepageLink!!,
+        createdAt = createdAt,
+        pinnedAt = pinnedAt,
+        lastCleanUpAt = lastCleanUpAt,
+        numberOfUnreadPosts = numberOfUnreadPosts,
+        pinnedPosition = pinnedPosition,
+        showFeedFavIcon = showFeedFavIcon ?: true,
+        remoteId = remoteId,
+      )
+    }
+  }
+
   suspend fun updateFeedName(newFeedName: String, feedId: String) {
     withContext(dispatchersProvider.databaseWrite) {
       feedQueries.updateFeedName(
@@ -1653,69 +1714,7 @@ class RssRepository(
       .pinnedSources(
         postsAfter = postsAfter,
         postsUpperBound = postsUpperBound,
-        mapper = {
-          type: String,
-          id: String,
-          name: String,
-          icon: String?,
-          description: String?,
-          link: String?,
-          homepageLink: String?,
-          createdAt: Instant,
-          pinnedAt: Instant?,
-          lastCleanUpAt: Instant?,
-          numberOfUnreadPosts: Long,
-          feedIds: String?,
-          feedHomepageLinks: String?,
-          feedIcons: String?,
-          feedShowFavIconSettings: String?,
-          updatedAt: Instant?,
-          pinnedPosition: Double,
-          showFeedFavIcon: Boolean?,
-          remoteId: String? ->
-          if (type == "group") {
-            FeedGroup(
-              id = id,
-              name = name,
-              feedIds =
-                feedIds.orEmpty().split(Constants.GROUP_CONCAT_SEPARATOR).filterNot {
-                  it.isBlank()
-                },
-              feedHomepageLinks =
-                feedHomepageLinks
-                  ?.split(Constants.GROUP_CONCAT_SEPARATOR)
-                  ?.filterNot { it.isBlank() }
-                  .orEmpty(),
-              feedIconLinks =
-                feedIcons
-                  ?.split(Constants.GROUP_CONCAT_SEPARATOR)
-                  ?.filterNot { it.isBlank() }
-                  .orEmpty(),
-              feedShowFavIconSettings = mapToFeedShowFavIconSettings(feedShowFavIconSettings),
-              createdAt = createdAt,
-              updatedAt = updatedAt!!,
-              pinnedAt = pinnedAt,
-              numberOfUnreadPosts = numberOfUnreadPosts,
-              pinnedPosition = pinnedPosition,
-            )
-          } else {
-            Feed(
-              id = id,
-              name = name,
-              icon = icon!!,
-              description = description!!,
-              link = link!!,
-              homepageLink = homepageLink!!,
-              createdAt = createdAt,
-              pinnedAt = pinnedAt,
-              lastCleanUpAt = lastCleanUpAt,
-              numberOfUnreadPosts = numberOfUnreadPosts,
-              pinnedPosition = pinnedPosition,
-              showFeedFavIcon = showFeedFavIcon ?: true,
-              remoteId = remoteId,
-            )
-          }
-        },
+        mapper = ::mapToSource,
       )
       .asFlow()
       .mapToList(dispatchersProvider.databaseRead)
@@ -1737,69 +1736,7 @@ class RssRepository(
           orderBy = orderBy.value,
           limit = limit,
           offset = offset,
-          mapper = {
-            type: String,
-            id: String,
-            name: String,
-            icon: String?,
-            description: String?,
-            link: String?,
-            homepageLink: String?,
-            createdAt: Instant,
-            pinnedAt: Instant?,
-            lastCleanUpAt: Instant?,
-            numberOfUnreadPosts: Long,
-            feedIds: String?,
-            feedHomepageLinks: String?,
-            feedIcons: String?,
-            feedShowFavIconSettings: String?,
-            updatedAt: Instant?,
-            pinnedPosition: Double,
-            showFeedFavIcon: Boolean?,
-            remoteId: String? ->
-            if (type == "group") {
-              FeedGroup(
-                id = id,
-                name = name,
-                feedIds =
-                  feedIds.orEmpty().split(Constants.GROUP_CONCAT_SEPARATOR).filterNot {
-                    it.isBlank()
-                  },
-                feedHomepageLinks =
-                  feedHomepageLinks
-                    ?.split(Constants.GROUP_CONCAT_SEPARATOR)
-                    ?.filterNot { it.isBlank() }
-                    .orEmpty(),
-                feedIconLinks =
-                  feedIcons
-                    ?.split(Constants.GROUP_CONCAT_SEPARATOR)
-                    ?.filterNot { it.isBlank() }
-                    .orEmpty(),
-                feedShowFavIconSettings = mapToFeedShowFavIconSettings(feedShowFavIconSettings),
-                createdAt = createdAt,
-                updatedAt = updatedAt!!,
-                pinnedAt = pinnedAt,
-                numberOfUnreadPosts = numberOfUnreadPosts,
-                pinnedPosition = pinnedPosition,
-              )
-            } else {
-              Feed(
-                id = id,
-                name = name,
-                icon = icon!!,
-                description = description!!,
-                link = link!!,
-                homepageLink = homepageLink!!,
-                createdAt = createdAt,
-                pinnedAt = pinnedAt,
-                lastCleanUpAt = lastCleanUpAt,
-                numberOfUnreadPosts = numberOfUnreadPosts,
-                pinnedPosition = pinnedPosition,
-                showFeedFavIcon = showFeedFavIcon ?: true,
-                remoteId = remoteId,
-              )
-            }
-          },
+          mapper = ::mapToSource,
         )
       },
     )
@@ -1815,69 +1752,7 @@ class RssRepository(
         postsAfter = postsAfter,
         postsUpperBound = postsUpperBound,
         id = id,
-        mapper = {
-          type: String,
-          id: String,
-          name: String,
-          icon: String?,
-          description: String?,
-          link: String?,
-          homepageLink: String?,
-          createdAt: Instant,
-          pinnedAt: Instant?,
-          lastCleanUpAt: Instant?,
-          numberOfUnreadPosts: Long,
-          feedIds: String?,
-          feedHomepageLinks: String?,
-          feedIcons: String?,
-          feedShowFavIconSettings: String?,
-          updatedAt: Instant?,
-          pinnedPosition: Double,
-          showFeedFavIcon: Boolean?,
-          remoteId: String? ->
-          if (type == "group") {
-            FeedGroup(
-              id = id,
-              name = name,
-              feedIds =
-                feedIds.orEmpty().split(Constants.GROUP_CONCAT_SEPARATOR).filterNot {
-                  it.isBlank()
-                },
-              feedHomepageLinks =
-                feedHomepageLinks
-                  ?.split(Constants.GROUP_CONCAT_SEPARATOR)
-                  ?.filterNot { it.isBlank() }
-                  .orEmpty(),
-              feedIconLinks =
-                feedIcons
-                  ?.split(Constants.GROUP_CONCAT_SEPARATOR)
-                  ?.filterNot { it.isBlank() }
-                  .orEmpty(),
-              feedShowFavIconSettings = mapToFeedShowFavIconSettings(feedShowFavIconSettings),
-              createdAt = createdAt,
-              updatedAt = updatedAt!!,
-              pinnedAt = pinnedAt,
-              numberOfUnreadPosts = numberOfUnreadPosts,
-              pinnedPosition = pinnedPosition,
-            )
-          } else {
-            Feed(
-              id = id,
-              name = name,
-              icon = icon!!,
-              description = description!!,
-              link = link!!,
-              homepageLink = homepageLink!!,
-              createdAt = createdAt,
-              pinnedAt = pinnedAt,
-              lastCleanUpAt = lastCleanUpAt,
-              numberOfUnreadPosts = numberOfUnreadPosts,
-              pinnedPosition = pinnedPosition,
-              showFeedFavIcon = showFeedFavIcon ?: true,
-              remoteId = remoteId,
-            )
-          }
-        },
+        mapper = ::mapToSource,
       )
       .asFlow()
       .mapToOneOrNull(dispatchersProvider.databaseRead)


### PR DESCRIPTION
This PR improves the maintainability of `RssRepository` by encapsulating the logic for switching between `FeedGroup` and `Feed` into a single reusable function. This reduces code duplication across multiple data retrieval methods. Additionally, it ensures that `remoteId` is consistently mapped for both `Feed` and `FeedGroup` types.

---
*PR created automatically by Jules for task [11712835063990465681](https://jules.google.com/task/11712835063990465681) started by @msasikanth*