### PR TITLE
🧹 Consolidate duplicate mapper logic in RssRepository

### DIFF
--- a/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/repository/RssRepository.kt
+++ b/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/repository/RssRepository.kt
@@ -202,49 +202,7 @@ class RssRepository(
   }
 
   fun feed(feedId: String): Feed? {
-    return feedQueries
-      .feed(
-        feedId,
-        mapper = {
-          id: String,
-          name: String,
-          icon: String,
-          description: String,
-          link: String,
-          homepageLink: String,
-          createdAt: Instant,
-          pinnedAt: Instant?,
-          lastCleanUpAt: Instant?,
-          alwaysFetchSourceArticle: Boolean,
-          pinnedPosition: Double,
-          showFeedFavIcon: Boolean,
-          lastUpdatedAt: Instant?,
-          refreshInterval: String,
-          isDeleted: Boolean,
-          hideFromAllFeeds: Boolean,
-          remoteId: String? ->
-          Feed(
-            id = id,
-            name = name,
-            icon = icon,
-            description = description,
-            homepageLink = homepageLink,
-            createdAt = createdAt,
-            link = link,
-            pinnedAt = pinnedAt,
-            lastCleanUpAt = lastCleanUpAt,
-            lastUpdatedAt = lastUpdatedAt,
-            refreshInterval = Duration.parse(refreshInterval),
-            alwaysFetchSourceArticle = alwaysFetchSourceArticle,
-            pinnedPosition = pinnedPosition,
-            showFeedFavIcon = showFeedFavIcon,
-            hideFromAllFeeds = hideFromAllFeeds,
-            isDeleted = isDeleted,
-            remoteId = remoteId,
-          )
-        },
-      )
-      .executeAsOneOrNull()
+    return feedQueries.feed(feedId, mapper = ::mapToFeed).executeAsOneOrNull()
   }
 
   suspend fun postsCountForFeed(feedId: String): Long {
@@ -583,137 +541,20 @@ class RssRepository(
 
   fun allFeeds(): Flow<List<Feed>> {
     return feedQueries
-      .allFeedsBlocking(
-        mapper = {
-          id: String,
-          name: String,
-          icon: String,
-          description: String,
-          link: String,
-          homepageLink: String,
-          createdAt: Instant,
-          pinnedAt: Instant?,
-          lastCleanUpAt: Instant?,
-          alwaysFetchSourceArticle: Boolean,
-          pinnedPosition: Double,
-          showFeedFavIcon: Boolean,
-          lastUpdatedAt: Instant?,
-          refreshInterval: String,
-          isDeleted: Boolean,
-          hideFromAllFeeds: Boolean,
-          remoteId: String? ->
-          Feed(
-            id = id,
-            name = name,
-            icon = icon,
-            description = description,
-            homepageLink = homepageLink,
-            createdAt = createdAt,
-            link = link,
-            pinnedAt = pinnedAt,
-            lastCleanUpAt = lastCleanUpAt,
-            lastUpdatedAt = lastUpdatedAt,
-            refreshInterval = Duration.parse(refreshInterval),
-            alwaysFetchSourceArticle = alwaysFetchSourceArticle,
-            pinnedPosition = pinnedPosition,
-            showFeedFavIcon = showFeedFavIcon,
-            hideFromAllFeeds = hideFromAllFeeds,
-            isDeleted = isDeleted,
-            remoteId = remoteId,
-          )
-        }
-      )
+      .allFeedsBlocking(mapper = ::mapToFeed)
       .asFlow()
       .mapToList(dispatchersProvider.databaseRead)
   }
 
   suspend fun allFeedsBlocking(): List<Feed> {
     return withContext(dispatchersProvider.databaseRead) {
-      feedQueries
-        .allFeedsBlocking(
-          mapper = {
-            id: String,
-            name: String,
-            icon: String,
-            description: String,
-            link: String,
-            homepageLink: String,
-            createdAt: Instant,
-            pinnedAt: Instant?,
-            lastCleanUpAt: Instant?,
-            alwaysFetchSourceArticle: Boolean,
-            pinnedPosition: Double,
-            showFeedFavIcon: Boolean,
-            lastUpdatedAt: Instant?,
-            refreshInterval: String,
-            isDeleted: Boolean,
-            hideFromAllFeeds: Boolean,
-            remoteId: String? ->
-            Feed(
-              id = id,
-              name = name,
-              icon = icon,
-              description = description,
-              homepageLink = homepageLink,
-              createdAt = createdAt,
-              link = link,
-              pinnedAt = pinnedAt,
-              lastCleanUpAt = lastCleanUpAt,
-              lastUpdatedAt = lastUpdatedAt,
-              refreshInterval = Duration.parse(refreshInterval),
-              alwaysFetchSourceArticle = alwaysFetchSourceArticle,
-              pinnedPosition = pinnedPosition,
-              showFeedFavIcon = showFeedFavIcon,
-              hideFromAllFeeds = hideFromAllFeeds,
-              isDeleted = isDeleted,
-              remoteId = remoteId,
-            )
-          }
-        )
-        .executeAsList()
+      feedQueries.allFeedsBlocking(mapper = ::mapToFeed).executeAsList()
     }
   }
 
   suspend fun allFeedGroupsBlocking(): List<FeedGroup> {
     return withContext(dispatchersProvider.databaseRead) {
-      feedGroupQueries
-        .allGroupsBlocking(
-          mapper = {
-            id: String,
-            name: String,
-            feedIds: String?,
-            feedHomepageLinks: String,
-            feedIconLinks: String,
-            feedShowFavIconSettings: String,
-            createdAt: Instant,
-            updatedAt: Instant,
-            pinnedAt: Instant?,
-            pinnedPosition: Double,
-            isDeleted: Boolean,
-            remoteId: String? ->
-            FeedGroup(
-              id = id,
-              name = name,
-              feedIds =
-                feedIds?.split(Constants.GROUP_CONCAT_SEPARATOR)?.filter { it.isNotBlank() }
-                  ?: emptyList(),
-              feedHomepageLinks =
-                feedHomepageLinks.split(Constants.GROUP_CONCAT_SEPARATOR).filter {
-                  it.isNotBlank()
-                },
-              feedIconLinks =
-                feedIconLinks.split(Constants.GROUP_CONCAT_SEPARATOR).filter { it.isNotBlank() },
-              feedShowFavIconSettings = mapToFeedShowFavIconSettings(feedShowFavIconSettings),
-              createdAt = createdAt,
-              updatedAt = updatedAt,
-              pinnedAt = pinnedAt,
-              pinnedPosition = pinnedPosition,
-              isDeleted = isDeleted,
-              remoteId = remoteId,
-            )
-          }
-        )
-        .executeAsList()
+      feedGroupQueries.allGroupsBlocking(mapper = ::mapToFeedGroup).executeAsList()
     }
   }
 
@@ -738,46 +579,7 @@ class RssRepository(
           postsAfter = postsAfter,
           limit = limit,
           offset = offset,
-          mapper = {
-            id,
-            name,
-            icon,
-            description,
-            link,
-            homepageLink,
-            createdAt,
-            pinnedAt,
-            lastCleanUpAt,
-            alwaysFetchSourceArticle,
-            pinnedPosition,
-            lastUpdatedAt,
-            refreshInterval,
-            isDeleted,
-            remoteId,
-            numberOfUnreadPosts,
-            showFeedFavIcon,
-            hideFromAllFeeds ->
-            Feed(
-              id = id,
-              name = name,
-              icon = icon,
-              description = description,
-              link = link,
-              homepageLink = homepageLink,
-              createdAt = createdAt,
-              pinnedAt = pinnedAt,
-              lastCleanUpAt = lastCleanUpAt,
-              alwaysFetchSourceArticle = alwaysFetchSourceArticle,
-              pinnedPosition = pinnedPosition,
-              lastUpdatedAt = lastUpdatedAt,
-              refreshInterval = Duration.parse(refreshInterval),
-              isDeleted = isDeleted,
-              remoteId = remoteId,
-              numberOfUnreadPosts = numberOfUnreadPosts,
-              showFeedFavIcon = showFeedFavIcon,
-              hideFromAllFeeds = hideFromAllFeeds,
-            )
-          },
+          mapper = ::mapToFeedWithUnreadCountAndRefreshInterval,
         )
       },
     )
@@ -793,42 +595,7 @@ class RssRepository(
         id = feedId,
         postsAfter = postsAfter,
         postsUpperBound = postsUpperBound,
-        mapper = {
-          id: String,
-          name: String,
-          icon: String,
-          description: String,
-          link: String,
-          homepageLink: String,
-          createdAt: Instant,
-          pinnedAt: Instant?,
-          lastCleanUpAt: Instant?,
-          alwaysFetchSourceArticle: Boolean,
-          pinnedPosition: Double,
-          numberOfUnreadPosts: Long,
-          showFeedFavIcon: Boolean,
-          hideFromAllFeeds: Boolean,
-          isDeleted: Boolean,
-          remoteId: String? ->
-          Feed(
-            id = id,
-            name = name,
-            icon = icon,
-            description = description,
-            homepageLink = homepageLink,
-            createdAt = createdAt,
-            link = link,
-            pinnedAt = pinnedAt,
-            lastCleanUpAt = lastCleanUpAt,
-            alwaysFetchSourceArticle = alwaysFetchSourceArticle,
-            pinnedPosition = pinnedPosition,
-            numberOfUnreadPosts = numberOfUnreadPosts,
-            showFeedFavIcon = showFeedFavIcon,
-            hideFromAllFeeds = hideFromAllFeeds,
-            isDeleted = isDeleted,
-            remoteId = remoteId,
-          )
-        },
+        mapper = ::mapToFeedWithUnreadCount,
       )
       .asFlow()
       .mapToOne(dispatchersProvider.databaseRead)
@@ -845,42 +612,7 @@ class RssRepository(
           id = feedId,
           postsAfter = postsAfter,
           postsUpperBound = postsUpperBound,
-          mapper = {
-            id: String,
-            name: String,
-            icon: String,
-            description: String,
-            link: String,
-            homepageLink: String,
-            createdAt: Instant,
-            pinnedAt: Instant?,
-            lastCleanUpAt: Instant?,
-            alwaysFetchSourceArticle: Boolean,
-            pinnedPosition: Double,
-            numberOfUnreadPosts: Long,
-            showFeedFavIcon: Boolean,
-            hideFromAllFeeds: Boolean,
-            isDeleted: Boolean,
-            remoteId: String? ->
-            Feed(
-              id = id,
-              name = name,
-              icon = icon,
-              description = description,
-              homepageLink = homepageLink,
-              createdAt = createdAt,
-              link = link,
-              pinnedAt = pinnedAt,
-              lastCleanUpAt = lastCleanUpAt,
-              alwaysFetchSourceArticle = alwaysFetchSourceArticle,
-              pinnedPosition = pinnedPosition,
-              numberOfUnreadPosts = numberOfUnreadPosts,
-              showFeedFavIcon = showFeedFavIcon,
-              hideFromAllFeeds = hideFromAllFeeds,
-              isDeleted = isDeleted,
-              remoteId = remoteId,
-            )
-          },
+          mapper = ::mapToFeedWithUnreadCount,
         )
         .executeAsOne()
     }
@@ -1317,49 +1049,7 @@ class RssRepository(
   }
 
   fun feedByRemoteId(remoteId: String): Feed? {
-    return feedQueries
-      .feedByRemoteId(
-        remoteId,
-        mapper = {
-          id: String,
-          name: String,
-          icon: String,
-          description: String,
-          link: String,
-          homepageLink: String,
-          createdAt: Instant,
-          pinnedAt: Instant?,
-          lastCleanUpAt: Instant?,
-          alwaysFetchSourceArticle: Boolean,
-          pinnedPosition: Double,
-          showFeedFavIcon: Boolean,
-          lastUpdatedAt: Instant?,
-          refreshInterval: String,
-          isDeleted: Boolean,
-          hideFromAllFeeds: Boolean,
-          remoteId: String? ->
-          Feed(
-            id = id,
-            name = name,
-            icon = icon,
-            description = description,
-            homepageLink = homepageLink,
-            createdAt = createdAt,
-            link = link,
-            pinnedAt = pinnedAt,
-            lastCleanUpAt = lastCleanUpAt,
-            lastUpdatedAt = lastUpdatedAt,
-            refreshInterval = Duration.parse(refreshInterval),
-            alwaysFetchSourceArticle = alwaysFetchSourceArticle,
-            pinnedPosition = pinnedPosition,
-            showFeedFavIcon = showFeedFavIcon,
-            hideFromAllFeeds = hideFromAllFeeds,
-            isDeleted = isDeleted,
-            remoteId = remoteId,
-          )
-        },
-      )
-      .executeAsOneOrNull()
+    return feedQueries.feedByRemoteId(remoteId, mapper = ::mapToFeed).executeAsOneOrNull()
   }
 
   suspend fun upsertPosts(posts: List<Post>) {
@@ -1437,45 +1127,7 @@ class RssRepository(
 
   suspend fun feedGroupBlocking(id: String): FeedGroup? {
     return withContext(dispatchersProvider.databaseRead) {
-      feedGroupQueries
-        .group(
-          id,
-          mapper = {
-            id: String,
-            name: String,
-            feedIds: String?,
-            feedHomepageLinks: String,
-            feedIconLinks: String,
-            feedShowFavIconSettings: String,
-            createdAt: Instant,
-            updatedAt: Instant,
-            pinnedAt: Instant?,
-            pinnedPosition: Double,
-            isDeleted: Boolean,
-            remoteId: String? ->
-            FeedGroup(
-              id = id,
-              name = name,
-              feedIds =
-                feedIds?.split(Constants.GROUP_CONCAT_SEPARATOR)?.filter { it.isNotBlank() }
-                  ?: emptyList(),
-              feedHomepageLinks =
-                feedHomepageLinks.split(Constants.GROUP_CONCAT_SEPARATOR).filter {
-                  it.isNotBlank()
-                },
-              feedIconLinks =
-                feedIconLinks.split(Constants.GROUP_CONCAT_SEPARATOR).filter { it.isNotBlank() },
-              feedShowFavIconSettings = mapToFeedShowFavIconSettings(feedShowFavIconSettings),
-              createdAt = createdAt,
-              updatedAt = updatedAt,
-              pinnedAt = pinnedAt,
-              pinnedPosition = pinnedPosition,
-              isDeleted = isDeleted,
-              remoteId = remoteId,
-            )
-          },
-        )
-        .executeAsOneOrNull()
+      feedGroupQueries.group(id, mapper = ::mapToFeedGroup).executeAsOneOrNull()
     }
   }
 
@@ -1653,69 +1305,7 @@ class RssRepository(
       .pinnedSources(
         postsAfter = postsAfter,
         postsUpperBound = postsUpperBound,
-        mapper = {
-          type: String,
-          id: String,
-          name: String,
-          icon: String?,
-          description: String?,
-          link: String?,
-          homepageLink: String?,
-          createdAt: Instant,
-          pinnedAt: Instant?,
-          lastCleanUpAt: Instant?,
-          numberOfUnreadPosts: Long,
-          feedIds: String?,
-          feedHomepageLinks: String?,
-          feedIcons: String?,
-          feedShowFavIconSettings: String?,
-          updatedAt: Instant?,
-          pinnedPosition: Double,
-          showFeedFavIcon: Boolean?,
-          remoteId: String? ->
-          if (type == "group") {
-            FeedGroup(
-              id = id,
-              name = name,
-              feedIds =
-                feedIds.orEmpty().split(Constants.GROUP_CONCAT_SEPARATOR).filterNot {
-                  it.isBlank()
-                },
-              feedHomepageLinks =
-                feedHomepageLinks
-                  ?.split(Constants.GROUP_CONCAT_SEPARATOR)
-                  ?.filterNot { it.isBlank() }
-                  .orEmpty(),
-              feedIconLinks =
-                feedIcons
-                  ?.split(Constants.GROUP_CONCAT_SEPARATOR)
-                  ?.filterNot { it.isBlank() }
-                  .orEmpty(),
-              feedShowFavIconSettings = mapToFeedShowFavIconSettings(feedShowFavIconSettings),
-              createdAt = createdAt,
-              updatedAt = updatedAt!!,
-              pinnedAt = pinnedAt,
-              numberOfUnreadPosts = numberOfUnreadPosts,
-              pinnedPosition = pinnedPosition,
-            )
-          } else {
-            Feed(
-              id = id,
-              name = name,
-              icon = icon!!,
-              description = description!!,
-              link = link!!,
-              homepageLink = homepageLink!!,
-              createdAt = createdAt,
-              pinnedAt = pinnedAt,
-              lastCleanUpAt = lastCleanUpAt,
-              numberOfUnreadPosts = numberOfUnreadPosts,
-              pinnedPosition = pinnedPosition,
-              showFeedFavIcon = showFeedFavIcon ?: true,
-              remoteId = remoteId,
-            )
-          }
-        },
+        mapper = ::mapToSource,
       )
       .asFlow()
       .mapToList(dispatchersProvider.databaseRead)
@@ -1737,69 +1327,7 @@ class RssRepository(
           orderBy = orderBy.value,
           limit = limit,
           offset = offset,
-          mapper = {
-            type: String,
-            id: String,
-            name: String,
-            icon: String?,
-            description: String?,
-            link: String?,
-            homepageLink: String?,
-            createdAt: Instant,
-            pinnedAt: Instant?,
-            lastCleanUpAt: Instant?,
-            numberOfUnreadPosts: Long,
-            feedIds: String?,
-            feedHomepageLinks: String?,
-            feedIcons: String?,
-            feedShowFavIconSettings: String?,
-            updatedAt: Instant?,
-            pinnedPosition: Double,
-            showFeedFavIcon: Boolean?,
-            remoteId: String? ->
-            if (type == "group") {
-              FeedGroup(
-                id = id,
-                name = name,
-                feedIds =
-                  feedIds.orEmpty().split(Constants.GROUP_CONCAT_SEPARATOR).filterNot {
-                    it.isBlank()
-                  },
-                feedHomepageLinks =
-                  feedHomepageLinks
-                    ?.split(Constants.GROUP_CONCAT_SEPARATOR)
-                    ?.filterNot { it.isBlank() }
-                    .orEmpty(),
-                feedIconLinks =
-                  feedIcons
-                    ?.split(Constants.GROUP_CONCAT_SEPARATOR)
-                    ?.filterNot { it.isBlank() }
-                    .orEmpty(),
-                feedShowFavIconSettings = mapToFeedShowFavIconSettings(feedShowFavIconSettings),
-                createdAt = createdAt,
-                updatedAt = updatedAt!!,
-                pinnedAt = pinnedAt,
-                numberOfUnreadPosts = numberOfUnreadPosts,
-                pinnedPosition = pinnedPosition,
-              )
-            } else {
-              Feed(
-                id = id,
-                name = name,
-                icon = icon!!,
-                description = description!!,
-                link = link!!,
-                homepageLink = homepageLink!!,
-                createdAt = createdAt,
-                pinnedAt = pinnedAt,
-                lastCleanUpAt = lastCleanUpAt,
-                numberOfUnreadPosts = numberOfUnreadPosts,
-                pinnedPosition = pinnedPosition,
-                showFeedFavIcon = showFeedFavIcon ?: true,
-                remoteId = remoteId,
-              )
-            }
-          },
+          mapper = ::mapToSource,
         )
       },
     )
@@ -1815,69 +1343,7 @@ class RssRepository(
         postsAfter = postsAfter,
         postsUpperBound = postsUpperBound,
         id = id,
-        mapper = {
-          type: String,
-          id: String,
-          name: String,
-          icon: String?,
-          description: String?,
-          link: String?,
-          homepageLink: String?,
-          createdAt: Instant,
-          pinnedAt: Instant?,
-          lastCleanUpAt: Instant?,
-          numberOfUnreadPosts: Long,
-          feedIds: String?,
-          feedHomepageLinks: String?,
-          feedIcons: String?,
-          feedShowFavIconSettings: String?,
-          updatedAt: Instant?,
-          pinnedPosition: Double,
-          showFeedFavIcon: Boolean?,
-          remoteId: String? ->
-          if (type == "group") {
-            FeedGroup(
-              id = id,
-              name = name,
-              feedIds =
-                feedIds.orEmpty().split(Constants.GROUP_CONCAT_SEPARATOR).filterNot {
-                  it.isBlank()
-                },
-              feedHomepageLinks =
-                feedHomepageLinks
-                  ?.split(Constants.GROUP_CONCAT_SEPARATOR)
-                  ?.filterNot { it.isBlank() }
-                  .orEmpty(),
-              feedIconLinks =
-                feedIcons
-                  ?.split(Constants.GROUP_CONCAT_SEPARATOR)
-                  ?.filterNot { it.isBlank() }
-                  .orEmpty(),
-              feedShowFavIconSettings = mapToFeedShowFavIconSettings(feedShowFavIconSettings),
-              createdAt = createdAt,
-              updatedAt = updatedAt!!,
-              pinnedAt = pinnedAt,
-              numberOfUnreadPosts = numberOfUnreadPosts,
-              pinnedPosition = pinnedPosition,
-            )
-          } else {
-            Feed(
-              id = id,
-              name = name,
-              icon = icon!!,
-              description = description!!,
-              link = link!!,
-              homepageLink = homepageLink!!,
-              createdAt = createdAt,
-              pinnedAt = pinnedAt,
-              lastCleanUpAt = lastCleanUpAt,
-              numberOfUnreadPosts = numberOfUnreadPosts,
-              pinnedPosition = pinnedPosition,
-              showFeedFavIcon = showFeedFavIcon ?: true,
-              remoteId = remoteId,
-            )
-          }
-        },
+        mapper = ::mapToSource,
       )
       .asFlow()
       .mapToOneOrNull(dispatchersProvider.databaseRead)
@@ -1892,39 +1358,7 @@ class RssRepository(
         feedGroupQueries.groups(
           limit = limit,
           offset = offset,
-          mapper = {
-            id: String,
-            name: String,
-            feedIds: String?,
-            feedHomepageLinks: String,
-            feedIcons: String,
-            feedShowFavIconSettings: String,
-            createdAt: Instant,
-            updatedAt: Instant,
-            pinnedAt: Instant?,
-            pinnedPosition: Double,
-            remoteId: String? ->
-            FeedGroup(
-              id = id,
-              name = name,
-              feedIds =
-                feedIds.orEmpty().split(Constants.GROUP_CONCAT_SEPARATOR).filterNot {
-                  it.isBlank()
-                },
-              feedHomepageLinks =
-                feedHomepageLinks.split(Constants.GROUP_CONCAT_SEPARATOR).filterNot {
-                  it.isBlank()
-                },
-              feedIconLinks =
-                feedIcons.split(Constants.GROUP_CONCAT_SEPARATOR).filterNot { it.isBlank() },
-              feedShowFavIconSettings = mapToFeedShowFavIconSettings(feedShowFavIconSettings),
-              createdAt = createdAt,
-              updatedAt = updatedAt,
-              pinnedAt = pinnedAt,
-              pinnedPosition = pinnedPosition,
-              remoteId = remoteId,
-            )
-          },
+          mapper = ::mapToFeedGroupFromGroups,
         )
       },
     )
@@ -1936,77 +1370,13 @@ class RssRepository(
 
   suspend fun groupByIds(ids: Set<String>): List<FeedGroup> {
     return withContext(dispatchersProvider.databaseRead) {
-      feedGroupQueries
-        .groupsByIds(
-          ids = ids,
-          mapper = {
-            id: String,
-            name: String,
-            feedIds: String?,
-            feedHomepageLinks: String,
-            feedIcons: String,
-            feedShowFavIconSettings: String,
-            createdAt: Instant,
-            updatedAt: Instant,
-            pinnedAt: Instant?,
-            remoteId: String? ->
-            FeedGroup(
-              id = id,
-              name = name,
-              feedIds =
-                feedIds.orEmpty().split(Constants.GROUP_CONCAT_SEPARATOR).filterNot {
-                  it.isBlank()
-                },
-              feedHomepageLinks =
-                feedHomepageLinks.split(Constants.GROUP_CONCAT_SEPARATOR).filterNot {
-                  it.isBlank()
-                },
-              feedIconLinks =
-                feedIcons.split(Constants.GROUP_CONCAT_SEPARATOR).filterNot { it.isBlank() },
-              feedShowFavIconSettings = mapToFeedShowFavIconSettings(feedShowFavIconSettings),
-              createdAt = createdAt,
-              updatedAt = updatedAt,
-              pinnedAt = pinnedAt,
-              remoteId = remoteId,
-            )
-          },
-        )
-        .executeAsList()
+      feedGroupQueries.groupsByIds(ids = ids, mapper = ::mapToFeedGroupFromGroupsByIds).executeAsList()
     }
   }
 
   fun groupById(groupId: String): Flow<FeedGroup> {
     return feedGroupQueries
-      .groupsByIds(
-        ids = setOf(groupId),
-        mapper = {
-          id: String,
-          name: String,
-          feedIds: String?,
-          feedHomepageLinks: String,
-          feedIcons: String,
-          feedShowFavIconSettings: String,
-          createdAt: Instant,
-          updatedAt: Instant,
-          pinnedAt: Instant?,
-          remoteId: String? ->
-          FeedGroup(
-            id = id,
-            name = name,
-            feedIds =
-              feedIds.orEmpty().split(Constants.GROUP_CONCAT_SEPARATOR).filterNot { it.isBlank() },
-            feedHomepageLinks =
-              feedHomepageLinks.split(Constants.GROUP_CONCAT_SEPARATOR).filterNot { it.isBlank() },
-            feedIconLinks =
-              feedIcons.split(Constants.GROUP_CONCAT_SEPARATOR).filterNot { it.isBlank() },
-            feedShowFavIconSettings = mapToFeedShowFavIconSettings(feedShowFavIconSettings),
-            createdAt = createdAt,
-            updatedAt = updatedAt,
-            pinnedAt = pinnedAt,
-            remoteId = remoteId,
-          )
-        },
-      )
+      .groupsByIds(ids = setOf(groupId), mapper = ::mapToFeedGroupFromGroupsByIds)
       .asFlow()
       .mapToOne(dispatchersProvider.databaseRead)
   }
@@ -2025,42 +1395,7 @@ class RssRepository(
           orderBy = orderBy.value,
           limit = limit,
           offset = offset,
-          mapper = {
-            id: String,
-            name: String,
-            icon: String,
-            description: String,
-            link: String,
-            homepageLink: String,
-            createdAt: Instant,
-            pinnedAt: Instant?,
-            lastCleanUpAt: Instant?,
-            alwaysFetchSourceArticle: Boolean,
-            pinnedPosition: Double,
-            numberOfUnreadPosts: Long,
-            showFeedFavIcon: Boolean,
-            hideFromAllFeeds: Boolean,
-            isDeleted: Boolean,
-            remoteId: String? ->
-            Feed(
-              id = id,
-              name = name,
-              icon = icon,
-              description = description,
-              link = link,
-              homepageLink = homepageLink,
-              createdAt = createdAt,
-              pinnedAt = pinnedAt,
-              lastCleanUpAt = lastCleanUpAt,
-              alwaysFetchSourceArticle = alwaysFetchSourceArticle,
-              pinnedPosition = pinnedPosition,
-              numberOfUnreadPosts = numberOfUnreadPosts,
-              showFeedFavIcon = showFeedFavIcon,
-              hideFromAllFeeds = hideFromAllFeeds,
-              isDeleted = isDeleted,
-              remoteId = remoteId,
-            )
-          },
+          mapper = ::mapToFeedWithUnreadCount,
         )
       },
     )
@@ -2160,6 +1495,275 @@ class RssRepository(
         )
       )
     }
+  }
+
+  private fun mapToFeed(
+    id: String,
+    name: String,
+    icon: String,
+    description: String,
+    link: String,
+    homepageLink: String,
+    createdAt: Instant,
+    pinnedAt: Instant?,
+    lastCleanUpAt: Instant?,
+    alwaysFetchSourceArticle: Boolean,
+    pinnedPosition: Double,
+    showFeedFavIcon: Boolean,
+    lastUpdatedAt: Instant?,
+    refreshInterval: String,
+    isDeleted: Boolean,
+    hideFromAllFeeds: Boolean,
+    remoteId: String?,
+  ): Feed {
+    return Feed(
+      id = id,
+      name = name,
+      icon = icon,
+      description = description,
+      homepageLink = homepageLink,
+      createdAt = createdAt,
+      link = link,
+      pinnedAt = pinnedAt,
+      lastCleanUpAt = lastCleanUpAt,
+      lastUpdatedAt = lastUpdatedAt,
+      refreshInterval = Duration.parse(refreshInterval),
+      alwaysFetchSourceArticle = alwaysFetchSourceArticle,
+      pinnedPosition = pinnedPosition,
+      showFeedFavIcon = showFeedFavIcon,
+      hideFromAllFeeds = hideFromAllFeeds,
+      isDeleted = isDeleted,
+      remoteId = remoteId,
+    )
+  }
+
+  private fun mapToFeedWithUnreadCount(
+    id: String,
+    name: String,
+    icon: String,
+    description: String,
+    link: String,
+    homepageLink: String,
+    createdAt: Instant,
+    pinnedAt: Instant?,
+    lastCleanUpAt: Instant?,
+    alwaysFetchSourceArticle: Boolean,
+    pinnedPosition: Double,
+    numberOfUnreadPosts: Long,
+    showFeedFavIcon: Boolean,
+    hideFromAllFeeds: Boolean,
+    isDeleted: Boolean,
+    remoteId: String?,
+  ): Feed {
+    return Feed(
+      id = id,
+      name = name,
+      icon = icon,
+      description = description,
+      homepageLink = homepageLink,
+      createdAt = createdAt,
+      link = link,
+      pinnedAt = pinnedAt,
+      lastCleanUpAt = lastCleanUpAt,
+      alwaysFetchSourceArticle = alwaysFetchSourceArticle,
+      pinnedPosition = pinnedPosition,
+      numberOfUnreadPosts = numberOfUnreadPosts,
+      showFeedFavIcon = showFeedFavIcon,
+      hideFromAllFeeds = hideFromAllFeeds,
+      isDeleted = isDeleted,
+      remoteId = remoteId,
+    )
+  }
+
+  private fun mapToFeedWithUnreadCountAndRefreshInterval(
+    id: String,
+    name: String,
+    icon: String,
+    description: String,
+    link: String,
+    homepageLink: String,
+    createdAt: Instant,
+    pinnedAt: Instant?,
+    lastCleanUpAt: Instant?,
+    alwaysFetchSourceArticle: Boolean,
+    pinnedPosition: Double,
+    lastUpdatedAt: Instant?,
+    refreshInterval: String,
+    isDeleted: Boolean,
+    remoteId: String?,
+    numberOfUnreadPosts: Long,
+    showFeedFavIcon: Boolean,
+    hideFromAllFeeds: Boolean,
+  ): Feed {
+    return Feed(
+      id = id,
+      name = name,
+      icon = icon,
+      description = description,
+      link = link,
+      homepageLink = homepageLink,
+      createdAt = createdAt,
+      pinnedAt = pinnedAt,
+      lastCleanUpAt = lastCleanUpAt,
+      alwaysFetchSourceArticle = alwaysFetchSourceArticle,
+      pinnedPosition = pinnedPosition,
+      lastUpdatedAt = lastUpdatedAt,
+      refreshInterval = Duration.parse(refreshInterval),
+      isDeleted = isDeleted,
+      remoteId = remoteId,
+      numberOfUnreadPosts = numberOfUnreadPosts,
+      showFeedFavIcon = showFeedFavIcon,
+      hideFromAllFeeds = hideFromAllFeeds,
+    )
+  }
+
+  private fun mapToSource(
+    type: String,
+    id: String,
+    name: String,
+    icon: String?,
+    description: String?,
+    link: String?,
+    homepageLink: String?,
+    createdAt: Instant,
+    pinnedAt: Instant?,
+    lastCleanUpAt: Instant?,
+    numberOfUnreadPosts: Long,
+    feedIds: String?,
+    feedHomepageLinks: String?,
+    feedIcons: String?,
+    feedShowFavIconSettings: String?,
+    updatedAt: Instant?,
+    pinnedPosition: Double,
+    showFeedFavIcon: Boolean?,
+    remoteId: String?,
+  ): Source {
+    return if (type == "group") {
+      FeedGroup(
+        id = id,
+        name = name,
+        feedIds =
+          feedIds.orEmpty().split(Constants.GROUP_CONCAT_SEPARATOR).filterNot { it.isBlank() },
+        feedHomepageLinks =
+          feedHomepageLinks?.split(Constants.GROUP_CONCAT_SEPARATOR)?.filterNot { it.isBlank() }
+            .orEmpty(),
+        feedIconLinks =
+          feedIcons?.split(Constants.GROUP_CONCAT_SEPARATOR)?.filterNot { it.isBlank() }.orEmpty(),
+        feedShowFavIconSettings = mapToFeedShowFavIconSettings(feedShowFavIconSettings),
+        createdAt = createdAt,
+        updatedAt = updatedAt!!,
+        pinnedAt = pinnedAt,
+        numberOfUnreadPosts = numberOfUnreadPosts,
+        pinnedPosition = pinnedPosition,
+      )
+    } else {
+      Feed(
+        id = id,
+        name = name,
+        icon = icon!!,
+        description = description!!,
+        link = link!!,
+        homepageLink = homepageLink!!,
+        createdAt = createdAt,
+        pinnedAt = pinnedAt,
+        lastCleanUpAt = lastCleanUpAt,
+        numberOfUnreadPosts = numberOfUnreadPosts,
+        pinnedPosition = pinnedPosition,
+        showFeedFavIcon = showFeedFavIcon ?: true,
+        remoteId = remoteId,
+      )
+    }
+  }
+
+  private fun mapToFeedGroup(
+    id: String,
+    name: String,
+    feedIds: String?,
+    feedHomepageLinks: String,
+    feedIconLinks: String,
+    feedShowFavIconSettings: String,
+    createdAt: Instant,
+    updatedAt: Instant,
+    pinnedAt: Instant?,
+    pinnedPosition: Double,
+    isDeleted: Boolean,
+    remoteId: String?,
+  ): FeedGroup {
+    return FeedGroup(
+      id = id,
+      name = name,
+      feedIds =
+        feedIds?.split(Constants.GROUP_CONCAT_SEPARATOR)?.filter { it.isNotBlank() } ?: emptyList(),
+      feedHomepageLinks =
+        feedHomepageLinks.split(Constants.GROUP_CONCAT_SEPARATOR).filter { it.isNotBlank() },
+      feedIconLinks =
+        feedIconLinks.split(Constants.GROUP_CONCAT_SEPARATOR).filter { it.isNotBlank() },
+      feedShowFavIconSettings = mapToFeedShowFavIconSettings(feedShowFavIconSettings),
+      createdAt = createdAt,
+      updatedAt = updatedAt,
+      pinnedAt = pinnedAt,
+      pinnedPosition = pinnedPosition,
+      isDeleted = isDeleted,
+      remoteId = remoteId,
+    )
+  }
+
+  private fun mapToFeedGroupFromGroups(
+    id: String,
+    name: String,
+    feedIds: String?,
+    feedHomepageLinks: String,
+    feedIcons: String,
+    feedShowFavIconSettings: String,
+    createdAt: Instant,
+    updatedAt: Instant,
+    pinnedAt: Instant?,
+    pinnedPosition: Double,
+    remoteId: String?,
+  ): FeedGroup {
+    return FeedGroup(
+      id = id,
+      name = name,
+      feedIds =
+        feedIds.orEmpty().split(Constants.GROUP_CONCAT_SEPARATOR).filterNot { it.isBlank() },
+      feedHomepageLinks =
+        feedHomepageLinks.split(Constants.GROUP_CONCAT_SEPARATOR).filterNot { it.isBlank() },
+      feedIconLinks = feedIcons.split(Constants.GROUP_CONCAT_SEPARATOR).filterNot { it.isBlank() },
+      feedShowFavIconSettings = mapToFeedShowFavIconSettings(feedShowFavIconSettings),
+      createdAt = createdAt,
+      updatedAt = updatedAt,
+      pinnedAt = pinnedAt,
+      pinnedPosition = pinnedPosition,
+      remoteId = remoteId,
+    )
+  }
+
+  private fun mapToFeedGroupFromGroupsByIds(
+    id: String,
+    name: String,
+    feedIds: String?,
+    feedHomepageLinks: String,
+    feedIcons: String,
+    feedShowFavIconSettings: String,
+    createdAt: Instant,
+    updatedAt: Instant,
+    pinnedAt: Instant?,
+    remoteId: String?,
+  ): FeedGroup {
+    return FeedGroup(
+      id = id,
+      name = name,
+      feedIds =
+        feedIds.orEmpty().split(Constants.GROUP_CONCAT_SEPARATOR).filterNot { it.isBlank() },
+      feedHomepageLinks =
+        feedHomepageLinks.split(Constants.GROUP_CONCAT_SEPARATOR).filterNot { it.isBlank() },
+      feedIconLinks = feedIcons.split(Constants.GROUP_CONCAT_SEPARATOR).filterNot { it.isBlank() },
+      feedShowFavIconSettings = mapToFeedShowFavIconSettings(feedShowFavIconSettings),
+      createdAt = createdAt,
+      updatedAt = updatedAt,
+      pinnedAt = pinnedAt,
+      remoteId = remoteId,
+    )
   }
 
   private fun mapToResolvedPost(

--- a/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/repository/RssRepository.kt
+++ b/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/repository/RssRepository.kt
@@ -1355,11 +1355,7 @@ class RssRepository(
       transacter = feedGroupQueries,
       context = dispatchersProvider.databaseRead,
       queryProvider = { limit, offset ->
-        feedGroupQueries.groups(
-          limit = limit,
-          offset = offset,
-          mapper = ::mapToFeedGroupFromGroups,
-        )
+        feedGroupQueries.groups(limit = limit, offset = offset, mapper = ::mapToFeedGroupFromGroups)
       },
     )
   }
@@ -1370,7 +1366,9 @@ class RssRepository(
 
   suspend fun groupByIds(ids: Set<String>): List<FeedGroup> {
     return withContext(dispatchersProvider.databaseRead) {
-      feedGroupQueries.groupsByIds(ids = ids, mapper = ::mapToFeedGroupFromGroupsByIds).executeAsList()
+      feedGroupQueries
+        .groupsByIds(ids = ids, mapper = ::mapToFeedGroupFromGroupsByIds)
+        .executeAsList()
     }
   }
 
@@ -1645,7 +1643,9 @@ class RssRepository(
         feedIds =
           feedIds.orEmpty().split(Constants.GROUP_CONCAT_SEPARATOR).filterNot { it.isBlank() },
         feedHomepageLinks =
-          feedHomepageLinks?.split(Constants.GROUP_CONCAT_SEPARATOR)?.filterNot { it.isBlank() }
+          feedHomepageLinks
+            ?.split(Constants.GROUP_CONCAT_SEPARATOR)
+            ?.filterNot { it.isBlank() }
             .orEmpty(),
         feedIconLinks =
           feedIcons?.split(Constants.GROUP_CONCAT_SEPARATOR)?.filterNot { it.isBlank() }.orEmpty(),


### PR DESCRIPTION
This PR refactors `RssRepository.kt` to eliminate code duplication in the database mappers. 

🎯 **What:**
- Extracted duplicate inline mapper lambdas for `Feed`, `Source`, and `FeedGroup` into private functions.
- Used method references (e.g., `mapper = ::mapToFeed`) at call sites.

💡 **Why:**
- Reduces code size and boilerplate.
- Improves maintainability by centralizing object creation logic for database results.
- Enhances readability of the repository methods.

✅ **Verification:**
- Ran `./gradlew :core:data:jvmTest` - Passed.
- Ran `./gradlew :core:data:testAndroidHostTest` - Passed.
- Verified compilation for all targets.

✨ **Result:**
- Cleaner and more maintainable `RssRepository.kt` with reduced duplication.

---
*PR created automatically by Jules for task [7107401960274695000](https://jules.google.com/task/7107401960274695000) started by @msasikanth*