### PR TITLE
Move formatDuration utility to shared module

### DIFF
--- a/core/base/src/commonMain/kotlin/dev/sasikanth/rss/reader/util/DurationExt.kt
+++ b/core/base/src/commonMain/kotlin/dev/sasikanth/rss/reader/util/DurationExt.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 Sasikanth Miriyampalli
+ *
+ * Licensed under the GPL, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package dev.sasikanth.rss.reader.util
+
+fun formatDuration(duration: Long): String {
+  val seconds = (duration / 1000) % 60
+  val minutes = (duration / (1000 * 60)) % 60
+  val hours = (duration / (1000 * 60 * 60))
+
+  return if (hours > 0) {
+    "${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}"
+  } else {
+    "${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}"
+  }
+}

--- a/core/base/src/commonTest/kotlin/dev/sasikanth/rss/reader/util/DurationExtTest.kt
+++ b/core/base/src/commonTest/kotlin/dev/sasikanth/rss/reader/util/DurationExtTest.kt
@@ -48,7 +48,7 @@ class DurationExtTest {
 
   @Test
   fun formatting_duration_with_single_digit_values_should_work_correctly() {
-     // given
+    // given
     val duration = 3661000L // 1 hour 1 minute 1 second
 
     // when

--- a/core/base/src/commonTest/kotlin/dev/sasikanth/rss/reader/util/DurationExtTest.kt
+++ b/core/base/src/commonTest/kotlin/dev/sasikanth/rss/reader/util/DurationExtTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 Sasikanth Miriyampalli
+ *
+ * Licensed under the GPL, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package dev.sasikanth.rss.reader.util
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DurationExtTest {
+
+  @Test
+  fun formatting_duration_less_than_an_hour_should_work_correctly() {
+    // given
+    val duration = 150000L // 2 minutes 30 seconds
+
+    // when
+    val result = formatDuration(duration)
+
+    // then
+    assertEquals("02:30", result)
+  }
+
+  @Test
+  fun formatting_duration_more_than_an_hour_should_work_correctly() {
+    // given
+    val duration = 3900000L // 1 hour 5 minutes 0 seconds
+
+    // when
+    val result = formatDuration(duration)
+
+    // then
+    assertEquals("01:05:00", result)
+  }
+
+  @Test
+  fun formatting_duration_with_single_digit_values_should_work_correctly() {
+     // given
+    val duration = 3661000L // 1 hour 1 minute 1 second
+
+    // when
+    val result = formatDuration(duration)
+
+    // then
+    assertEquals("01:01:01", result)
+  }
+}

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/reader/page/ui/ReaderPage.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/reader/page/ui/ReaderPage.kt
@@ -162,6 +162,7 @@ import dev.sasikanth.rss.reader.resources.icons.VisibilityOff
 import dev.sasikanth.rss.reader.share.LocalShareHandler
 import dev.sasikanth.rss.reader.ui.AppTheme
 import dev.sasikanth.rss.reader.ui.GolosFontFamily
+import dev.sasikanth.rss.reader.util.formatDuration
 import dev.sasikanth.rss.reader.util.readerDateTimestamp
 import dev.sasikanth.rss.reader.utils.LocalBlockImage
 import dev.sasikanth.rss.reader.utils.ParallaxAlignment
@@ -1004,17 +1005,6 @@ private fun MediaControls(
   }
 }
 
-private fun formatDuration(duration: Long): String {
-  val seconds = (duration / 1000) % 60
-  val minutes = (duration / (1000 * 60)) % 60
-  val hours = (duration / (1000 * 60 * 60))
-
-  return if (hours > 0) {
-    "${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}"
-  } else {
-    "${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}"
-  }
-}
 
 @Composable
 private fun SleepTimerBottomSheet(

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/reader/page/ui/ReaderPage.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/reader/page/ui/ReaderPage.kt
@@ -1005,7 +1005,6 @@ private fun MediaControls(
   }
 }
 
-
 @Composable
 private fun SleepTimerBottomSheet(
   playbackState: PlaybackState,


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was a duplicate-ready utility function `formatDuration` in `ReaderPage.kt`. I moved it to the `core:base` module as a shared utility.
💡 **Why:** Moving this to a shared utility class allows other parts of the app to use it and keeps the UI file cleaner.
✅ **Verification:** 
- Added unit tests in `core:base` covering various duration scenarios (seconds, minutes, hours).
- Verified the build of the `shared` module after the refactoring.
- Confirmed that `formatDuration` logic remains identical to the original.
✨ **Result:** Improved maintainability and reusability of the duration formatting logic.

---
*PR created automatically by Jules for task [4447431045322532737](https://jules.google.com/task/4447431045322532737) started by @msasikanth*