### PR TITLE
Optimize buffer reuse in Okio adapter

### DIFF
--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/favicons/FavIconFetcher.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/favicons/FavIconFetcher.kt
@@ -54,6 +54,7 @@ import kotlinx.io.RawSource
 import kotlinx.io.UnsafeIoApi
 import kotlinx.io.unsafe.UnsafeBufferOperations
 import okio.Buffer as OkioBuffer
+import okio.BufferedSource as OkioBufferedSource
 import okio.EOFException as OkioEOFException
 import okio.FileSystem
 import okio.IOException as OkioIOException
@@ -303,11 +304,26 @@ class FavIconFetcher(
  */
 public fun OkioSource.asKotlinxIoRawSource(): RawSource =
   object : RawSource {
-    private val buffer =
-      OkioBuffer() // TODO: optimization - reuse BufferedSource's buffer if possible
+    private val bufferedSource = this@asKotlinxIoRawSource as? OkioBufferedSource
+    private val tempBuffer = if (bufferedSource == null) OkioBuffer() else null
 
     override fun readAtMostTo(sink: Buffer, byteCount: Long): Long = withOkio2KxIOExceptionMapping {
-      val readBytes = this@asKotlinxIoRawSource.read(buffer, byteCount)
+      if (byteCount == 0L) return 0L
+
+      val okioBuffer: OkioBuffer
+      val readBytes: Long
+
+      if (bufferedSource != null) {
+        if (bufferedSource.buffer.exhausted()) {
+          if (!bufferedSource.request(1)) return -1L
+        }
+        okioBuffer = bufferedSource.buffer
+        readBytes = min(okioBuffer.size, byteCount)
+      } else {
+        okioBuffer = tempBuffer!!
+        readBytes = this@asKotlinxIoRawSource.read(okioBuffer, byteCount)
+      }
+
       if (readBytes == -1L) return -1L
 
       var remaining = readBytes
@@ -315,7 +331,7 @@ public fun OkioSource.asKotlinxIoRawSource(): RawSource =
         @OptIn(UnsafeIoApi::class)
         UnsafeBufferOperations.writeToTail(sink, 1) { data, from, to ->
           val toRead = min((to - from).toLong(), remaining).toInt()
-          val read = buffer.read(data, from, toRead)
+          val read = okioBuffer.read(data, from, toRead)
           check(read != -1) { "Buffer was exhausted before reading $toRead bytes from it." }
           remaining -= read
           read

--- a/shared/src/commonTest/kotlin/dev/sasikanth/rss/reader/favicons/OkioAdapterTest.kt
+++ b/shared/src/commonTest/kotlin/dev/sasikanth/rss/reader/favicons/OkioAdapterTest.kt
@@ -1,0 +1,76 @@
+package dev.sasikanth.rss.reader.favicons
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.io.Buffer
+import kotlinx.io.readByteArray
+import okio.Buffer as OkioBuffer
+import okio.Source as OkioSource
+import okio.Timeout
+
+class OkioAdapterTest {
+
+  @Test
+  fun reading_from_raw_source_should_work() {
+    val data = "Hello, World!".encodeToByteArray()
+    val okioSource = object : OkioSource {
+      private var read = false
+      override fun read(sink: OkioBuffer, byteCount: Long): Long {
+        if (read) return -1L
+        sink.write(data)
+        read = true
+        return data.size.toLong()
+      }
+      override fun timeout(): Timeout = Timeout.NONE
+      override fun close() {}
+    }
+
+    val rawSource = okioSource.asKotlinxIoRawSource()
+    val sink = Buffer()
+    val readBytes = rawSource.readAtMostTo(sink, 100L)
+
+    assertEquals(data.size.toLong(), readBytes)
+    assertEquals("Hello, World!", sink.readByteArray().decodeToString())
+  }
+
+  @Test
+  fun reading_from_buffered_source_should_work() {
+    val content = "Hello, Buffered World!"
+    val okioBuffer = OkioBuffer().writeUtf8(content)
+
+    // okio.Buffer implements BufferedSource
+    val rawSource = okioBuffer.asKotlinxIoRawSource()
+    val sink = Buffer()
+
+    // Read partially
+    val readBytes1 = rawSource.readAtMostTo(sink, 7L)
+    assertEquals(7L, readBytes1)
+    assertEquals("Hello, ", sink.readByteArray().decodeToString())
+
+    // Read the rest
+    val readBytes2 = rawSource.readAtMostTo(sink, 100L)
+    assertEquals((content.length - 7).toLong(), readBytes2)
+    assertEquals("Buffered World!", sink.readByteArray().decodeToString())
+  }
+
+  @Test
+  fun reading_zero_bytes_should_return_zero() {
+    val okioBuffer = OkioBuffer().writeUtf8("Some data")
+    val rawSource = okioBuffer.asKotlinxIoRawSource()
+    val sink = Buffer()
+
+    val readBytes = rawSource.readAtMostTo(sink, 0L)
+    assertEquals(0L, readBytes)
+    assertEquals(0L, sink.size)
+  }
+
+  @Test
+  fun reading_at_eof_should_return_minus_one() {
+    val okioBuffer = OkioBuffer() // Empty
+    val rawSource = okioBuffer.asKotlinxIoRawSource()
+    val sink = Buffer()
+
+    val readBytes = rawSource.readAtMostTo(sink, 10L)
+    assertEquals(-1L, readBytes)
+  }
+}

--- a/shared/src/commonTest/kotlin/dev/sasikanth/rss/reader/favicons/OkioAdapterTest.kt
+++ b/shared/src/commonTest/kotlin/dev/sasikanth/rss/reader/favicons/OkioAdapterTest.kt
@@ -13,17 +13,21 @@ class OkioAdapterTest {
   @Test
   fun reading_from_raw_source_should_work() {
     val data = "Hello, World!".encodeToByteArray()
-    val okioSource = object : OkioSource {
-      private var read = false
-      override fun read(sink: OkioBuffer, byteCount: Long): Long {
-        if (read) return -1L
-        sink.write(data)
-        read = true
-        return data.size.toLong()
+    val okioSource =
+      object : OkioSource {
+        private var read = false
+
+        override fun read(sink: OkioBuffer, byteCount: Long): Long {
+          if (read) return -1L
+          sink.write(data)
+          read = true
+          return data.size.toLong()
+        }
+
+        override fun timeout(): Timeout = Timeout.NONE
+
+        override fun close() {}
       }
-      override fun timeout(): Timeout = Timeout.NONE
-      override fun close() {}
-    }
 
     val rawSource = okioSource.asKotlinxIoRawSource()
     val sink = Buffer()


### PR DESCRIPTION
This change optimizes the `OkioSource.asKotlinxIoRawSource` adapter by checking if the source is an instance of `okio.BufferedSource`. If it is, the adapter reuses the source's internal buffer instead of allocating a new intermediate `OkioBuffer`. This reduces both memory allocation and the number of data copies required to bridge between Okio and kotlinx-io.

Key changes:
- Modified `asKotlinxIoRawSource` in `FavIconFetcher.kt` to perform a type check and use the internal buffer when possible.
- Added `okio.BufferedSource` import.
- Created `OkioAdapterTest.kt` in `shared/src/commonTest` to verify the fix and prevent regressions.
- Verified the changes by running `:shared:jvmTest`.

---
*PR created automatically by Jules for task [5209666913377719635](https://jules.google.com/task/5209666913377719635) started by @msasikanth*