### PR TITLE
Remove Okio to Kotlinx IO adapter shim

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -93,6 +93,7 @@ kotlinx_immutable_collections = { module = "org.jetbrains.kotlinx:kotlinx-collec
 kotlinx_atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version.ref = "atomicfu" }
 kotlinx_serialization_json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx_serialization_json" }
 kotlinx_io = { module = "org.jetbrains.kotlinx:kotlinx-io-core", version.ref = "kotlinx_io" }
+kotlinx_io_okio = { module = "org.jetbrains.kotlinx:kotlinx-io-okio", version.ref = "kotlinx_io" }
 sqldelight_driver_android = { module = "app.cash.sqldelight:android-driver", version.ref = "sqldelight" }
 sqldelight_driver_native = { module = "app.cash.sqldelight:native-driver", version.ref = "sqldelight" }
 sqldelight_driver_jdbc = { module = "app.cash.sqldelight:sqlite-driver", version.ref = "sqldelight" }
@@ -167,6 +168,6 @@ bugsnag = { id = "com.bugsnag.android.gradle", version.ref = "bugsnag-plugin" }
 
 [bundles]
 compose = [ "compose_runtime", "compose_foundation", "compose_material", "compose_material3", "compose_material3_adaptive", "compose_material3_windowsizeclass", "compose_resources", "compose_ui_tooling_preview", "compose_ui", "compose_ui_util", "compose_material_icons_extended", "compose_backhandler" ]
-kotlinx = [ "kotlinx_coroutines", "kotlinx_datetime", "kotlinx_immutable_collections", "kotlinx_serialization_json", "kotlinx_io" ]
+kotlinx = [ "kotlinx_coroutines", "kotlinx_datetime", "kotlinx_immutable_collections", "kotlinx_serialization_json", "kotlinx_io", "kotlinx_io_okio" ]
 androidx_test = [ "androidx_test_runner", "androidx_test_rules" ]
 xmlutil = [ "xmlutil-core", "xmlutil-serialization" ]

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/favicons/FavIconFetcher.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/favicons/FavIconFetcher.kt
@@ -46,14 +46,11 @@ import coil3.util.MimeTypeMap
 import com.fleeksoft.ksoup.Ksoup
 import com.fleeksoft.ksoup.nodes.Document
 import com.fleeksoft.ksoup.parseSource
-import kotlin.math.min
 import kotlinx.io.Buffer
 import kotlinx.io.RawSource
 import kotlinx.io.okio.asKotlinxIoRawSource
-import okio.Buffer as OkioBuffer
 import okio.FileSystem
 import okio.IOException as OkioIOException
-import okio.Source as OkioSource
 
 private const val CACHE_CONTROL = "Cache-Control"
 private const val CONTENT_TYPE = "Content-Type"
@@ -290,4 +287,3 @@ class FavIconFetcher(
     }
   }
 }
-

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/favicons/FavIconFetcher.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/favicons/FavIconFetcher.kt
@@ -48,14 +48,9 @@ import com.fleeksoft.ksoup.nodes.Document
 import com.fleeksoft.ksoup.parseSource
 import kotlin.math.min
 import kotlinx.io.Buffer
-import kotlinx.io.EOFException as KxEOFException
-import kotlinx.io.IOException as KxIOException
 import kotlinx.io.RawSource
-import kotlinx.io.UnsafeIoApi
-import kotlinx.io.unsafe.UnsafeBufferOperations
+import kotlinx.io.okio.asKotlinxIoRawSource
 import okio.Buffer as OkioBuffer
-import okio.BufferedSource as OkioBufferedSource
-import okio.EOFException as OkioEOFException
 import okio.FileSystem
 import okio.IOException as OkioIOException
 import okio.Source as OkioSource
@@ -296,62 +291,3 @@ class FavIconFetcher(
   }
 }
 
-// TODO: Remove after Okio adapters are available in kotlinx-io library
-/**
- * Returns a [kotlinx.io.RawSource] backed by this [okio.Source].
- *
- * Closing one of these sources will also close another one.
- */
-public fun OkioSource.asKotlinxIoRawSource(): RawSource =
-  object : RawSource {
-    private val bufferedSource = this@asKotlinxIoRawSource as? OkioBufferedSource
-    private val buffer = if (bufferedSource == null) OkioBuffer() else null
-
-    override fun readAtMostTo(sink: Buffer, byteCount: Long): Long = withOkio2KxIOExceptionMapping {
-      if (byteCount == 0L) return 0L
-
-      val okioBuffer: OkioBuffer
-      val readBytes: Long
-
-      if (bufferedSource != null) {
-        if (bufferedSource.exhausted()) return -1L
-        okioBuffer = bufferedSource.buffer
-        readBytes = min(okioBuffer.size, byteCount)
-      } else {
-        readBytes = this@asKotlinxIoRawSource.read(buffer!!, byteCount)
-        if (readBytes == -1L) return -1L
-        okioBuffer = buffer
-      }
-
-      var remaining = readBytes
-      while (remaining > 0) {
-        @OptIn(UnsafeIoApi::class)
-        UnsafeBufferOperations.writeToTail(sink, 1) { data, from, to ->
-          val toRead = min((to - from).toLong(), remaining).toInt()
-          val read = okioBuffer.read(data, from, toRead)
-          check(read != -1) { "Buffer was exhausted before reading $toRead bytes from it." }
-          remaining -= read
-          read
-        }
-      }
-
-      return readBytes
-    }
-
-    override fun close() = withOkio2KxIOExceptionMapping { this@asKotlinxIoRawSource.close() }
-  }
-
-internal inline fun <T> withOkio2KxIOExceptionMapping(block: () -> T): T {
-  try {
-    return block()
-  } catch (
-    bypassIOE: KxIOException) { // on JVM, kotlinx.io.IOException and okio.IOException are the same
-    throw bypassIOE
-  } catch (bypassEOF: KxEOFException) { // see above
-    throw bypassEOF
-  } catch (eofe: OkioEOFException) {
-    throw KxIOException(eofe.message, eofe)
-  } catch (ioe: OkioIOException) {
-    throw KxIOException(ioe.message, ioe)
-  }
-}


### PR DESCRIPTION
This change removes a temporary shim that was used for Okio to Kotlinx IO interop. Now that `kotlinx-io` provides a native module for this, we use the library-provided extension. Verified by successful compilation of the `shared` module.

---
*PR created automatically by Jules for task [17589308337620060397](https://jules.google.com/task/17589308337620060397) started by @msasikanth*