### PR TITLE
⚡ Optimize FeedIcon image loading performance

### DIFF
--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/components/image/FeedIcon.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/components/image/FeedIcon.kt
@@ -59,7 +59,7 @@ internal fun FeedIcon(
 
   Box(
     modifier = Modifier.clip(shape).then(modifier).background(Color.White, shape),
-    contentAlignment = Alignment.Center
+    contentAlignment = Alignment.Center,
   ) {
     if (shouldBlockImage) {
       PlaceHolderIcon()
@@ -101,7 +101,7 @@ internal fun FeedIcon(
           if (!loadFavIcon) {
             useFallback = true
           }
-        }
+        },
       )
     }
   }

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/components/image/FeedIcon.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/components/image/FeedIcon.kt
@@ -22,6 +22,11 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.RssFeed
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
@@ -29,12 +34,12 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.layout.ContentScale
 import coil3.SingletonImageLoader
 import coil3.compose.LocalPlatformContext
-import coil3.compose.SubcomposeAsyncImage
 import coil3.request.ImageRequest
 import coil3.size.Dimension
 import coil3.size.Size
 import dev.sasikanth.rss.reader.favicons.FavIconImageLoader
 import dev.sasikanth.rss.reader.ui.AppTheme
+import dev.sasikanth.rss.reader.utils.LocalBlockImage
 import dev.sasikanth.rss.reader.utils.LocalShowFeedFavIconSetting
 
 @Composable
@@ -50,48 +55,55 @@ internal fun FeedIcon(
 ) {
   val globalShowFeedFavIcon = LocalShowFeedFavIconSetting.current
   val useFavIcon = showFeedFavIcon && globalShowFeedFavIcon
+  val shouldBlockImage = LocalBlockImage.current
 
-  Box(Modifier.clip(shape).then(modifier).background(Color.White, shape)) {
-    val context = LocalPlatformContext.current
-    val url = if (useFavIcon) homepageLink else icon
-    val imageRequest = ImageRequest.Builder(context).data(url).diskCacheKey(url).size(size).build()
-    val imageLoader =
-      if (useFavIcon) {
-        FavIconImageLoader.get(context)
-      } else {
-        SingletonImageLoader.get(context)
+  Box(
+    modifier = Modifier.clip(shape).then(modifier).background(Color.White, shape),
+    contentAlignment = Alignment.Center
+  ) {
+    if (shouldBlockImage) {
+      PlaceHolderIcon()
+    } else {
+      val context = LocalPlatformContext.current
+      var useFallback by remember(icon, homepageLink, useFavIcon) { mutableStateOf(false) }
+      val loadFavIcon = useFavIcon || useFallback
+
+      val imageRequest =
+        remember(icon, homepageLink, loadFavIcon, size) {
+          val url = if (loadFavIcon) homepageLink else icon
+          ImageRequest.Builder(context).data(url).diskCacheKey(url).size(size).build()
+        }
+
+      val imageLoader =
+        remember(loadFavIcon) {
+          if (loadFavIcon) {
+            FavIconImageLoader.get(context)
+          } else {
+            SingletonImageLoader.get(context)
+          }
+        }
+
+      var isSuccess by remember { mutableStateOf(false) }
+
+      if (!isSuccess) {
+        PlaceHolderIcon()
       }
 
-    SubcomposeAsyncImage(
-      model = imageRequest,
-      contentDescription = contentDescription,
-      modifier = Modifier.matchParentSize(),
-      contentScale = contentScale,
-      imageLoader = imageLoader,
-      error = {
-        if (!useFavIcon) {
-          val faviconImageRequest =
-            ImageRequest.Builder(context)
-              .data(homepageLink)
-              .diskCacheKey(homepageLink)
-              .size(size)
-              .build()
-
-          SubcomposeAsyncImage(
-            model = faviconImageRequest,
-            contentDescription = contentDescription,
-            modifier = Modifier.matchParentSize(),
-            contentScale = contentScale,
-            imageLoader = FavIconImageLoader.get(context),
-            error = { PlaceHolderIcon() },
-            loading = { PlaceHolderIcon() },
-          )
-        } else {
-          PlaceHolderIcon()
+      coil3.compose.AsyncImage(
+        model = imageRequest,
+        contentDescription = contentDescription,
+        modifier = Modifier.matchParentSize(),
+        contentScale = contentScale,
+        imageLoader = imageLoader,
+        onLoading = { isSuccess = false },
+        onSuccess = { isSuccess = true },
+        onError = {
+          if (!loadFavIcon) {
+            useFallback = true
+          }
         }
-      },
-      loading = { PlaceHolderIcon() },
-    )
+      )
+    }
   }
 }
 


### PR DESCRIPTION
This change optimizes the `FeedIcon` component by:
1. Wrapping `ImageRequest` and `ImageLoader` in `remember` blocks to avoid object allocations during recomposition.
2. Replacing `SubcomposeAsyncImage` with the more efficient `coil3.compose.AsyncImage`, which avoids subcomposition.
3. Replacing the nested `SubcomposeAsyncImage` fallback logic with a state-based approach that re-triggers the same `AsyncImage` instance with new parameters upon failure.
4. Rendering the `PlaceHolderIcon` behind the image in a `Box` to provide a visual during loading/error without the overhead of subcomposition.
5. Implementing a check for `LocalBlockImage.current` to ensure the component respects the app's image loading policy.

---
*PR created automatically by Jules for task [9140176255563566269](https://jules.google.com/task/9140176255563566269) started by @msasikanth*