### PR TITLE
🧹 Optimize FavIconFetcher buffer usage

### DIFF
--- a/shared/src/commonTest/kotlin/dev/sasikanth/rss/reader/favicons/FavIconFetcherTest.kt
+++ b/shared/src/commonTest/kotlin/dev/sasikanth/rss/reader/favicons/FavIconFetcherTest.kt
@@ -1,0 +1,61 @@
+package dev.sasikanth.rss.reader.favicons
+
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlinx.io.Buffer
+import kotlinx.io.readByteArray
+import okio.Buffer as OkioBuffer
+import okio.Source as OkioSource
+import okio.buffer
+
+class FavIconFetcherTest {
+
+  @Test
+  fun asKotlinxIoRawSource_should_read_data_from_okio_source() {
+    val data = "Hello, World!".encodeToByteArray()
+    val okioSource: OkioSource = OkioBuffer().apply { write(data) }
+
+    val kxRawSource = okioSource.asKotlinxIoRawSource()
+    val sink = Buffer()
+
+    val read = kxRawSource.readAtMostTo(sink, data.size.toLong())
+
+    assertEquals(data.size.toLong(), read)
+    assertContentEquals(data, sink.readByteArray())
+  }
+
+  @Test
+  fun asKotlinxIoRawSource_should_work_with_buffered_source() {
+    val data = "Hello, World!".encodeToByteArray()
+    val okioSource = OkioBuffer().apply { write(data) }.buffer()
+
+    val kxRawSource = okioSource.asKotlinxIoRawSource()
+    val sink = Buffer()
+
+    val read = kxRawSource.readAtMostTo(sink, data.size.toLong())
+
+    assertEquals(data.size.toLong(), read)
+    assertContentEquals(data, sink.readByteArray())
+  }
+
+  @Test
+  fun asKotlinxIoRawSource_should_handle_multiple_reads() {
+    val data = "Hello, World!".encodeToByteArray()
+    val okioSource: OkioSource = OkioBuffer().apply { write(data) }
+
+    val kxRawSource = okioSource.asKotlinxIoRawSource()
+    val sink = Buffer()
+
+    val read1 = kxRawSource.readAtMostTo(sink, 5)
+    assertEquals(5L, read1)
+    assertContentEquals("Hello".encodeToByteArray(), sink.readByteArray())
+
+    val read2 = kxRawSource.readAtMostTo(sink, 10)
+    assertEquals(8L, read2)
+    assertContentEquals(", World!".encodeToByteArray(), sink.readByteArray())
+
+    val read3 = kxRawSource.readAtMostTo(sink, 10)
+    assertEquals(-1L, read3)
+  }
+}


### PR DESCRIPTION
The `asKotlinxIoRawSource` extension function in `FavIconFetcher.kt` was creating an intermediate `OkioBuffer` for every instance, leading to redundant data copies and allocations.

This PR optimizes the function by:
1. Checking if the incoming `OkioSource` is already a `BufferedSource`.
2. If it is, we use its internal buffer directly during `readAtMostTo` operations.
3. We use `exhausted()` to ensure the buffer is populated from the underlying source when needed.
4. This reduces the number of data copies from two to one for buffered sources.

Additionally, a new test file `FavIconFetcherTest.kt` has been added to `shared/src/commonTest` to ensure the correctness of the conversion logic for both buffered and non-buffered sources.

---
*PR created automatically by Jules for task [16253153193121859234](https://jules.google.com/task/16253153193121859234) started by @msasikanth*