### PR TITLE
Refactor repeated string splitting logic to use `splitAndTrim`

### DIFF
--- a/core/base/src/commonMain/kotlin/dev/sasikanth/rss/reader/util/StringExt.kt
+++ b/core/base/src/commonMain/kotlin/dev/sasikanth/rss/reader/util/StringExt.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2026 Sasikanth Miriyampalli
+ *
+ * Licensed under the GPL, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package dev.sasikanth.rss.reader.util
+
+fun String.splitAndTrim(separator: String): List<String> {
+  return split(separator).map { it.trim() }.filter { it.isNotBlank() }
+}

--- a/core/base/src/commonTest/kotlin/dev/sasikanth/rss/reader/util/StringExtTest.kt
+++ b/core/base/src/commonTest/kotlin/dev/sasikanth/rss/reader/util/StringExtTest.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 Sasikanth Miriyampalli
+ *
+ * Licensed under the GPL, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package dev.sasikanth.rss.reader.util
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class StringExtTest {
+
+  @Test
+  fun splitAndTrimShouldWorkCorrectly() {
+    // given
+    val input = "a :: b :: c"
+    val separator = "::"
+
+    // when
+    val result = input.splitAndTrim(separator)
+
+    // then
+    assertEquals(listOf("a", "b", "c"), result)
+  }
+
+  @Test
+  fun splitAndTrimShouldFilterBlankStrings() {
+    // given
+    val input = "a :: :: b :: "
+    val separator = "::"
+
+    // when
+    val result = input.splitAndTrim(separator)
+
+    // then
+    assertEquals(listOf("a", "b"), result)
+  }
+
+  @Test
+  fun splitAndTrimShouldTrimElements() {
+    // given
+    val input = "  a  ::  b  "
+    val separator = "::"
+
+    // when
+    val result = input.splitAndTrim(separator)
+
+    // then
+    assertEquals(listOf("a", "b"), result)
+  }
+
+  @Test
+  fun splitAndTrimShouldReturnEmptyListForEmptyString() {
+    // given
+    val input = ""
+    val separator = "::"
+
+    // when
+    val result = input.splitAndTrim(separator)
+
+    // then
+    assertEquals(emptyList<String>(), result)
+  }
+}

--- a/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/repository/RssRepository.kt
+++ b/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/repository/RssRepository.kt
@@ -1449,7 +1449,8 @@ class RssRepository(
           UnreadSinceLastSync(
             newArticleCount = count,
             hasNewArticles = count > 0,
-            feedHomepageLinks = feedHomepageLinks.orEmpty().splitAndTrim(Constants.GROUP_CONCAT_SEPARATOR),
+            feedHomepageLinks =
+              feedHomepageLinks.orEmpty().splitAndTrim(Constants.GROUP_CONCAT_SEPARATOR),
             feedIcons = feedIcons.orEmpty().splitAndTrim(Constants.GROUP_CONCAT_SEPARATOR),
             feedShowFavIconSettings = mapToFeedShowFavIconSettings(feedShowFavIconSettings),
           )
@@ -1635,7 +1636,8 @@ class RssRepository(
         id = id,
         name = name,
         feedIds = feedIds.orEmpty().splitAndTrim(Constants.GROUP_CONCAT_SEPARATOR),
-        feedHomepageLinks = feedHomepageLinks.orEmpty().splitAndTrim(Constants.GROUP_CONCAT_SEPARATOR),
+        feedHomepageLinks =
+          feedHomepageLinks.orEmpty().splitAndTrim(Constants.GROUP_CONCAT_SEPARATOR),
         feedIconLinks = feedIcons.orEmpty().splitAndTrim(Constants.GROUP_CONCAT_SEPARATOR),
         feedShowFavIconSettings = mapToFeedShowFavIconSettings(feedShowFavIconSettings),
         createdAt = createdAt,

--- a/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/repository/RssRepository.kt
+++ b/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/repository/RssRepository.kt
@@ -54,6 +54,7 @@ import dev.sasikanth.rss.reader.data.utils.ReadingTimeCalculator
 import dev.sasikanth.rss.reader.di.scopes.AppScope
 import dev.sasikanth.rss.reader.util.DispatchersProvider
 import dev.sasikanth.rss.reader.util.nameBasedUuidOf
+import dev.sasikanth.rss.reader.util.splitAndTrim
 import kotlin.time.Clock
 import kotlin.time.Duration
 import kotlin.time.Instant
@@ -629,8 +630,7 @@ class RssRepository(
 
   private fun mapToFeedShowFavIconSettings(feedShowFavIconSettings: String?): List<Boolean> {
     return feedShowFavIconSettings
-      ?.split(Constants.GROUP_CONCAT_SEPARATOR)
-      ?.filterNot { it.isBlank() }
+      ?.splitAndTrim(Constants.GROUP_CONCAT_SEPARATOR)
       ?.map {
         when (it) {
           "true" -> true
@@ -1449,14 +1449,8 @@ class RssRepository(
           UnreadSinceLastSync(
             newArticleCount = count,
             hasNewArticles = count > 0,
-            feedHomepageLinks =
-              feedHomepageLinks.orEmpty().split(Constants.GROUP_CONCAT_SEPARATOR).filterNot {
-                it.isBlank()
-              },
-            feedIcons =
-              feedIcons.orEmpty().split(Constants.GROUP_CONCAT_SEPARATOR).filterNot {
-                it.isBlank()
-              },
+            feedHomepageLinks = feedHomepageLinks.orEmpty().splitAndTrim(Constants.GROUP_CONCAT_SEPARATOR),
+            feedIcons = feedIcons.orEmpty().splitAndTrim(Constants.GROUP_CONCAT_SEPARATOR),
             feedShowFavIconSettings = mapToFeedShowFavIconSettings(feedShowFavIconSettings),
           )
         },
@@ -1640,15 +1634,9 @@ class RssRepository(
       FeedGroup(
         id = id,
         name = name,
-        feedIds =
-          feedIds.orEmpty().split(Constants.GROUP_CONCAT_SEPARATOR).filterNot { it.isBlank() },
-        feedHomepageLinks =
-          feedHomepageLinks
-            ?.split(Constants.GROUP_CONCAT_SEPARATOR)
-            ?.filterNot { it.isBlank() }
-            .orEmpty(),
-        feedIconLinks =
-          feedIcons?.split(Constants.GROUP_CONCAT_SEPARATOR)?.filterNot { it.isBlank() }.orEmpty(),
+        feedIds = feedIds.orEmpty().splitAndTrim(Constants.GROUP_CONCAT_SEPARATOR),
+        feedHomepageLinks = feedHomepageLinks.orEmpty().splitAndTrim(Constants.GROUP_CONCAT_SEPARATOR),
+        feedIconLinks = feedIcons.orEmpty().splitAndTrim(Constants.GROUP_CONCAT_SEPARATOR),
         feedShowFavIconSettings = mapToFeedShowFavIconSettings(feedShowFavIconSettings),
         createdAt = createdAt,
         updatedAt = updatedAt!!,
@@ -1692,12 +1680,9 @@ class RssRepository(
     return FeedGroup(
       id = id,
       name = name,
-      feedIds =
-        feedIds?.split(Constants.GROUP_CONCAT_SEPARATOR)?.filter { it.isNotBlank() } ?: emptyList(),
-      feedHomepageLinks =
-        feedHomepageLinks.split(Constants.GROUP_CONCAT_SEPARATOR).filter { it.isNotBlank() },
-      feedIconLinks =
-        feedIconLinks.split(Constants.GROUP_CONCAT_SEPARATOR).filter { it.isNotBlank() },
+      feedIds = feedIds.orEmpty().splitAndTrim(Constants.GROUP_CONCAT_SEPARATOR),
+      feedHomepageLinks = feedHomepageLinks.splitAndTrim(Constants.GROUP_CONCAT_SEPARATOR),
+      feedIconLinks = feedIconLinks.splitAndTrim(Constants.GROUP_CONCAT_SEPARATOR),
       feedShowFavIconSettings = mapToFeedShowFavIconSettings(feedShowFavIconSettings),
       createdAt = createdAt,
       updatedAt = updatedAt,
@@ -1724,11 +1709,9 @@ class RssRepository(
     return FeedGroup(
       id = id,
       name = name,
-      feedIds =
-        feedIds.orEmpty().split(Constants.GROUP_CONCAT_SEPARATOR).filterNot { it.isBlank() },
-      feedHomepageLinks =
-        feedHomepageLinks.split(Constants.GROUP_CONCAT_SEPARATOR).filterNot { it.isBlank() },
-      feedIconLinks = feedIcons.split(Constants.GROUP_CONCAT_SEPARATOR).filterNot { it.isBlank() },
+      feedIds = feedIds.orEmpty().splitAndTrim(Constants.GROUP_CONCAT_SEPARATOR),
+      feedHomepageLinks = feedHomepageLinks.splitAndTrim(Constants.GROUP_CONCAT_SEPARATOR),
+      feedIconLinks = feedIcons.splitAndTrim(Constants.GROUP_CONCAT_SEPARATOR),
       feedShowFavIconSettings = mapToFeedShowFavIconSettings(feedShowFavIconSettings),
       createdAt = createdAt,
       updatedAt = updatedAt,
@@ -1753,11 +1736,9 @@ class RssRepository(
     return FeedGroup(
       id = id,
       name = name,
-      feedIds =
-        feedIds.orEmpty().split(Constants.GROUP_CONCAT_SEPARATOR).filterNot { it.isBlank() },
-      feedHomepageLinks =
-        feedHomepageLinks.split(Constants.GROUP_CONCAT_SEPARATOR).filterNot { it.isBlank() },
-      feedIconLinks = feedIcons.split(Constants.GROUP_CONCAT_SEPARATOR).filterNot { it.isBlank() },
+      feedIds = feedIds.orEmpty().splitAndTrim(Constants.GROUP_CONCAT_SEPARATOR),
+      feedHomepageLinks = feedHomepageLinks.splitAndTrim(Constants.GROUP_CONCAT_SEPARATOR),
+      feedIconLinks = feedIcons.splitAndTrim(Constants.GROUP_CONCAT_SEPARATOR),
       feedShowFavIconSettings = mapToFeedShowFavIconSettings(feedShowFavIconSettings),
       createdAt = createdAt,
       updatedAt = updatedAt,


### PR DESCRIPTION
This PR improves code health by consolidating repeated string splitting logic into a reusable extension function.

🎯 **What:** 
- Created `String.splitAndTrim(separator: String)` in `core/base/src/commonMain/kotlin/dev/sasikanth/rss/reader/util/StringExt.kt`.
- Replaced manual splitting and filtering logic in `RssRepository.kt` with `splitAndTrim`.
- Added unit tests in `core/base/src/commonTest/kotlin/dev/sasikanth/rss/reader/util/StringExtTest.kt`.

💡 **Why:** 
The codebase had multiple instances of manual splitting of `Constants.GROUP_CONCAT_SEPARATOR` followed by filtering blank strings. Centralizing this logic into `splitAndTrim` improves maintainability, reduces duplication, and ensures consistent behavior (including trimming) across the application.

✅ **Verification:** 
- Ran unit tests for the new extension function: `./gradlew :core:base:jvmTest` (Passed).
- Ran data layer tests: `./gradlew :core:data:jvmTest` (Passed).
- Verified all manual splitting instances in `RssRepository.kt` were replaced.

✨ **Result:** 
Cleaner, more maintainable code in `RssRepository.kt` and a new reusable utility for string processing.

---
*PR created automatically by Jules for task [4716254129704174099](https://jules.google.com/task/4716254129704174099) started by @msasikanth*