### PR TITLE
Pass dark mode overridden color scheme to ReaderActionsPanel

### DIFF
--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/reader/ui/ReaderScreen.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/reader/ui/ReaderScreen.kt
@@ -236,15 +236,13 @@ internal fun ReaderScreen(
     val sourceColorScheme = AppTheme.colorScheme
     val overriddenColorScheme =
       remember(state.selectedReaderColorScheme, isDarkTheme, sourceColorScheme) {
-        when (state.selectedReaderColorScheme) {
-          ReaderColorScheme.Dynamic -> null
-          ReaderColorScheme.Sepia -> sepiaColorScheme(sourceColorScheme)
-          ReaderColorScheme.Solarized -> solarizedColorScheme(isDarkTheme, sourceColorScheme)
-          ReaderColorScheme.Parchment -> parchmentColorScheme(sourceColorScheme)
-          ReaderColorScheme.Midnight -> midnightColorScheme(sourceColorScheme)
-          ReaderColorScheme.Forest -> forestColorScheme(sourceColorScheme)
-          ReaderColorScheme.Slate -> slateColorScheme(sourceColorScheme)
-        }
+        state.selectedReaderColorScheme.getOverriddenColorScheme(isDarkTheme, sourceColorScheme)
+      }
+
+    val darkAppColorScheme = appDynamicColorState.darkAppColorScheme
+    val overriddenDarkColorScheme =
+      remember(state.selectedReaderColorScheme, darkAppColorScheme) {
+        state.selectedReaderColorScheme.getOverriddenColorScheme(true, darkAppColorScheme)
       }
 
     AppTheme(
@@ -364,7 +362,7 @@ internal fun ReaderScreen(
               fontScaleFactor = state.readerFontScaleFactor,
               fontLineHeightFactor = state.readerLineHeightScaleFactor,
               isSubscribed = state.isSubscribed,
-              overriddenColorScheme = overriddenColorScheme,
+              overriddenColorScheme = overriddenDarkColorScheme,
               openInBrowserClick = {
                 coroutineScope.launch { linkHandler.openLink(readerPost.link) }
               },
@@ -577,7 +575,7 @@ private fun ReaderActionsPanel(
             )
             .graphicsLayer { clip = true }
       ) {
-        AppTheme(useDarkTheme = true) {
+        AppTheme(useDarkTheme = true, overriddenColorScheme = overriddenColorScheme) {
           AnimatedContent(
             modifier = Modifier.requiredHeightIn(min = 64.dp),
             contentAlignment = Alignment.BottomCenter,

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/reader/ui/ReaderThemes.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/reader/ui/ReaderThemes.kt
@@ -18,7 +18,23 @@
 package dev.sasikanth.rss.reader.reader.ui
 
 import androidx.compose.ui.graphics.Color
+import dev.sasikanth.rss.reader.data.repository.ReaderColorScheme
 import dev.sasikanth.rss.reader.ui.AppColorScheme
+
+internal fun ReaderColorScheme.getOverriddenColorScheme(
+  isDark: Boolean,
+  sourceColorScheme: AppColorScheme,
+): AppColorScheme? {
+  return when (this) {
+    ReaderColorScheme.Dynamic -> null
+    ReaderColorScheme.Sepia -> sepiaColorScheme(sourceColorScheme)
+    ReaderColorScheme.Solarized -> solarizedColorScheme(isDark, sourceColorScheme)
+    ReaderColorScheme.Parchment -> parchmentColorScheme(sourceColorScheme)
+    ReaderColorScheme.Midnight -> midnightColorScheme(sourceColorScheme)
+    ReaderColorScheme.Forest -> forestColorScheme(sourceColorScheme)
+    ReaderColorScheme.Slate -> slateColorScheme(sourceColorScheme)
+  }
+}
 
 internal data class ReaderThemeTokens(
   val primary: Color,


### PR DESCRIPTION
The `ReaderActionsPanel` is a dark-themed UI component. Previously, when a light reader theme (like Sepia or Parchment) was selected, it would pass its light color scheme to the action panel, causing some UI elements inside the panel to have incorrect light backgrounds.

This change:
1.  Introduces a `getOverriddenColorScheme` helper to easily get the light or dark version of any reader color scheme.
2.  In `ReaderScreen`, it now computes a specific `overriddenDarkColorScheme` (always based on a dark source) to be used by the action panel.
3.  Updates `ReaderActionsPanel` to correctly apply this overridden scheme to its content via `AppTheme`.

This ensures visual consistency within the action panel across all reader themes.

---
*PR created automatically by Jules for task [5062967883596614450](https://jules.google.com/task/5062967883596614450) started by @msasikanth*