### PR TITLE
⚡ Optimize N+1 database updates in sync coordinators

### DIFF
--- a/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/repository/RssRepository.kt
+++ b/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/repository/RssRepository.kt
@@ -876,11 +876,32 @@ class RssRepository(
   }
 
   suspend fun markPostsAsRead(postIds: Set<String>) {
+    updatePostReadStatus(postIds, read = true)
+  }
+
+  suspend fun updatePostReadStatus(postIds: Set<String>, read: Boolean) {
     val postIdsSnapshot = postIds.toList()
+    val now = Clock.System.now()
     withContext(dispatchersProvider.databaseWrite) {
       transactionRunner.invoke {
         postIdsSnapshot.forEach { postId ->
-          postQueries.updateReadStatus(read = 1L, id = postId, updatedAt = Clock.System.now())
+          postQueries.updateReadStatus(read = if (read) 1L else 0L, id = postId, updatedAt = now)
+        }
+      }
+    }
+  }
+
+  suspend fun updateBookmarkStatus(postIds: Set<String>, bookmarked: Boolean) {
+    val postIdsSnapshot = postIds.toList()
+    val now = Clock.System.now()
+    withContext(dispatchersProvider.databaseWrite) {
+      transactionRunner.invoke {
+        postIdsSnapshot.forEach { postId ->
+          postQueries.updateBookmarkStatus(
+            bookmarked = if (bookmarked) 1L else 0L,
+            id = postId,
+            updatedAt = now,
+          )
         }
       }
     }
@@ -949,6 +970,28 @@ class RssRepository(
   suspend fun updatePostSyncedAt(postId: String, syncedAt: Instant) {
     withContext(dispatchersProvider.databaseWrite) {
       postQueries.updatePostSyncedAt(syncedAt = syncedAt, id = postId)
+    }
+  }
+
+  suspend fun updatePostSyncedAt(postIds: Set<String>, syncedAt: Instant) {
+    val postIdsSnapshot = postIds.toList()
+    withContext(dispatchersProvider.databaseWrite) {
+      transactionRunner.invoke {
+        postIdsSnapshot.forEach { postId ->
+          postQueries.updatePostSyncedAt(syncedAt = syncedAt, id = postId)
+        }
+      }
+    }
+  }
+
+  suspend fun updatePostSyncedAt(posts: List<Post>) {
+    val postsSnapshot = posts.toList()
+    withContext(dispatchersProvider.databaseWrite) {
+      transactionRunner.invoke {
+        postsSnapshot.forEach { post ->
+          postQueries.updatePostSyncedAt(syncedAt = post.updatedAt, id = post.id)
+        }
+      }
     }
   }
 

--- a/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/sync/freshrss/FreshRSSSyncCoordinator.kt
+++ b/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/sync/freshrss/FreshRSSSyncCoordinator.kt
@@ -537,22 +537,41 @@ class FreshRSSSyncCoordinator(
           offset = offset,
         )
 
+      val toMarkRead = mutableSetOf<String>()
+      val toMarkUnread = mutableSetOf<String>()
+      val toBookmark = mutableSetOf<String>()
+      val toUnbookmark = mutableSetOf<String>()
+      val toUpdateSyncedAt = mutableSetOf<String>()
+
       localPosts.forEach { post ->
         val remoteRead = post.remoteId !in unreadIds
         val remoteBookmarked = post.remoteId in bookmarkIds
 
         // If local is synced (no pending changes), remote is source of truth
         if (post.syncedAt >= post.updatedAt) {
+          var changed = false
           if (post.read != remoteRead) {
-            rssRepository.updatePostReadStatus(read = remoteRead, id = post.id)
-            rssRepository.updatePostSyncedAt(post.id, Clock.System.now())
+            if (remoteRead) toMarkRead.add(post.id) else toMarkUnread.add(post.id)
+            changed = true
           }
           if (post.bookmarked != remoteBookmarked) {
-            rssRepository.updateBookmarkStatus(bookmarked = remoteBookmarked, id = post.id)
-            rssRepository.updatePostSyncedAt(post.id, Clock.System.now())
+            if (remoteBookmarked) toBookmark.add(post.id) else toUnbookmark.add(post.id)
+            changed = true
+          }
+
+          if (changed) {
+            toUpdateSyncedAt.add(post.id)
           }
         }
       }
+
+      if (toMarkRead.isNotEmpty()) rssRepository.updatePostReadStatus(toMarkRead, read = true)
+      if (toMarkUnread.isNotEmpty()) rssRepository.updatePostReadStatus(toMarkUnread, read = false)
+      if (toBookmark.isNotEmpty()) rssRepository.updateBookmarkStatus(toBookmark, bookmarked = true)
+      if (toUnbookmark.isNotEmpty())
+        rssRepository.updateBookmarkStatus(toUnbookmark, bookmarked = false)
+      if (toUpdateSyncedAt.isNotEmpty())
+        rssRepository.updatePostSyncedAt(toUpdateSyncedAt, Clock.System.now())
 
       offset += localPosts.size
     } while (localPosts.size >= LOCAL_POSTS_PAGE_SIZE)
@@ -590,7 +609,7 @@ class FreshRSSSyncCoordinator(
       toBookmark.chunked(STATUS_BATCH_SIZE).forEach { ids -> freshRssSource.addBookmarks(ids) }
       toUnbookmark.chunked(STATUS_BATCH_SIZE).forEach { ids -> freshRssSource.removeBookmarks(ids) }
 
-      dirtyPosts.forEach { post -> rssRepository.updatePostSyncedAt(post.id, post.updatedAt) }
+      rssRepository.updatePostSyncedAt(dirtyPosts)
     }
   }
 

--- a/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/sync/miniflux/MinifluxSyncCoordinator.kt
+++ b/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/sync/miniflux/MinifluxSyncCoordinator.kt
@@ -597,21 +597,42 @@ class MinifluxSyncCoordinator(
           limit = LOCAL_POSTS_PAGE_SIZE.toLong(),
           offset = localOffset,
         )
+
+      val toMarkRead = mutableSetOf<String>()
+      val toMarkUnread = mutableSetOf<String>()
+      val toBookmark = mutableSetOf<String>()
+      val toUnbookmark = mutableSetOf<String>()
+      val toUpdateSyncedAt = mutableSetOf<String>()
+
       localPosts.forEach { post ->
         val remoteRead = post.remoteId !in unreadIds
         val remoteBookmarked = post.remoteId in bookmarkIds
 
         if (post.syncedAt >= post.updatedAt) {
+          var changed = false
           if (post.read != remoteRead) {
-            rssRepository.updatePostReadStatus(read = remoteRead, id = post.id)
-            rssRepository.updatePostSyncedAt(post.id, Clock.System.now())
+            if (remoteRead) toMarkRead.add(post.id) else toMarkUnread.add(post.id)
+            changed = true
           }
           if (post.bookmarked != remoteBookmarked) {
-            rssRepository.updateBookmarkStatus(bookmarked = remoteBookmarked, id = post.id)
-            rssRepository.updatePostSyncedAt(post.id, Clock.System.now())
+            if (remoteBookmarked) toBookmark.add(post.id) else toUnbookmark.add(post.id)
+            changed = true
+          }
+
+          if (changed) {
+            toUpdateSyncedAt.add(post.id)
           }
         }
       }
+
+      if (toMarkRead.isNotEmpty()) rssRepository.updatePostReadStatus(toMarkRead, read = true)
+      if (toMarkUnread.isNotEmpty()) rssRepository.updatePostReadStatus(toMarkUnread, read = false)
+      if (toBookmark.isNotEmpty()) rssRepository.updateBookmarkStatus(toBookmark, bookmarked = true)
+      if (toUnbookmark.isNotEmpty())
+        rssRepository.updateBookmarkStatus(toUnbookmark, bookmarked = false)
+      if (toUpdateSyncedAt.isNotEmpty())
+        rssRepository.updatePostSyncedAt(toUpdateSyncedAt, Clock.System.now())
+
       localOffset += localPosts.size
     } while (localPosts.size >= LOCAL_POSTS_PAGE_SIZE)
   }
@@ -658,7 +679,7 @@ class MinifluxSyncCoordinator(
       toBookmark.chunked(STATUS_BATCH_SIZE).forEach { ids -> minifluxSource.addBookmarks(ids) }
       toUnbookmark.chunked(STATUS_BATCH_SIZE).forEach { ids -> minifluxSource.removeBookmarks(ids) }
 
-      dirtyPosts.forEach { post -> rssRepository.updatePostSyncedAt(post.id, post.updatedAt) }
+      rssRepository.updatePostSyncedAt(dirtyPosts)
     }
   }
 


### PR DESCRIPTION
This change optimizes the synchronization process with Miniflux and FreshRSS by addressing the N+1 database update problem. 

Previously, for each post with a status change during sync, individual database calls were made to update the read status, bookmark status, and `syncedAt` timestamp. With this optimization, we now collect these changes and perform them in bulk using new methods in `RssRepository`, which wrap the updates in a single database transaction per batch.

**Changes:**
- `RssRepository`: Added `updatePostReadStatus(Set<String>, Boolean)`, `updateBookmarkStatus(Set<String>, Boolean)`, and `updatePostSyncedAt` (bulk versions).
- `MinifluxSyncCoordinator` & `FreshRSSSyncCoordinator`: Refactored `syncStatuses` and `pushStatusChanges` to use the new bulk repository methods.

**Performance Impact:**
Reduces the number of database transactions from potentially hundreds or thousands per sync to a constant number per page of posts (usually 5-6 transactions per 1000 posts). This significantly improves sync performance and reduces I/O overhead.

---
*PR created automatically by Jules for task [9262662521854298160](https://jules.google.com/task/9262662521854298160) started by @msasikanth*