### PR TITLE
⚡ Optimize sync status push loop in Miniflux and FreshRSS

### DIFF
--- a/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/sync/freshrss/FreshRSSSyncCoordinator.kt
+++ b/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/sync/freshrss/FreshRSSSyncCoordinator.kt
@@ -595,10 +595,26 @@ class FreshRSSSyncCoordinator(
 
       if (dirtyPosts.isEmpty()) return
 
-      val toMarkRead = dirtyPosts.filter { it.read }.mapNotNull { it.remoteId }
-      val toMarkUnread = dirtyPosts.filter { !it.read }.mapNotNull { it.remoteId }
-      val toBookmark = dirtyPosts.filter { it.bookmarked }.mapNotNull { it.remoteId }
-      val toUnbookmark = dirtyPosts.filter { !it.bookmarked }.mapNotNull { it.remoteId }
+      val toMarkRead = mutableListOf<String>()
+      val toMarkUnread = mutableListOf<String>()
+      val toBookmark = mutableListOf<String>()
+      val toUnbookmark = mutableListOf<String>()
+
+      dirtyPosts.forEach { post ->
+        val remoteId = post.remoteId ?: return@forEach
+
+        if (post.read) {
+          toMarkRead.add(remoteId)
+        } else {
+          toMarkUnread.add(remoteId)
+        }
+
+        if (post.bookmarked) {
+          toBookmark.add(remoteId)
+        } else {
+          toUnbookmark.add(remoteId)
+        }
+      }
 
       toMarkRead.chunked(STATUS_BATCH_SIZE).forEach { ids ->
         freshRssSource.markArticlesAsRead(ids)

--- a/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/sync/miniflux/MinifluxSyncCoordinator.kt
+++ b/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/sync/miniflux/MinifluxSyncCoordinator.kt
@@ -659,18 +659,27 @@ class MinifluxSyncCoordinator(
 
       if (dirtyPosts.isEmpty()) return
 
-      val toMarkRead = dirtyPosts.filter { it.read }.mapNotNull { it.remoteId?.toLong() }
-      val toMarkUnread = dirtyPosts.filter { !it.read }.mapNotNull { it.remoteId?.toLong() }
+      val toMarkRead = mutableListOf<Long>()
+      val toMarkUnread = mutableListOf<Long>()
+      val toBookmark = mutableListOf<Long>()
+      val toUnbookmark = mutableListOf<Long>()
 
-      // Only push bookmark changes for posts where local state differs from remote state
-      val toBookmark =
-        dirtyPosts
-          .filter { it.bookmarked && it.remoteId !in remoteBookmarkIds }
-          .mapNotNull { it.remoteId?.toLong() }
-      val toUnbookmark =
-        dirtyPosts
-          .filter { !it.bookmarked && it.remoteId in remoteBookmarkIds }
-          .mapNotNull { it.remoteId?.toLong() }
+      dirtyPosts.forEach { post ->
+        val remoteId = post.remoteId?.toLongOrNull() ?: return@forEach
+
+        if (post.read) {
+          toMarkRead.add(remoteId)
+        } else {
+          toMarkUnread.add(remoteId)
+        }
+
+        // Only push bookmark changes for posts where local state differs from remote state
+        if (post.bookmarked && post.remoteId !in remoteBookmarkIds) {
+          toBookmark.add(remoteId)
+        } else if (!post.bookmarked && post.remoteId in remoteBookmarkIds) {
+          toUnbookmark.add(remoteId)
+        }
+      }
 
       toMarkRead.chunked(STATUS_BATCH_SIZE).forEach { ids -> minifluxSource.markEntriesAsRead(ids) }
       toMarkUnread.chunked(STATUS_BATCH_SIZE).forEach { ids ->


### PR DESCRIPTION
The synchronization push logic for Miniflux and FreshRSS was inefficient, iterating over the list of dirty posts multiple times to segregate them into different status categories (read, unread, bookmarked, unbookmarked). This PR optimizes this by using a single-pass loop, reducing both time complexity and memory pressure from intermediate list allocations.

Key changes:
- Replaced 4x `filter` + 4x `mapNotNull` chains with a single `forEach` loop.
- Used mutable lists to collect IDs in one pass.
- Applied the optimization to both `MinifluxSyncCoordinator` and `FreshRSSSyncCoordinator`.
- Improved null/malformed ID handling in `MinifluxSyncCoordinator` using `toLongOrNull()`.

---
*PR created automatically by Jules for task [2980936037469141401](https://jules.google.com/task/2980936037469141401) started by @msasikanth*