### PR TITLE
⚡ Optimize N+1 database updates in sync coordinators

### DIFF
--- a/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/repository/RssRepository.kt
+++ b/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/repository/RssRepository.kt
@@ -90,6 +90,7 @@ class RssRepository(
 ) {
   private companion object {
     private const val POST_UPSERT_BATCH_SIZE = 200
+    private const val SQLITE_BATCH_SIZE = 990
   }
 
   suspend fun deleteAllLocalData() {
@@ -884,8 +885,12 @@ class RssRepository(
     val now = Clock.System.now()
     withContext(dispatchersProvider.databaseWrite) {
       transactionRunner.invoke {
-        postIdsSnapshot.forEach { postId ->
-          postQueries.updateReadStatus(read = if (read) 1L else 0L, id = postId, updatedAt = now)
+        postIdsSnapshot.chunked(SQLITE_BATCH_SIZE).forEach { chunk ->
+          postQueries.updatePostsReadStatus(
+            read = if (read) 1L else 0L,
+            updatedAt = now,
+            ids = chunk,
+          )
         }
       }
     }
@@ -896,11 +901,11 @@ class RssRepository(
     val now = Clock.System.now()
     withContext(dispatchersProvider.databaseWrite) {
       transactionRunner.invoke {
-        postIdsSnapshot.forEach { postId ->
-          postQueries.updateBookmarkStatus(
+        postIdsSnapshot.chunked(SQLITE_BATCH_SIZE).forEach { chunk ->
+          postQueries.updatePostsBookmarkStatus(
             bookmarked = if (bookmarked) 1L else 0L,
-            id = postId,
             updatedAt = now,
+            ids = chunk,
           )
         }
       }
@@ -977,19 +982,19 @@ class RssRepository(
     val postIdsSnapshot = postIds.toList()
     withContext(dispatchersProvider.databaseWrite) {
       transactionRunner.invoke {
-        postIdsSnapshot.forEach { postId ->
-          postQueries.updatePostSyncedAt(syncedAt = syncedAt, id = postId)
+        postIdsSnapshot.chunked(SQLITE_BATCH_SIZE).forEach { chunk ->
+          postQueries.updatePostsSyncedAt(syncedAt = syncedAt, ids = chunk)
         }
       }
     }
   }
 
   suspend fun updatePostSyncedAt(posts: List<Post>) {
-    val postsSnapshot = posts.toList()
+    val postIds = posts.map { it.id }
     withContext(dispatchersProvider.databaseWrite) {
       transactionRunner.invoke {
-        postsSnapshot.forEach { post ->
-          postQueries.updatePostSyncedAt(syncedAt = post.updatedAt, id = post.id)
+        postIds.chunked(SQLITE_BATCH_SIZE).forEach { chunk ->
+          postQueries.updatePostsSyncedAtToUpdatedAt(ids = chunk)
         }
       }
     }

--- a/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/sync/freshrss/FreshRSSSyncCoordinator.kt
+++ b/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/sync/freshrss/FreshRSSSyncCoordinator.kt
@@ -176,7 +176,10 @@ class FreshRSSSyncCoordinator(
     val feeds = rssRepository.allFeedsBlocking()
     val localSources = feeds + feedGroups
 
-    localSources.filter { it.isDeleted }.forEach { rssRepository.deleteSources(setOf(it)) }
+    val toDelete = localSources.filter { it.isDeleted }.toSet()
+    if (toDelete.isNotEmpty()) {
+      rssRepository.deleteSources(toDelete)
+    }
   }
 
   private suspend fun pushFeedChanges(syncStartTime: Instant) {

--- a/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/sync/miniflux/MinifluxSyncCoordinator.kt
+++ b/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/sync/miniflux/MinifluxSyncCoordinator.kt
@@ -182,7 +182,10 @@ class MinifluxSyncCoordinator(
     val feeds = rssRepository.allFeedsBlocking()
     val localSources = feeds + feedGroups
 
-    localSources.filter { it.isDeleted }.forEach { rssRepository.deleteSources(setOf(it)) }
+    val toDelete = localSources.filter { it.isDeleted }.toSet()
+    if (toDelete.isNotEmpty()) {
+      rssRepository.deleteSources(toDelete)
+    }
   }
 
   private suspend fun pushFeedChanges(syncStartTime: Instant) {

--- a/core/data/src/commonMain/sqldelight/dev/sasikanth/rss/reader/data/database/Post.sq
+++ b/core/data/src/commonMain/sqldelight/dev/sasikanth/rss/reader/data/database/Post.sq
@@ -530,8 +530,14 @@ WHERE
 updateBookmarkStatus:
 UPDATE post SET flags = CASE WHEN :bookmarked = 1 THEN flags | 1 ELSE flags & ~1 END, updatedAt = :updatedAt WHERE id = :id;
 
+updatePostsBookmarkStatus:
+UPDATE post SET flags = CASE WHEN :bookmarked = 1 THEN flags | 1 ELSE flags & ~1 END, updatedAt = :updatedAt WHERE id IN :ids;
+
 updateReadStatus:
 UPDATE post SET flags = CASE WHEN :read = 1 THEN flags | 2 ELSE flags & ~2 END, updatedAt = :updatedAt WHERE id = :id;
+
+updatePostsReadStatus:
+UPDATE post SET flags = CASE WHEN :read = 1 THEN flags | 2 ELSE flags & ~2 END, updatedAt = :updatedAt WHERE id IN :ids;
 
 updateSeedColor:
 UPDATE post SET seedColor = :seedColor WHERE id = :id;
@@ -668,6 +674,12 @@ UPDATE post SET remoteId = :remoteId, updatedAt = :updatedAt, syncedAt = :update
 
 updatePostSyncedAt:
 UPDATE post SET syncedAt = :syncedAt WHERE id = :id;
+
+updatePostsSyncedAt:
+UPDATE post SET syncedAt = :syncedAt WHERE id IN :ids;
+
+updatePostsSyncedAtToUpdatedAt:
+UPDATE post SET syncedAt = updatedAt WHERE id IN :ids;
 
 postsWithRemoteId:
 SELECT * FROM post WHERE remoteId IS NOT NULL;


### PR DESCRIPTION
The sync coordinators previously triggered multiple database updates in a loop, resulting in excessive SQL statements even within a single transaction. This PR introduces bulk update methods using SQL `IN` clauses to consolidate these updates into fewer database operations.

Key improvements:
- **Bulk Updates**: Added `updatePostsSyncedAt`, `updatePostsSyncedAtToUpdatedAt`, `updatePostsReadStatus`, and `updatePostsBookmarkStatus` to `Post.sq`.
- **Chunking for Safety**: `RssRepository` now automatically chunks these bulk updates into batches of 990 to avoid SQLite's 999 host parameter limit.
- **Coordinator Optimization**: `purgeDeletedSources` in both `MinifluxSyncCoordinator` and `FreshRSSSyncCoordinator` now performs a single bulk deletion call instead of iterating over deleted sources.
- **Improved Performance**: Reducing the number of SQL statements minimizes database roundtrip overhead and statement parsing time.

---
*PR created automatically by Jules for task [1944856975043781579](https://jules.google.com/task/1944856975043781579) started by @msasikanth*