### PR TITLE
Restore Search and fix Discovery icon

### DIFF
--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/app/Navigation.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/app/Navigation.kt
@@ -73,6 +73,7 @@ import dev.sasikanth.rss.reader.reader.ReaderViewModel
 import dev.sasikanth.rss.reader.reader.page.ReaderPageViewModel
 import dev.sasikanth.rss.reader.reader.ui.ReaderScreen
 import dev.sasikanth.rss.reader.search.SearchViewModel
+import dev.sasikanth.rss.reader.search.ui.SearchScreen
 import dev.sasikanth.rss.reader.settings.SettingsEvent
 import dev.sasikanth.rss.reader.settings.SettingsViewModel
 import dev.sasikanth.rss.reader.settings.ui.SettingsScreen
@@ -218,6 +219,18 @@ fun NavGraphBuilder.mainScreen(
           triggerSync = triggerSync,
           openPost = { index, post -> openPost(index, post, FromScreen.Home) },
           onMenuClicked = openDrawer,
+          modifier = screenModifier,
+        )
+      },
+      searchContent = { goBack ->
+        val viewModel = viewModel { searchViewModel() }
+
+        SearchScreen(
+          searchViewModel = viewModel,
+          goBack = goBack,
+          openPost = { searchQuery, sortOrder, index, post ->
+            openPost(index, post, FromScreen.Search(searchQuery, sortOrder))
+          },
           modifier = screenModifier,
         )
       },

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/main/ui/MainDestination.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/main/ui/MainDestination.kt
@@ -22,6 +22,7 @@ import dev.sasikanth.rss.reader.resources.icons.Bookmark
 import dev.sasikanth.rss.reader.resources.icons.BookmarkFilled
 import dev.sasikanth.rss.reader.resources.icons.Home
 import dev.sasikanth.rss.reader.resources.icons.HomeFilled
+import dev.sasikanth.rss.reader.resources.icons.Newsstand
 import dev.sasikanth.rss.reader.resources.icons.Search
 import dev.sasikanth.rss.reader.resources.icons.Settings
 import dev.sasikanth.rss.reader.resources.icons.SettingsFilled
@@ -30,6 +31,7 @@ import org.jetbrains.compose.resources.StringResource
 import twine.shared.generated.resources.Res
 import twine.shared.generated.resources.bookmarks
 import twine.shared.generated.resources.discoveryTitle
+import twine.shared.generated.resources.postsSearchHint
 import twine.shared.generated.resources.screenHome
 import twine.shared.generated.resources.settings
 
@@ -39,9 +41,14 @@ internal enum class MainDestination(
   val label: StringResource,
 ) {
   Home(icon = TwineIcons.Home, selectedIcon = TwineIcons.HomeFilled, label = Res.string.screenHome),
-  Discovery(
+  Search(
     icon = TwineIcons.Search,
     selectedIcon = TwineIcons.Search,
+    label = Res.string.postsSearchHint,
+  ),
+  Discovery(
+    icon = TwineIcons.Newsstand,
+    selectedIcon = TwineIcons.Newsstand,
     label = Res.string.discoveryTitle,
   ),
   Bookmarks(

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/main/ui/MainScreen.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/main/ui/MainScreen.kt
@@ -62,6 +62,7 @@ import kotlinx.coroutines.launch
 internal fun MainScreen(
   feedsViewModel: FeedsViewModel,
   homeContent: @Composable (openDrawer: () -> Unit) -> Unit,
+  searchContent: @Composable (openDrawer: () -> Unit) -> Unit,
   bookmarksContent: @Composable (openDrawer: () -> Unit) -> Unit,
   settingsContent: @Composable (openDrawer: () -> Unit) -> Unit,
   discoveryContent: @Composable (openDrawer: () -> Unit) -> Unit,
@@ -199,6 +200,7 @@ internal fun MainScreen(
         MainScreenContent(
           selectedDestination = selectedDestination,
           homeContent = { homeContent(openDrawer) },
+          searchContent = { searchContent(goBackToHome) },
           bookmarksContent = { bookmarksContent(goBackToHome) },
           settingsContent = { settingsContent(goBackToHome) },
           discoveryContent = { discoveryContent(goBackToHome) },
@@ -220,6 +222,7 @@ internal fun MainScreen(
           MainScreenContent(
             selectedDestination = selectedDestination,
             homeContent = { homeContent(openDrawer) },
+            searchContent = { searchContent(goBackToHome) },
             bookmarksContent = { bookmarksContent(goBackToHome) },
             settingsContent = { settingsContent(goBackToHome) },
             discoveryContent = { discoveryContent(goBackToHome) },
@@ -247,6 +250,7 @@ internal fun MainScreen(
         MainScreenContent(
           selectedDestination = selectedDestination,
           homeContent = { homeContent(openDrawer) },
+          searchContent = { searchContent(goBackToHome) },
           bookmarksContent = { bookmarksContent(goBackToHome) },
           settingsContent = { settingsContent(goBackToHome) },
           discoveryContent = { discoveryContent(goBackToHome) },
@@ -260,12 +264,14 @@ internal fun MainScreen(
 private fun MainScreenContent(
   selectedDestination: MainDestination,
   homeContent: @Composable () -> Unit,
+  searchContent: @Composable () -> Unit,
   bookmarksContent: @Composable () -> Unit,
   settingsContent: @Composable () -> Unit,
   discoveryContent: @Composable () -> Unit,
 ) {
   when (selectedDestination) {
     MainDestination.Home -> homeContent()
+    MainDestination.Search -> searchContent()
     MainDestination.Bookmarks -> bookmarksContent()
     MainDestination.Settings -> settingsContent()
     MainDestination.Discovery -> discoveryContent()


### PR DESCRIPTION
This change restores the Search screen to the main navigation drawer and corrects the Discovery navigation item's icon.

Key changes:
- `MainDestination.kt`: Added `Search` destination and changed `Discovery` icon to `Newsstand`.
- `MainScreen.kt`: Added `searchContent` parameter and handled `MainDestination.Search` in `MainScreenContent`.
- `Navigation.kt`: Provided the `SearchScreen` implementation to `MainScreen`.

Verified the changes by compiling the shared module (`./gradlew :shared:jvmMainClasses`) and running unit tests (`./gradlew :shared:jvmTest`).

---
*PR created automatically by Jules for task [12123622394143295138](https://jules.google.com/task/12123622394143295138) started by @msasikanth*