### PR TITLE
Refactor settings screen into sub-screens and improve UI

### DIFF
--- a/resources/icons/src/commonMain/kotlin/dev/sasikanth/rss/reader/resources/icons/Account.kt
+++ b/resources/icons/src/commonMain/kotlin/dev/sasikanth/rss/reader/resources/icons/Account.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 Sasikanth Miriyampalli
+ *
+ * Licensed under the GPL, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package dev.sasikanth.rss.reader.resources.icons
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+
+val TwineIcons.Account: ImageVector
+  get() {
+    if (_Account != null) {
+      return _Account!!
+    }
+    _Account =
+      ImageVector.Builder(
+          name = "Account",
+          defaultWidth = 20.dp,
+          defaultHeight = 20.dp,
+          viewportWidth = 20f,
+          viewportHeight = 20f,
+        )
+        .apply {
+          path(fill = SolidColor(Color(0xFF211A1D))) {
+            moveTo(10f, 11f)
+            curveTo(13.5f, 11f, 17f, 12f, 17f, 15f)
+            curveTo(17f, 16.381f, 15.881f, 17.5f, 14.5f, 17.5f)
+            horizontalLineTo(5.5f)
+            curveTo(4.119f, 17.5f, 3f, 16.381f, 3f, 15f)
+            curveTo(3f, 12f, 6.5f, 11f, 10f, 11f)
+            close()
+            moveTo(10f, 12.5f)
+            curveTo(8.353f, 12.5f, 6.857f, 12.741f, 5.832f, 13.229f)
+            curveTo(4.872f, 13.687f, 4.5f, 14.246f, 4.5f, 15f)
+            curveTo(4.5f, 15.552f, 4.948f, 16f, 5.5f, 16f)
+            horizontalLineTo(14.5f)
+            curveTo(15.052f, 16f, 15.5f, 15.552f, 15.5f, 15f)
+            curveTo(15.5f, 14.246f, 15.128f, 13.687f, 14.168f, 13.229f)
+            curveTo(13.143f, 12.741f, 11.647f, 12.5f, 10f, 12.5f)
+            close()
+            moveTo(10f, 2.5f)
+            curveTo(11.933f, 2.5f, 13.5f, 4.067f, 13.5f, 6f)
+            curveTo(13.5f, 7.933f, 11.933f, 9.5f, 10f, 9.5f)
+            curveTo(8.067f, 9.5f, 6.5f, 7.933f, 6.5f, 6f)
+            curveTo(6.5f, 4.067f, 8.067f, 2.5f, 10f, 2.5f)
+            close()
+            moveTo(10f, 4f)
+            curveTo(8.895f, 4f, 8f, 4.895f, 8f, 6f)
+            curveTo(8f, 7.105f, 8.895f, 8f, 10f, 8f)
+            curveTo(11.105f, 8f, 12f, 7.105f, 12f, 6f)
+            curveTo(12f, 4.895f, 11.105f, 4f, 10f, 4f)
+            close()
+          }
+        }
+        .build()
+
+    return _Account!!
+  }
+
+@Suppress("ObjectPropertyName") private var _Account: ImageVector? = null

--- a/resources/icons/src/commonMain/kotlin/dev/sasikanth/rss/reader/resources/icons/Appearance.kt
+++ b/resources/icons/src/commonMain/kotlin/dev/sasikanth/rss/reader/resources/icons/Appearance.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 Sasikanth Miriyampalli
+ *
+ * Licensed under the GPL, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package dev.sasikanth.rss.reader.resources.icons
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+
+val TwineIcons.Appearance: ImageVector
+  get() {
+    if (_Appearance != null) {
+      return _Appearance!!
+    }
+    _Appearance =
+      ImageVector.Builder(
+          name = "Appearance",
+          defaultWidth = 20.dp,
+          defaultHeight = 20.dp,
+          viewportWidth = 20f,
+          viewportHeight = 20f,
+        )
+        .apply {
+          path(fill = SolidColor(Color(0xFF211A1D)), pathFillType = PathFillType.EvenOdd) {
+            moveTo(12.75f, 2f)
+            curveTo(14.269f, 2f, 15.5f, 3.231f, 15.5f, 4.75f)
+            curveTo(15.5f, 6.174f, 14.418f, 7.344f, 13.031f, 7.485f)
+            lineTo(12.75f, 7.5f)
+            horizontalLineTo(8.25f)
+            lineTo(7.969f, 7.485f)
+            curveTo(6.835f, 7.37f, 5.906f, 6.567f, 5.604f, 5.5f)
+            horizontalLineTo(5f)
+            curveTo(4.724f, 5.5f, 4.5f, 5.724f, 4.5f, 6f)
+            verticalLineTo(8.5f)
+            curveTo(4.5f, 8.776f, 4.724f, 9f, 5f, 9f)
+            horizontalLineTo(9.5f)
+            curveTo(10.605f, 9f, 11.5f, 9.895f, 11.5f, 11f)
+            verticalLineTo(11.631f)
+            curveTo(12.373f, 11.94f, 13f, 12.771f, 13f, 13.75f)
+            verticalLineTo(16.75f)
+            curveTo(13f, 17.993f, 11.993f, 19f, 10.75f, 19f)
+            curveTo(9.507f, 19f, 8.5f, 17.993f, 8.5f, 16.75f)
+            verticalLineTo(13.75f)
+            curveTo(8.5f, 12.771f, 9.127f, 11.94f, 10f, 11.631f)
+            verticalLineTo(11f)
+            curveTo(10f, 10.724f, 9.776f, 10.5f, 9.5f, 10.5f)
+            horizontalLineTo(5f)
+            curveTo(3.895f, 10.5f, 3f, 9.605f, 3f, 8.5f)
+            verticalLineTo(6f)
+            curveTo(3f, 4.895f, 3.895f, 4f, 5f, 4f)
+            horizontalLineTo(5.606f)
+            curveTo(5.933f, 2.846f, 6.991f, 2f, 8.25f, 2f)
+            horizontalLineTo(12.75f)
+            close()
+            moveTo(10.75f, 13f)
+            curveTo(10.336f, 13f, 10f, 13.336f, 10f, 13.75f)
+            verticalLineTo(16.75f)
+            lineTo(10.004f, 16.827f)
+            curveTo(10.042f, 17.205f, 10.362f, 17.5f, 10.75f, 17.5f)
+            curveTo(11.138f, 17.5f, 11.458f, 17.205f, 11.496f, 16.827f)
+            lineTo(11.5f, 16.75f)
+            verticalLineTo(13.75f)
+            curveTo(11.5f, 13.336f, 11.164f, 13f, 10.75f, 13f)
+            close()
+            moveTo(8.25f, 3.5f)
+            curveTo(7.56f, 3.5f, 7f, 4.06f, 7f, 4.75f)
+            curveTo(7f, 5.44f, 7.56f, 6f, 8.25f, 6f)
+            horizontalLineTo(12.75f)
+            curveTo(13.44f, 6f, 14f, 5.44f, 14f, 4.75f)
+            curveTo(14f, 4.06f, 13.44f, 3.5f, 12.75f, 3.5f)
+            horizontalLineTo(8.25f)
+            close()
+          }
+        }
+        .build()
+
+    return _Appearance!!
+  }
+
+@Suppress("ObjectPropertyName") private var _Appearance: ImageVector? = null

--- a/resources/icons/src/commonMain/kotlin/dev/sasikanth/rss/reader/resources/icons/Behaviors.kt
+++ b/resources/icons/src/commonMain/kotlin/dev/sasikanth/rss/reader/resources/icons/Behaviors.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 Sasikanth Miriyampalli
+ *
+ * Licensed under the GPL, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package dev.sasikanth.rss.reader.resources.icons
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+
+val TwineIcons.Behaviors: ImageVector
+  get() {
+    if (_Behaviors != null) {
+      return _Behaviors!!
+    }
+    _Behaviors =
+      ImageVector.Builder(
+          name = "Behaviors",
+          defaultWidth = 20.dp,
+          defaultHeight = 20.dp,
+          viewportWidth = 20f,
+          viewportHeight = 20f,
+        )
+        .apply {
+          path(fill = SolidColor(Color(0xFF211A1D))) {
+            moveTo(14.257f, 5.007f)
+            curveTo(16.899f, 5.141f, 19f, 7.325f, 19f, 10f)
+            curveTo(19f, 12.675f, 16.899f, 14.859f, 14.257f, 14.993f)
+            lineTo(14f, 15f)
+            horizontalLineTo(6f)
+            curveTo(3.239f, 15f, 1f, 12.761f, 1f, 10f)
+            curveTo(1f, 7.239f, 3.239f, 5f, 6f, 5f)
+            horizontalLineTo(14f)
+            lineTo(14.257f, 5.007f)
+            close()
+            moveTo(6f, 6.5f)
+            curveTo(4.067f, 6.5f, 2.5f, 8.067f, 2.5f, 10f)
+            curveTo(2.5f, 11.933f, 4.067f, 13.5f, 6f, 13.5f)
+            horizontalLineTo(14f)
+            curveTo(15.933f, 13.5f, 17.5f, 11.933f, 17.5f, 10f)
+            curveTo(17.5f, 8.067f, 15.933f, 6.5f, 14f, 6.5f)
+            horizontalLineTo(6f)
+            close()
+            moveTo(14f, 8f)
+            curveTo(15.105f, 8f, 16f, 8.895f, 16f, 10f)
+            curveTo(16f, 11.105f, 15.105f, 12f, 14f, 12f)
+            curveTo(12.895f, 12f, 12f, 11.105f, 12f, 10f)
+            curveTo(12f, 8.895f, 12.895f, 8f, 14f, 8f)
+            close()
+          }
+        }
+        .build()
+
+    return _Behaviors!!
+  }
+
+@Suppress("ObjectPropertyName") private var _Behaviors: ImageVector? = null

--- a/resources/icons/src/commonMain/kotlin/dev/sasikanth/rss/reader/resources/icons/Changelog.kt
+++ b/resources/icons/src/commonMain/kotlin/dev/sasikanth/rss/reader/resources/icons/Changelog.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 Sasikanth Miriyampalli
+ *
+ * Licensed under the GPL, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package dev.sasikanth.rss.reader.resources.icons
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+
+val TwineIcons.Changelog: ImageVector
+  get() {
+    if (_Changelog != null) {
+      return _Changelog!!
+    }
+    _Changelog =
+      ImageVector.Builder(
+          name = "Changelog",
+          defaultWidth = 20.dp,
+          defaultHeight = 20.dp,
+          viewportWidth = 20f,
+          viewportHeight = 20f,
+        )
+        .apply {
+          path(fill = SolidColor(Color(0xFF161D1C))) {
+            moveTo(12.373f, 2f)
+            curveTo(13.138f, 2f, 13.87f, 2.153f, 14.537f, 2.432f)
+            curveTo(14.768f, 2.528f, 14.936f, 2.733f, 14.984f, 2.979f)
+            curveTo(15.033f, 3.224f, 14.956f, 3.478f, 14.779f, 3.654f)
+            lineTo(12.748f, 5.685f)
+            verticalLineTo(7.25f)
+            horizontalLineTo(14.314f)
+            lineTo(16.344f, 5.219f)
+            curveTo(16.521f, 5.042f, 16.774f, 4.965f, 17.02f, 5.014f)
+            curveTo(17.265f, 5.062f, 17.47f, 5.23f, 17.566f, 5.461f)
+            curveTo(17.845f, 6.128f, 17.998f, 6.86f, 17.998f, 7.625f)
+            curveTo(17.998f, 10.731f, 15.479f, 13.25f, 12.373f, 13.25f)
+            curveTo(11.893f, 13.25f, 11.428f, 13.188f, 10.984f, 13.074f)
+            lineTo(6.4f, 17.657f)
+            curveTo(5.279f, 18.778f, 3.462f, 18.778f, 2.341f, 17.657f)
+            curveTo(1.22f, 16.536f, 1.219f, 14.718f, 2.341f, 13.597f)
+            lineTo(6.924f, 9.014f)
+            curveTo(6.81f, 8.57f, 6.748f, 8.105f, 6.748f, 7.625f)
+            curveTo(6.748f, 4.519f, 9.267f, 2f, 12.373f, 2f)
+            close()
+            moveTo(12.373f, 3.5f)
+            curveTo(10.095f, 3.5f, 8.248f, 5.347f, 8.248f, 7.625f)
+            curveTo(8.248f, 8.1f, 8.329f, 8.556f, 8.478f, 8.981f)
+            curveTo(8.572f, 9.253f, 8.504f, 9.555f, 8.301f, 9.759f)
+            lineTo(3.401f, 14.658f)
+            curveTo(2.866f, 15.194f, 2.866f, 16.061f, 3.401f, 16.597f)
+            curveTo(3.937f, 17.132f, 4.804f, 17.132f, 5.34f, 16.597f)
+            lineTo(10.239f, 11.697f)
+            curveTo(10.443f, 11.494f, 10.745f, 11.426f, 11.017f, 11.521f)
+            curveTo(11.442f, 11.669f, 11.898f, 11.75f, 12.373f, 11.75f)
+            curveTo(14.651f, 11.75f, 16.498f, 9.903f, 16.498f, 7.625f)
+            curveTo(16.498f, 7.484f, 16.491f, 7.344f, 16.478f, 7.207f)
+            lineTo(15.153f, 8.53f)
+            curveTo(15.013f, 8.671f, 14.822f, 8.75f, 14.623f, 8.75f)
+            horizontalLineTo(11.998f)
+            curveTo(11.584f, 8.75f, 11.248f, 8.414f, 11.248f, 8f)
+            verticalLineTo(5.375f)
+            curveTo(11.248f, 5.176f, 11.327f, 4.985f, 11.468f, 4.845f)
+            lineTo(12.791f, 3.521f)
+            curveTo(12.654f, 3.507f, 12.514f, 3.5f, 12.373f, 3.5f)
+            close()
+          }
+        }
+        .build()
+
+    return _Changelog!!
+  }
+
+@Suppress("ObjectPropertyName") private var _Changelog: ImageVector? = null

--- a/resources/icons/src/commonMain/kotlin/dev/sasikanth/rss/reader/resources/icons/Sync.kt
+++ b/resources/icons/src/commonMain/kotlin/dev/sasikanth/rss/reader/resources/icons/Sync.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 Sasikanth Miriyampalli
+ *
+ * Licensed under the GPL, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package dev.sasikanth.rss.reader.resources.icons
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+
+val TwineIcons.Sync: ImageVector
+  get() {
+    if (_Sync != null) {
+      return _Sync!!
+    }
+    _Sync =
+      ImageVector.Builder(
+          name = "Sync",
+          defaultWidth = 20.dp,
+          defaultHeight = 20.dp,
+          viewportWidth = 20f,
+          viewportHeight = 20f,
+        )
+        .apply {
+          path(fill = SolidColor(Color(0xFF211A1D))) {
+            moveTo(3.276f, 7.168f)
+            curveTo(3.571f, 6.928f, 4.006f, 6.945f, 4.28f, 7.22f)
+            lineTo(6.78f, 9.72f)
+            curveTo(7.073f, 10.013f, 7.073f, 10.487f, 6.78f, 10.78f)
+            curveTo(6.487f, 11.073f, 6.013f, 11.073f, 5.72f, 10.78f)
+            lineTo(4.516f, 9.576f)
+            curveTo(4.505f, 9.716f, 4.5f, 9.857f, 4.5f, 10f)
+            curveTo(4.5f, 13.038f, 6.962f, 15.5f, 10f, 15.5f)
+            curveTo(10.771f, 15.5f, 11.502f, 15.342f, 12.166f, 15.058f)
+            curveTo(12.547f, 14.894f, 12.987f, 15.071f, 13.15f, 15.451f)
+            curveTo(13.314f, 15.832f, 13.137f, 16.272f, 12.757f, 16.435f)
+            curveTo(11.91f, 16.799f, 10.977f, 17f, 10f, 17f)
+            curveTo(6.134f, 17f, 3f, 13.866f, 3f, 10f)
+            curveTo(3f, 9.847f, 3.006f, 9.695f, 3.016f, 9.544f)
+            lineTo(1.78f, 10.78f)
+            curveTo(1.487f, 11.073f, 1.013f, 11.073f, 0.72f, 10.78f)
+            curveTo(0.427f, 10.487f, 0.427f, 10.013f, 0.72f, 9.72f)
+            lineTo(3.22f, 7.22f)
+            lineTo(3.276f, 7.168f)
+            close()
+            moveTo(10f, 3f)
+            curveTo(13.866f, 3f, 17f, 6.134f, 17f, 10f)
+            curveTo(17f, 10.153f, 16.993f, 10.304f, 16.983f, 10.455f)
+            lineTo(18.22f, 9.22f)
+            curveTo(18.513f, 8.927f, 18.987f, 8.927f, 19.28f, 9.22f)
+            curveTo(19.573f, 9.513f, 19.573f, 9.987f, 19.28f, 10.28f)
+            lineTo(16.78f, 12.78f)
+            lineTo(16.724f, 12.832f)
+            curveTo(16.429f, 13.072f, 15.994f, 13.055f, 15.72f, 12.78f)
+            lineTo(13.22f, 10.28f)
+            curveTo(12.927f, 9.987f, 12.927f, 9.513f, 13.22f, 9.22f)
+            curveTo(13.513f, 8.927f, 13.987f, 8.927f, 14.28f, 9.22f)
+            lineTo(15.483f, 10.423f)
+            curveTo(15.494f, 10.283f, 15.5f, 10.142f, 15.5f, 10f)
+            curveTo(15.5f, 6.962f, 13.038f, 4.5f, 10f, 4.5f)
+            curveTo(9.229f, 4.5f, 8.498f, 4.658f, 7.834f, 4.942f)
+            curveTo(7.453f, 5.106f, 7.013f, 4.929f, 6.85f, 4.549f)
+            curveTo(6.686f, 4.168f, 6.862f, 3.728f, 7.243f, 3.564f)
+            curveTo(8.09f, 3.201f, 9.023f, 3f, 10f, 3f)
+            close()
+          }
+        }
+        .build()
+
+    return _Sync!!
+  }
+
+@Suppress("ObjectPropertyName") private var _Sync: ImageVector? = null

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -53,6 +53,14 @@
   <string name="bookmarks">Bookmarks</string>
   <string name="bookmarksPlaceholder">Bookmarked posts will appear here 🔖</string>
   <string name="settings">Settings</string>
+  <string name="settingsAppearanceAndLayout">Appearance &amp; layout</string>
+  <string name="settingsAppearanceAndLayoutSubtitle">Customize how Twine looks</string>
+  <string name="settingsFeaturesAndBehaviors">Features &amp; behaviors</string>
+  <string name="settingsFeaturesAndBehaviorsSubtitle">Customize how Twine works</string>
+  <string name="settingsServicesAndSync">Services &amp; sync</string>
+  <string name="settingsServicesAndSyncSubtitle">Manage RSS services</string>
+  <string name="settingsYourInsights">Your insights</string>
+  <string name="settingsYourInsightsSubtitle">Manage your reading data</string>
   <string name="moreMenuOptions">More menu options</string>
   <string name="settingsHeaderBehaviour">Behavior</string>
   <string name="settingsHeaderOpml" translatable="false">OPML</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -61,6 +61,7 @@
   <string name="settingsServicesAndSyncSubtitle">Manage RSS services</string>
   <string name="settingsYourInsights">Your insights</string>
   <string name="settingsYourInsightsSubtitle">Manage your reading data</string>
+  <string name="settingsAppInfoAndFeedback">App info &amp; feedback</string>
   <string name="moreMenuOptions">More menu options</string>
   <string name="settingsHeaderBehaviour">Behavior</string>
   <string name="settingsHeaderOpml" translatable="false">OPML</string>

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/about/ui/AboutScreen.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/about/ui/AboutScreen.kt
@@ -35,13 +35,11 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -56,9 +54,8 @@ import androidx.compose.ui.util.fastForEach
 import coil3.compose.AsyncImage
 import dev.sasikanth.rss.reader.about.Person
 import dev.sasikanth.rss.reader.about.Social
-import dev.sasikanth.rss.reader.components.CircularIconButton
+import dev.sasikanth.rss.reader.components.SimpleTopAppBar
 import dev.sasikanth.rss.reader.platform.LocalLinkHandler
-import dev.sasikanth.rss.reader.resources.icons.ArrowBack
 import dev.sasikanth.rss.reader.resources.icons.GitHub
 import dev.sasikanth.rss.reader.resources.icons.Threads
 import dev.sasikanth.rss.reader.resources.icons.TwineIcons
@@ -76,7 +73,6 @@ import twine.shared.generated.resources.aboutSocialGitHub
 import twine.shared.generated.resources.aboutSocialThreads
 import twine.shared.generated.resources.aboutSocialTwitter
 import twine.shared.generated.resources.aboutSocialWebsite
-import twine.shared.generated.resources.buttonGoBack
 
 @Composable
 fun AboutScreen(goBack: () -> Unit, modifier: Modifier = Modifier) {
@@ -141,39 +137,7 @@ fun AboutScreen(goBack: () -> Unit, modifier: Modifier = Modifier) {
 
   Scaffold(
     modifier = modifier,
-    topBar = {
-      Box {
-        CenterAlignedTopAppBar(
-          title = {
-            Text(
-              text = stringResource(Res.string.about),
-              color = AppTheme.colorScheme.onSurface,
-              style = MaterialTheme.typography.titleMedium,
-            )
-          },
-          navigationIcon = {
-            CircularIconButton(
-              modifier = Modifier.padding(start = 12.dp),
-              icon = TwineIcons.ArrowBack,
-              label = stringResource(Res.string.buttonGoBack),
-              onClick = { goBack() },
-            )
-          },
-          colors =
-            TopAppBarDefaults.topAppBarColors(
-              containerColor = AppTheme.colorScheme.surface,
-              navigationIconContentColor = AppTheme.colorScheme.onSurface,
-              titleContentColor = AppTheme.colorScheme.onSurface,
-              actionIconContentColor = AppTheme.colorScheme.onSurface,
-            ),
-        )
-
-        HorizontalDivider(
-          modifier = Modifier.fillMaxWidth().align(Alignment.BottomStart),
-          color = AppTheme.colorScheme.outlineVariant,
-        )
-      }
-    },
+    topBar = { SimpleTopAppBar(title = stringResource(Res.string.about), onBackClick = goBack) },
     content = { padding ->
       Box(modifier = Modifier.fillMaxSize()) {
         LazyColumn(

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/app/App.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/app/App.kt
@@ -381,6 +381,17 @@ fun App(
           navController = navController,
         )
 
+        settingsAppearanceScreen(
+          settingsViewModel = settingsViewModel,
+          navController = navController,
+        )
+
+        settingsBehaviorScreen(settingsViewModel = settingsViewModel, navController = navController)
+
+        settingsServicesScreen(settingsViewModel = settingsViewModel, navController = navController)
+
+        settingsDataScreen(settingsViewModel = settingsViewModel, navController = navController)
+
         feedInfoDialog(feedViewModel = feedViewModel, navController = navController)
 
         groupSelectionDialog(

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/app/App.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/app/App.kt
@@ -392,6 +392,8 @@ fun App(
 
         settingsDataScreen(settingsViewModel = settingsViewModel, navController = navController)
 
+        settingsAppInfoScreen(settingsViewModel = settingsViewModel, navController = navController)
+
         feedInfoDialog(feedViewModel = feedViewModel, navController = navController)
 
         groupSelectionDialog(

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/app/Navigation.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/app/Navigation.kt
@@ -76,7 +76,11 @@ import dev.sasikanth.rss.reader.search.SearchViewModel
 import dev.sasikanth.rss.reader.search.ui.SearchScreen
 import dev.sasikanth.rss.reader.settings.SettingsEvent
 import dev.sasikanth.rss.reader.settings.SettingsViewModel
+import dev.sasikanth.rss.reader.settings.ui.SettingsAppearanceScreen
+import dev.sasikanth.rss.reader.settings.ui.SettingsBehaviorScreen
+import dev.sasikanth.rss.reader.settings.ui.SettingsDataScreen
 import dev.sasikanth.rss.reader.settings.ui.SettingsScreen
+import dev.sasikanth.rss.reader.settings.ui.SettingsServicesScreen
 import dev.sasikanth.rss.reader.statistics.StatisticsViewModel
 import dev.sasikanth.rss.reader.statistics.ui.StatisticsScreen
 import kotlin.reflect.typeOf
@@ -275,12 +279,12 @@ fun NavGraphBuilder.mainScreen(
         SettingsScreen(
           viewModel = viewModel,
           goBack = goBack,
+          openAppearanceSettings = { navController.navigate(Screen.SettingsAppearance) },
+          openBehaviorSettings = { navController.navigate(Screen.SettingsBehavior) },
+          openServicesSettings = { navController.navigate(Screen.SettingsServices) },
+          openDataSettings = { navController.navigate(Screen.SettingsData) },
           openAbout = { navController.navigate(Screen.About) },
-          openStatistics = { navController.navigate(Screen.Statistics) },
-          openBlockedWords = { navController.navigate(Screen.BlockedWords) },
           openPaywall = { navController.navigate(Screen.Paywall) },
-          openFreshRssLogin = { navController.navigate(Screen.FreshRssLogin) },
-          openMinifluxLogin = { navController.navigate(Screen.MinifluxLogin) },
           modifier = screenModifier,
         )
       },
@@ -299,6 +303,64 @@ fun NavGraphBuilder.mainScreen(
       openGroupSelectionSheet = { feedsViewModel.dispatch(FeedsEvent.OnAddToGroupClicked) },
       openAddFeedScreen = { navController.navigate(Screen.AddFeed) },
       openPaywall = { navController.navigate(Screen.Paywall) },
+    )
+  }
+}
+
+fun NavGraphBuilder.settingsAppearanceScreen(
+  settingsViewModel: () -> SettingsViewModel,
+  navController: NavHostController,
+) {
+  composable<Screen.SettingsAppearance> {
+    val viewModel = viewModel { settingsViewModel() }
+    SettingsAppearanceScreen(
+      viewModel = viewModel,
+      goBack = { navController.popBackStack() },
+      openPaywall = { navController.navigate(Screen.Paywall) },
+    )
+  }
+}
+
+fun NavGraphBuilder.settingsBehaviorScreen(
+  settingsViewModel: () -> SettingsViewModel,
+  navController: NavHostController,
+) {
+  composable<Screen.SettingsBehavior> {
+    val viewModel = viewModel { settingsViewModel() }
+    SettingsBehaviorScreen(
+      viewModel = viewModel,
+      goBack = { navController.popBackStack() },
+      openBlockedWords = { navController.navigate(Screen.BlockedWords) },
+    )
+  }
+}
+
+fun NavGraphBuilder.settingsServicesScreen(
+  settingsViewModel: () -> SettingsViewModel,
+  navController: NavHostController,
+) {
+  composable<Screen.SettingsServices> {
+    val viewModel = viewModel { settingsViewModel() }
+    SettingsServicesScreen(
+      viewModel = viewModel,
+      goBack = { navController.popBackStack() },
+      openPaywall = { navController.navigate(Screen.Paywall) },
+      openFreshRssLogin = { navController.navigate(Screen.FreshRssLogin) },
+      openMinifluxLogin = { navController.navigate(Screen.MinifluxLogin) },
+    )
+  }
+}
+
+fun NavGraphBuilder.settingsDataScreen(
+  settingsViewModel: () -> SettingsViewModel,
+  navController: NavHostController,
+) {
+  composable<Screen.SettingsData> {
+    val viewModel = viewModel { settingsViewModel() }
+    SettingsDataScreen(
+      viewModel = viewModel,
+      goBack = { navController.popBackStack() },
+      openStatistics = { navController.navigate(Screen.Statistics) },
     )
   }
 }

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/app/Navigation.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/app/Navigation.kt
@@ -76,6 +76,7 @@ import dev.sasikanth.rss.reader.search.SearchViewModel
 import dev.sasikanth.rss.reader.search.ui.SearchScreen
 import dev.sasikanth.rss.reader.settings.SettingsEvent
 import dev.sasikanth.rss.reader.settings.SettingsViewModel
+import dev.sasikanth.rss.reader.settings.ui.SettingsAppInfoScreen
 import dev.sasikanth.rss.reader.settings.ui.SettingsAppearanceScreen
 import dev.sasikanth.rss.reader.settings.ui.SettingsBehaviorScreen
 import dev.sasikanth.rss.reader.settings.ui.SettingsDataScreen
@@ -277,13 +278,12 @@ fun NavGraphBuilder.mainScreen(
         }
 
         SettingsScreen(
-          viewModel = viewModel,
           goBack = goBack,
           openAppearanceSettings = { navController.navigate(Screen.SettingsAppearance) },
           openBehaviorSettings = { navController.navigate(Screen.SettingsBehavior) },
           openServicesSettings = { navController.navigate(Screen.SettingsServices) },
           openDataSettings = { navController.navigate(Screen.SettingsData) },
-          openAbout = { navController.navigate(Screen.About) },
+          openAppInfoSettings = { navController.navigate(Screen.SettingsAppInfo) },
           modifier = screenModifier,
         )
       },
@@ -360,6 +360,20 @@ fun NavGraphBuilder.settingsDataScreen(
       viewModel = viewModel,
       goBack = { navController.popBackStack() },
       openStatistics = { navController.navigate(Screen.Statistics) },
+    )
+  }
+}
+
+fun NavGraphBuilder.settingsAppInfoScreen(
+  settingsViewModel: () -> SettingsViewModel,
+  navController: NavHostController,
+) {
+  composable<Screen.SettingsAppInfo> {
+    val viewModel = viewModel { settingsViewModel() }
+    SettingsAppInfoScreen(
+      viewModel = viewModel,
+      goBack = { navController.popBackStack() },
+      openAbout = { navController.navigate(Screen.About) },
     )
   }
 }

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/app/Navigation.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/app/Navigation.kt
@@ -23,9 +23,11 @@ import androidx.compose.ui.Modifier
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.dialog
 import androidx.navigation.navDeepLink
 import androidx.navigation.toRoute
@@ -184,6 +186,9 @@ fun NavGraphBuilder.mainScreen(
     val triggerSync = it.toRoute<Screen.Main>().triggerSync
     val feedsViewModel = viewModel { feedsViewModel() }
 
+    val currentEntry by navController.currentBackStackEntryAsState()
+    val isMainActive = currentEntry?.destination?.hasRoute(Screen.Main::class) ?: false
+
     LaunchedEffect(useDarkTheme) {
       toggleLightStatusBar(!useDarkTheme)
       toggleLightNavBar(!useDarkTheme)
@@ -302,6 +307,7 @@ fun NavGraphBuilder.mainScreen(
       openGroupSelectionSheet = { feedsViewModel.dispatch(FeedsEvent.OnAddToGroupClicked) },
       openAddFeedScreen = { navController.navigate(Screen.AddFeed) },
       openPaywall = { navController.navigate(Screen.Paywall) },
+      canHandleBack = isMainActive,
     )
   }
 }

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/app/Navigation.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/app/Navigation.kt
@@ -284,7 +284,6 @@ fun NavGraphBuilder.mainScreen(
           openServicesSettings = { navController.navigate(Screen.SettingsServices) },
           openDataSettings = { navController.navigate(Screen.SettingsData) },
           openAbout = { navController.navigate(Screen.About) },
-          openPaywall = { navController.navigate(Screen.Paywall) },
           modifier = screenModifier,
         )
       },

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/app/Screens.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/app/Screens.kt
@@ -56,6 +56,8 @@ sealed interface Screen {
 
   @Serializable data object SettingsData : Screen
 
+  @Serializable data object SettingsAppInfo : Screen
+
   @Serializable data object AccountSelection : Screen
 
   @Serializable data class Discovery(val isFromOnboarding: Boolean = false) : Screen

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/app/Screens.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/app/Screens.kt
@@ -48,6 +48,14 @@ sealed interface Screen {
 
   @Serializable data object Settings : Screen
 
+  @Serializable data object SettingsAppearance : Screen
+
+  @Serializable data object SettingsBehavior : Screen
+
+  @Serializable data object SettingsServices : Screen
+
+  @Serializable data object SettingsData : Screen
+
   @Serializable data object AccountSelection : Screen
 
   @Serializable data class Discovery(val isFromOnboarding: Boolean = false) : Screen

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/blockedwords/BlockedWordsScreen.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/blockedwords/BlockedWordsScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.animation.shrinkHorizontally
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -43,7 +42,6 @@ import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.foundation.text.selection.TextSelectionColors
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Check
-import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -52,7 +50,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -71,9 +68,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import dev.sasikanth.rss.reader.components.CircularIconButton
+import dev.sasikanth.rss.reader.components.SimpleTopAppBar
 import dev.sasikanth.rss.reader.core.model.local.BlockedWord
-import dev.sasikanth.rss.reader.resources.icons.ArrowBack
 import dev.sasikanth.rss.reader.resources.icons.DeleteOutline
 import dev.sasikanth.rss.reader.resources.icons.TwineIcons
 import dev.sasikanth.rss.reader.ui.AppTheme
@@ -87,7 +83,6 @@ import twine.shared.generated.resources.blockedWordsDesc
 import twine.shared.generated.resources.blockedWordsEmpty
 import twine.shared.generated.resources.blockedWordsHint
 import twine.shared.generated.resources.buttonAdd
-import twine.shared.generated.resources.buttonGoBack
 import twine.shared.generated.resources.delete
 import twine.shared.generated.resources.readLess
 import twine.shared.generated.resources.readMore
@@ -105,37 +100,7 @@ fun BlockedWordsScreen(
   Scaffold(
     modifier = modifier,
     topBar = {
-      Box {
-        CenterAlignedTopAppBar(
-          title = {
-            Text(
-              text = stringResource(Res.string.blockedWords),
-              color = AppTheme.colorScheme.onSurface,
-              style = MaterialTheme.typography.titleMedium,
-            )
-          },
-          navigationIcon = {
-            CircularIconButton(
-              modifier = Modifier.padding(start = 12.dp),
-              icon = TwineIcons.ArrowBack,
-              label = stringResource(Res.string.buttonGoBack),
-              onClick = { goBack() },
-            )
-          },
-          colors =
-            TopAppBarDefaults.topAppBarColors(
-              containerColor = AppTheme.colorScheme.surface,
-              navigationIconContentColor = AppTheme.colorScheme.onSurface,
-              titleContentColor = AppTheme.colorScheme.onSurface,
-              actionIconContentColor = AppTheme.colorScheme.onSurface,
-            ),
-        )
-
-        HorizontalDivider(
-          modifier = Modifier.fillMaxWidth().align(Alignment.BottomStart),
-          color = AppTheme.colorScheme.outlineVariant,
-        )
-      }
+      SimpleTopAppBar(title = stringResource(Res.string.blockedWords), onBackClick = goBack)
     },
     containerColor = AppTheme.colorScheme.backdrop,
     contentColor = Color.Unspecified,

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/components/SimpleTopAppBar.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/components/SimpleTopAppBar.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 Sasikanth Miriyampalli
+ *
+ * Licensed under the GPL, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package dev.sasikanth.rss.reader.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import dev.sasikanth.rss.reader.resources.icons.ArrowBack
+import dev.sasikanth.rss.reader.resources.icons.TwineIcons
+import dev.sasikanth.rss.reader.ui.AppTheme
+import org.jetbrains.compose.resources.stringResource
+import twine.shared.generated.resources.Res
+import twine.shared.generated.resources.buttonGoBack
+
+@Composable
+fun SimpleTopAppBar(
+  title: String,
+  onBackClick: () -> Unit,
+  modifier: Modifier = Modifier,
+  actions: @Composable RowScope.() -> Unit = {},
+) {
+  Box(modifier = modifier) {
+    TopAppBar(
+      title = {
+        Text(
+          modifier = Modifier.padding(start = 12.dp),
+          text = title,
+          color = AppTheme.colorScheme.onSurface,
+          style = MaterialTheme.typography.titleLarge,
+          fontWeight = FontWeight.SemiBold,
+        )
+      },
+      navigationIcon = {
+        CircularIconButton(
+          modifier = Modifier.padding(start = 12.dp),
+          icon = TwineIcons.ArrowBack,
+          label = stringResource(Res.string.buttonGoBack),
+          backgroundColor = AppTheme.colorScheme.inverseSurface,
+          borderColor = AppTheme.colorScheme.inverseSurface,
+          contentColor = AppTheme.colorScheme.inverseOnSurface,
+          onClick = onBackClick,
+        )
+      },
+      actions = actions,
+      contentPadding = PaddingValues(vertical = 8.dp),
+      colors =
+        TopAppBarDefaults.topAppBarColors(
+          containerColor = AppTheme.colorScheme.surfaceContainerHigh,
+          navigationIconContentColor = AppTheme.colorScheme.onSurface,
+          titleContentColor = AppTheme.colorScheme.onSurface,
+          actionIconContentColor = AppTheme.colorScheme.onSurface,
+        ),
+    )
+
+    HorizontalDivider(
+      modifier = Modifier.fillMaxWidth().align(Alignment.BottomStart),
+      color = AppTheme.colorScheme.outlineVariant,
+    )
+  }
+}

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/freshrss/ui/FreshRssLoginScreen.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/freshrss/ui/FreshRssLoginScreen.kt
@@ -19,7 +19,6 @@ package dev.sasikanth.rss.reader.freshrss.ui
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -33,9 +32,7 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Snackbar
@@ -43,7 +40,6 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -53,6 +49,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
@@ -61,19 +58,16 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.sasikanth.rss.reader.components.Button
-import dev.sasikanth.rss.reader.components.CircularIconButton
+import dev.sasikanth.rss.reader.components.SimpleTopAppBar
 import dev.sasikanth.rss.reader.components.TextField
 import dev.sasikanth.rss.reader.freshrss.FreshRssLoginError
 import dev.sasikanth.rss.reader.freshrss.FreshRssLoginEvent
 import dev.sasikanth.rss.reader.freshrss.FreshRssLoginViewModel
-import dev.sasikanth.rss.reader.resources.icons.ArrowBack
-import dev.sasikanth.rss.reader.resources.icons.TwineIcons
 import dev.sasikanth.rss.reader.ui.AppTheme
 import org.jetbrains.compose.resources.getString
 import org.jetbrains.compose.resources.stringResource
 import twine.shared.generated.resources.Res
 import twine.shared.generated.resources.buttonCancel
-import twine.shared.generated.resources.buttonGoBack
 import twine.shared.generated.resources.freshRssClearDataDesc
 import twine.shared.generated.resources.freshRssClearDataPositive
 import twine.shared.generated.resources.freshRssClearDataTitle
@@ -162,37 +156,7 @@ fun FreshRssLoginScreen(
   Scaffold(
     modifier = modifier,
     topBar = {
-      Box {
-        CenterAlignedTopAppBar(
-          title = {
-            Text(
-              text = stringResource(Res.string.freshRssLoginTitle),
-              color = AppTheme.colorScheme.onSurface,
-              style = MaterialTheme.typography.titleMedium,
-            )
-          },
-          navigationIcon = {
-            CircularIconButton(
-              modifier = Modifier.padding(start = 12.dp),
-              icon = TwineIcons.ArrowBack,
-              label = stringResource(Res.string.buttonGoBack),
-              onClick = goBack,
-            )
-          },
-          colors =
-            TopAppBarDefaults.topAppBarColors(
-              containerColor = AppTheme.colorScheme.surface,
-              navigationIconContentColor = AppTheme.colorScheme.onSurface,
-              titleContentColor = AppTheme.colorScheme.onSurface,
-              actionIconContentColor = AppTheme.colorScheme.onSurface,
-            ),
-        )
-
-        HorizontalDivider(
-          modifier = Modifier.align(Alignment.BottomCenter),
-          color = AppTheme.colorScheme.outlineVariant,
-        )
-      }
+      SimpleTopAppBar(title = stringResource(Res.string.freshRssLoginTitle), onBackClick = goBack)
     },
     snackbarHost = {
       SnackbarHost(hostState = snackbarHostState) { snackbarData ->
@@ -248,6 +212,7 @@ fun FreshRssLoginScreen(
       }
     },
     containerColor = AppTheme.colorScheme.backdrop,
+    contentColor = Color.Unspecified,
   ) { padding ->
     LazyColumn(
       modifier = Modifier.fillMaxSize().padding(padding).padding(horizontal = 24.dp),

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/ui/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/ui/HomeScreen.kt
@@ -121,6 +121,7 @@ internal fun HomeScreen(
   openPost: (Int, ResolvedPost) -> Unit,
   onMenuClicked: (() -> Unit)? = null,
   modifier: Modifier = Modifier,
+  canHandleBack: Boolean = true,
 ) {
   val coroutineScope = rememberCoroutineScope()
   val state by viewModel.state.collectAsStateWithLifecycle()

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/main/ui/MainScreen.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/main/ui/MainScreen.kt
@@ -72,6 +72,7 @@ internal fun MainScreen(
   openAddFeedScreen: () -> Unit,
   openPaywall: () -> Unit,
   modifier: Modifier = Modifier,
+  canHandleBack: Boolean = true,
 ) {
   val sizeClass = LocalWindowSizeClass.current
   val drawerState = rememberDrawerState(DrawerValue.Closed)
@@ -84,11 +85,12 @@ internal fun MainScreen(
   NavigationEventHandler(
     state = rememberNavigationEventState(NavigationEventInfo.None),
     isBackEnabled =
-      selectedDestination != MainDestination.Home ||
-        (sizeClass.isWidthAtLeastBreakpoint(WindowSizeClass.WIDTH_DP_EXPANDED_LOWER_BOUND) &&
-          isSideNavigationExpanded &&
-          !sizeClass.isWidthAtLeastBreakpoint(WindowSizeClass.WIDTH_DP_LARGE_LOWER_BOUND)) ||
-        (drawerState.isOpen),
+      canHandleBack &&
+        (selectedDestination != MainDestination.Home ||
+          (sizeClass.isWidthAtLeastBreakpoint(WindowSizeClass.WIDTH_DP_EXPANDED_LOWER_BOUND) &&
+            isSideNavigationExpanded &&
+            !sizeClass.isWidthAtLeastBreakpoint(WindowSizeClass.WIDTH_DP_LARGE_LOWER_BOUND)) ||
+          (drawerState.isOpen)),
   ) {
     when {
       drawerState.isOpen -> {

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/miniflux/ui/MinifluxLoginScreen.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/miniflux/ui/MinifluxLoginScreen.kt
@@ -19,7 +19,6 @@ package dev.sasikanth.rss.reader.miniflux.ui
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -33,9 +32,7 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Snackbar
@@ -43,7 +40,6 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -53,6 +49,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
@@ -61,19 +58,16 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.sasikanth.rss.reader.components.Button
-import dev.sasikanth.rss.reader.components.CircularIconButton
+import dev.sasikanth.rss.reader.components.SimpleTopAppBar
 import dev.sasikanth.rss.reader.components.TextField
 import dev.sasikanth.rss.reader.miniflux.MinifluxLoginError
 import dev.sasikanth.rss.reader.miniflux.MinifluxLoginEvent
 import dev.sasikanth.rss.reader.miniflux.MinifluxLoginViewModel
-import dev.sasikanth.rss.reader.resources.icons.ArrowBack
-import dev.sasikanth.rss.reader.resources.icons.TwineIcons
 import dev.sasikanth.rss.reader.ui.AppTheme
 import org.jetbrains.compose.resources.getString
 import org.jetbrains.compose.resources.stringResource
 import twine.shared.generated.resources.Res
 import twine.shared.generated.resources.buttonCancel
-import twine.shared.generated.resources.buttonGoBack
 import twine.shared.generated.resources.minifluxAPIKeyHint
 import twine.shared.generated.resources.minifluxApiKey
 import twine.shared.generated.resources.minifluxClearDataDesc
@@ -162,37 +156,7 @@ fun MinifluxLoginScreen(
   Scaffold(
     modifier = modifier,
     topBar = {
-      Box {
-        CenterAlignedTopAppBar(
-          title = {
-            Text(
-              text = stringResource(Res.string.minifluxLoginTitle),
-              color = AppTheme.colorScheme.onSurface,
-              style = MaterialTheme.typography.titleMedium,
-            )
-          },
-          navigationIcon = {
-            CircularIconButton(
-              modifier = Modifier.padding(start = 12.dp),
-              icon = TwineIcons.ArrowBack,
-              label = stringResource(Res.string.buttonGoBack),
-              onClick = goBack,
-            )
-          },
-          colors =
-            TopAppBarDefaults.topAppBarColors(
-              containerColor = AppTheme.colorScheme.surface,
-              navigationIconContentColor = AppTheme.colorScheme.onSurface,
-              titleContentColor = AppTheme.colorScheme.onSurface,
-              actionIconContentColor = AppTheme.colorScheme.onSurface,
-            ),
-        )
-
-        HorizontalDivider(
-          modifier = Modifier.align(Alignment.BottomCenter),
-          color = AppTheme.colorScheme.outlineVariant,
-        )
-      }
+      SimpleTopAppBar(title = stringResource(Res.string.minifluxLoginTitle), onBackClick = goBack)
     },
     snackbarHost = {
       SnackbarHost(hostState = snackbarHostState) { snackbarData ->
@@ -244,6 +208,7 @@ fun MinifluxLoginScreen(
       }
     },
     containerColor = AppTheme.colorScheme.backdrop,
+    contentColor = Color.Unspecified,
   ) { padding ->
     LazyColumn(
       modifier = Modifier.fillMaxSize().padding(padding).padding(horizontal = 24.dp),

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/SettingsAppInfoScreen.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/SettingsAppInfoScreen.kt
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2026 Sasikanth Miriyampalli
+ *
+ * Licensed under the GPL, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package dev.sasikanth.rss.reader.settings.ui
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import dev.sasikanth.rss.reader.components.CircularIconButton
+import dev.sasikanth.rss.reader.platform.LocalLinkHandler
+import dev.sasikanth.rss.reader.resources.icons.ArrowBack
+import dev.sasikanth.rss.reader.resources.icons.TwineIcons
+import dev.sasikanth.rss.reader.settings.SettingsViewModel
+import dev.sasikanth.rss.reader.settings.ui.items.AboutItem
+import dev.sasikanth.rss.reader.settings.ui.items.ReportIssueSettingItem
+import dev.sasikanth.rss.reader.ui.AppTheme
+import dev.sasikanth.rss.reader.utils.Constants
+import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.stringResource
+import twine.shared.generated.resources.Res
+import twine.shared.generated.resources.buttonGoBack
+import twine.shared.generated.resources.settingsAppInfoAndFeedback
+
+@Composable
+internal fun SettingsAppInfoScreen(
+  viewModel: SettingsViewModel,
+  goBack: () -> Unit,
+  openAbout: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  val coroutineScope = rememberCoroutineScope()
+  val state by viewModel.state.collectAsStateWithLifecycle()
+  val layoutDirection = LocalLayoutDirection.current
+  val linkHandler = LocalLinkHandler.current
+
+  Scaffold(
+    modifier = modifier,
+    topBar = {
+      Box {
+        CenterAlignedTopAppBar(
+          title = {
+            Text(
+              stringResource(Res.string.settingsAppInfoAndFeedback),
+              color = AppTheme.colorScheme.onSurface,
+              style = MaterialTheme.typography.titleMedium,
+            )
+          },
+          navigationIcon = {
+            CircularIconButton(
+              modifier = Modifier.padding(start = 12.dp),
+              icon = TwineIcons.ArrowBack,
+              label = stringResource(Res.string.buttonGoBack),
+              onClick = goBack,
+            )
+          },
+          contentPadding = PaddingValues(vertical = 8.dp),
+          colors =
+            TopAppBarDefaults.topAppBarColors(
+              containerColor = AppTheme.colorScheme.surface,
+              navigationIconContentColor = AppTheme.colorScheme.onSurface,
+              titleContentColor = AppTheme.colorScheme.onSurface,
+              actionIconContentColor = AppTheme.colorScheme.onSurface,
+            ),
+        )
+
+        HorizontalDivider(
+          modifier = Modifier.fillMaxWidth().align(Alignment.BottomStart),
+          color = AppTheme.colorScheme.outlineVariant,
+        )
+      }
+    },
+    content = { padding ->
+      LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding =
+          PaddingValues(
+            start = padding.calculateStartPadding(layoutDirection) + settingsItemHorizontalPadding,
+            top = padding.calculateTopPadding() + 8.dp,
+            end = padding.calculateEndPadding(layoutDirection) + settingsItemHorizontalPadding,
+            bottom = padding.calculateBottomPadding() + 80.dp,
+          ),
+      ) {
+        item {
+          ReportIssueSettingItem(
+            appInfo = state.appInfo,
+            onClick = {
+              coroutineScope.launch { linkHandler.openLink(Constants.REPORT_ISSUE_LINK) }
+            },
+          )
+        }
+
+        item { SettingsDivider() }
+
+        item { AboutItem { openAbout() } }
+      }
+    },
+    containerColor = AppTheme.colorScheme.backdrop,
+    contentColor = Color.Unspecified,
+  )
+}

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/SettingsAppInfoScreen.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/SettingsAppInfoScreen.kt
@@ -16,33 +16,23 @@
  */
 package dev.sasikanth.rss.reader.settings.ui
 
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material3.CenterAlignedTopAppBar
-import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import dev.sasikanth.rss.reader.components.CircularIconButton
+import dev.sasikanth.rss.reader.components.SimpleTopAppBar
 import dev.sasikanth.rss.reader.platform.LocalLinkHandler
-import dev.sasikanth.rss.reader.resources.icons.ArrowBack
-import dev.sasikanth.rss.reader.resources.icons.TwineIcons
 import dev.sasikanth.rss.reader.settings.SettingsViewModel
 import dev.sasikanth.rss.reader.settings.ui.items.AboutItem
 import dev.sasikanth.rss.reader.settings.ui.items.ReportIssueSettingItem
@@ -51,7 +41,6 @@ import dev.sasikanth.rss.reader.utils.Constants
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 import twine.shared.generated.resources.Res
-import twine.shared.generated.resources.buttonGoBack
 import twine.shared.generated.resources.settingsAppInfoAndFeedback
 
 @Composable
@@ -69,38 +58,10 @@ internal fun SettingsAppInfoScreen(
   Scaffold(
     modifier = modifier,
     topBar = {
-      Box {
-        CenterAlignedTopAppBar(
-          title = {
-            Text(
-              stringResource(Res.string.settingsAppInfoAndFeedback),
-              color = AppTheme.colorScheme.onSurface,
-              style = MaterialTheme.typography.titleMedium,
-            )
-          },
-          navigationIcon = {
-            CircularIconButton(
-              modifier = Modifier.padding(start = 12.dp),
-              icon = TwineIcons.ArrowBack,
-              label = stringResource(Res.string.buttonGoBack),
-              onClick = goBack,
-            )
-          },
-          contentPadding = PaddingValues(vertical = 8.dp),
-          colors =
-            TopAppBarDefaults.topAppBarColors(
-              containerColor = AppTheme.colorScheme.surface,
-              navigationIconContentColor = AppTheme.colorScheme.onSurface,
-              titleContentColor = AppTheme.colorScheme.onSurface,
-              actionIconContentColor = AppTheme.colorScheme.onSurface,
-            ),
-        )
-
-        HorizontalDivider(
-          modifier = Modifier.fillMaxWidth().align(Alignment.BottomStart),
-          color = AppTheme.colorScheme.outlineVariant,
-        )
-      }
+      SimpleTopAppBar(
+        title = stringResource(Res.string.settingsAppInfoAndFeedback),
+        onBackClick = goBack,
+      )
     },
     content = { padding ->
       LazyColumn(

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/SettingsAppearanceScreen.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/SettingsAppearanceScreen.kt
@@ -1,0 +1,278 @@
+/*
+ * Copyright 2026 Sasikanth Miriyampalli
+ *
+ * Licensed under the GPL, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package dev.sasikanth.rss.reader.settings.ui
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import dev.sasikanth.rss.reader.components.CircularIconButton
+import dev.sasikanth.rss.reader.components.SubHeader
+import dev.sasikanth.rss.reader.components.ToggleableButtonGroup
+import dev.sasikanth.rss.reader.components.ToggleableButtonItem
+import dev.sasikanth.rss.reader.data.repository.AppThemeMode
+import dev.sasikanth.rss.reader.resources.icons.ArrowBack
+import dev.sasikanth.rss.reader.resources.icons.TwineIcons
+import dev.sasikanth.rss.reader.settings.SettingsEvent
+import dev.sasikanth.rss.reader.settings.SettingsViewModel
+import dev.sasikanth.rss.reader.settings.ui.items.AmoledSettingItem
+import dev.sasikanth.rss.reader.settings.ui.items.AppIconSelectionSheet
+import dev.sasikanth.rss.reader.settings.ui.items.AppIconSettingItem
+import dev.sasikanth.rss.reader.settings.ui.items.HomeLayoutSelector
+import dev.sasikanth.rss.reader.settings.ui.items.ThemeVariantSettingItem
+import dev.sasikanth.rss.reader.settings.ui.items.TwinePremiumBanner
+import dev.sasikanth.rss.reader.ui.AppTheme
+import org.jetbrains.compose.resources.stringResource
+import twine.shared.generated.resources.Res
+import twine.shared.generated.resources.buttonGoBack
+import twine.shared.generated.resources.homeViewMode
+import twine.shared.generated.resources.settingsAppearanceAndLayout
+import twine.shared.generated.resources.settingsHeaderTheme
+import twine.shared.generated.resources.settingsThemeAuto
+import twine.shared.generated.resources.settingsThemeDark
+import twine.shared.generated.resources.settingsThemeLight
+
+@Composable
+internal fun SettingsAppearanceScreen(
+  viewModel: SettingsViewModel,
+  goBack: () -> Unit,
+  openPaywall: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  val state by viewModel.state.collectAsStateWithLifecycle()
+  val layoutDirection = LocalLayoutDirection.current
+
+  LaunchedEffect(state.openPaywall) {
+    if (state.openPaywall) {
+      openPaywall()
+      viewModel.dispatch(SettingsEvent.MarkOpenPaywallAsDone)
+    }
+  }
+
+  LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
+    viewModel.dispatch(SettingsEvent.LoadSubscriptionStatus)
+  }
+
+  Scaffold(
+    modifier = modifier,
+    topBar = {
+      Box {
+        CenterAlignedTopAppBar(
+          title = {
+            Text(
+              stringResource(Res.string.settingsAppearanceAndLayout),
+              color = AppTheme.colorScheme.onSurface,
+              style = MaterialTheme.typography.titleMedium,
+            )
+          },
+          navigationIcon = {
+            CircularIconButton(
+              modifier = Modifier.padding(start = 12.dp),
+              icon = TwineIcons.ArrowBack,
+              label = stringResource(Res.string.buttonGoBack),
+              onClick = goBack,
+            )
+          },
+          contentPadding = PaddingValues(vertical = 8.dp),
+          colors =
+            TopAppBarDefaults.topAppBarColors(
+              containerColor = AppTheme.colorScheme.surface,
+              navigationIconContentColor = AppTheme.colorScheme.onSurface,
+              titleContentColor = AppTheme.colorScheme.onSurface,
+              actionIconContentColor = AppTheme.colorScheme.onSurface,
+            ),
+        )
+
+        HorizontalDivider(
+          modifier = Modifier.fillMaxWidth().align(Alignment.BottomStart),
+          color = AppTheme.colorScheme.outlineVariant,
+        )
+      }
+    },
+    content = { padding ->
+      if (state.showAppIconSelectionSheet) {
+        AppIconSelectionSheet(
+          currentAppIcon = state.appIcon,
+          onAppIconChange = {
+            viewModel.dispatch(SettingsEvent.OnAppIconChanged(it))
+            viewModel.dispatch(SettingsEvent.CloseAppIconSelectionSheet)
+          },
+          onDismiss = { viewModel.dispatch(SettingsEvent.CloseAppIconSelectionSheet) },
+        )
+      }
+
+      LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding =
+          PaddingValues(
+            start = padding.calculateStartPadding(layoutDirection) + settingsItemHorizontalPadding,
+            top = padding.calculateTopPadding() + 8.dp,
+            end = padding.calculateEndPadding(layoutDirection) + settingsItemHorizontalPadding,
+            bottom = padding.calculateBottomPadding() + 80.dp,
+          ),
+      ) {
+        // region Twine Premium banner
+        item {
+          AnimatedVisibility(
+            visible = !state.appInfo.isFoss && state.subscriptionResult != null,
+            enter = fadeIn() + expandVertically(),
+            exit = fadeOut() + shrinkVertically(),
+          ) {
+            Column {
+              TwinePremiumBanner(
+                modifier = Modifier.animateItem(),
+                subscriptionResult = state.subscriptionResult,
+                onClick = { openPaywall() },
+              )
+
+              SettingsDivider()
+            }
+          }
+        }
+        // endregion
+
+        item { SubHeader(text = stringResource(Res.string.homeViewMode)) }
+
+        item {
+          HomeLayoutSelector(
+            homeViewMode = state.homeViewMode,
+            onClick = { viewModel.dispatch(SettingsEvent.ChangeHomeViewMode(it)) },
+          )
+        }
+
+        item { SettingsDivider(24.dp) }
+
+        item { SubHeader(text = stringResource(Res.string.settingsHeaderTheme)) }
+
+        item {
+          ThemeVariantSettingItem(
+            selectedThemeVariant = state.themeVariant,
+            isSubscribed = state.isSubscribed,
+            useDarkTheme = AppTheme.isDark,
+            onThemeVariantChanged = {
+              if (it.isPremium && !state.isSubscribed) {
+                openPaywall()
+              } else {
+                viewModel.dispatch(SettingsEvent.OnThemeVariantChanged(it))
+              }
+            },
+          )
+        }
+
+        item { SettingsDivider(24.dp) }
+
+        item {
+          AnimatedVisibility(
+            visible = !state.themeVariant.isDarkModeOnly && !state.themeVariant.isLightModeOnly,
+            enter = fadeIn() + expandVertically(),
+            exit = fadeOut() + shrinkVertically(),
+          ) {
+            val appThemeMode = state.appThemeMode
+            ToggleableButtonGroup(
+              modifier =
+                Modifier.fillMaxWidth()
+                  .padding(horizontal = 24.dp)
+                  .padding(top = 24.dp, bottom = 24.dp),
+              items =
+                listOf(
+                  ToggleableButtonItem(
+                    label = stringResource(Res.string.settingsThemeAuto),
+                    isSelected = appThemeMode == AppThemeMode.Auto,
+                    identifier = AppThemeMode.Auto,
+                  ),
+                  ToggleableButtonItem(
+                    label = stringResource(Res.string.settingsThemeLight),
+                    isSelected = appThemeMode == AppThemeMode.Light,
+                    identifier = AppThemeMode.Light,
+                  ),
+                  ToggleableButtonItem(
+                    label = stringResource(Res.string.settingsThemeDark),
+                    isSelected = appThemeMode == AppThemeMode.Dark,
+                    identifier = AppThemeMode.Dark,
+                  ),
+                ),
+              onItemSelected = {
+                viewModel.dispatch(
+                  SettingsEvent.OnAppThemeModeChanged(it.identifier as AppThemeMode)
+                )
+              },
+            )
+          }
+        }
+
+        item {
+          AnimatedVisibility(
+            visible =
+              AppTheme.isDark &&
+                !state.themeVariant.isDarkModeOnly &&
+                !state.themeVariant.isLightModeOnly,
+            enter = fadeIn() + expandVertically(),
+            exit = fadeOut() + shrinkVertically(),
+          ) {
+            AmoledSettingItem(
+              useAmoled = state.useAmoled,
+              onValueChanged = { newValue ->
+                viewModel.dispatch(SettingsEvent.ToggleAmoled(newValue))
+              },
+            )
+          }
+        }
+
+        if (state.canSubscribe) {
+          item { SettingsDivider(24.dp) }
+
+          item {
+            AppIconSettingItem(
+              appIcon = state.appIcon,
+              isSubscribed = state.isSubscribed,
+              onClick = { viewModel.dispatch(SettingsEvent.AppIconClicked) },
+            )
+          }
+        }
+      }
+    },
+    containerColor = AppTheme.colorScheme.backdrop,
+    contentColor = Color.Unspecified,
+  )
+}

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/SettingsAppearanceScreen.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/SettingsAppearanceScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.calculateEndPadding
@@ -30,16 +29,10 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material3.CenterAlignedTopAppBar
-import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalLayoutDirection
@@ -47,13 +40,11 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import dev.sasikanth.rss.reader.components.CircularIconButton
+import dev.sasikanth.rss.reader.components.SimpleTopAppBar
 import dev.sasikanth.rss.reader.components.SubHeader
 import dev.sasikanth.rss.reader.components.ToggleableButtonGroup
 import dev.sasikanth.rss.reader.components.ToggleableButtonItem
 import dev.sasikanth.rss.reader.data.repository.AppThemeMode
-import dev.sasikanth.rss.reader.resources.icons.ArrowBack
-import dev.sasikanth.rss.reader.resources.icons.TwineIcons
 import dev.sasikanth.rss.reader.settings.SettingsEvent
 import dev.sasikanth.rss.reader.settings.SettingsViewModel
 import dev.sasikanth.rss.reader.settings.ui.items.AmoledSettingItem
@@ -65,7 +56,6 @@ import dev.sasikanth.rss.reader.settings.ui.items.TwinePremiumBanner
 import dev.sasikanth.rss.reader.ui.AppTheme
 import org.jetbrains.compose.resources.stringResource
 import twine.shared.generated.resources.Res
-import twine.shared.generated.resources.buttonGoBack
 import twine.shared.generated.resources.homeViewMode
 import twine.shared.generated.resources.settingsAppearanceAndLayout
 import twine.shared.generated.resources.settingsHeaderTheme
@@ -97,38 +87,10 @@ internal fun SettingsAppearanceScreen(
   Scaffold(
     modifier = modifier,
     topBar = {
-      Box {
-        CenterAlignedTopAppBar(
-          title = {
-            Text(
-              stringResource(Res.string.settingsAppearanceAndLayout),
-              color = AppTheme.colorScheme.onSurface,
-              style = MaterialTheme.typography.titleMedium,
-            )
-          },
-          navigationIcon = {
-            CircularIconButton(
-              modifier = Modifier.padding(start = 12.dp),
-              icon = TwineIcons.ArrowBack,
-              label = stringResource(Res.string.buttonGoBack),
-              onClick = goBack,
-            )
-          },
-          contentPadding = PaddingValues(vertical = 8.dp),
-          colors =
-            TopAppBarDefaults.topAppBarColors(
-              containerColor = AppTheme.colorScheme.surface,
-              navigationIconContentColor = AppTheme.colorScheme.onSurface,
-              titleContentColor = AppTheme.colorScheme.onSurface,
-              actionIconContentColor = AppTheme.colorScheme.onSurface,
-            ),
-        )
-
-        HorizontalDivider(
-          modifier = Modifier.fillMaxWidth().align(Alignment.BottomStart),
-          color = AppTheme.colorScheme.outlineVariant,
-        )
-      }
+      SimpleTopAppBar(
+        title = stringResource(Res.string.settingsAppearanceAndLayout),
+        onBackClick = goBack,
+      )
     },
     content = { padding ->
       if (state.showAppIconSelectionSheet) {

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/SettingsBehaviorScreen.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/SettingsBehaviorScreen.kt
@@ -1,0 +1,301 @@
+/*
+ * Copyright 2026 Sasikanth Miriyampalli
+ *
+ * Licensed under the GPL, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package dev.sasikanth.rss.reader.settings.ui
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Snackbar
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import dev.sasikanth.rss.reader.components.CircularIconButton
+import dev.sasikanth.rss.reader.resources.icons.ArrowBack
+import dev.sasikanth.rss.reader.resources.icons.TwineIcons
+import dev.sasikanth.rss.reader.settings.SettingsEvent
+import dev.sasikanth.rss.reader.settings.SettingsViewModel
+import dev.sasikanth.rss.reader.settings.ui.items.AutoSyncSettingItem
+import dev.sasikanth.rss.reader.settings.ui.items.BlockImagesSettingItem
+import dev.sasikanth.rss.reader.settings.ui.items.BlockedWordsSettingItem
+import dev.sasikanth.rss.reader.settings.ui.items.BrowserTypeSettingItem
+import dev.sasikanth.rss.reader.settings.ui.items.DownloadFullContentSettingItem
+import dev.sasikanth.rss.reader.settings.ui.items.MarkAsReadOnSettingItem
+import dev.sasikanth.rss.reader.settings.ui.items.NotificationsSettingItem
+import dev.sasikanth.rss.reader.settings.ui.items.OpmlFeedSelectionSheet
+import dev.sasikanth.rss.reader.settings.ui.items.PostsDeletionPeriodSettingItem
+import dev.sasikanth.rss.reader.settings.ui.items.ShowFeedFavIconSettingItem
+import dev.sasikanth.rss.reader.settings.ui.items.ShowReaderViewSettingItem
+import dev.sasikanth.rss.reader.settings.ui.items.UnreadPostsCountSettingItem
+import dev.sasikanth.rss.reader.ui.AppTheme
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.stringResource
+import twine.shared.generated.resources.Res
+import twine.shared.generated.resources.buttonGoBack
+import twine.shared.generated.resources.settingsFeaturesAndBehaviors
+import twine.shared.generated.resources.settingsFreeFeedLimitReached
+import twine.shared.generated.resources.settingsUpgradeToPremium
+
+@Composable
+internal fun SettingsBehaviorScreen(
+  viewModel: SettingsViewModel,
+  goBack: () -> Unit,
+  openBlockedWords: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  val state by viewModel.state.collectAsStateWithLifecycle()
+  val layoutDirection = LocalLayoutDirection.current
+
+  val snackbarHostState = remember { SnackbarHostState() }
+  val freeFeedLimitReachedString = stringResource(Res.string.settingsFreeFeedLimitReached)
+  val upgradeToPremiumString = stringResource(Res.string.settingsUpgradeToPremium)
+
+  LaunchedEffect(state.showFreeFeedLimitWarning) {
+    if (state.showFreeFeedLimitWarning) {
+      launch {
+        delay(2.seconds)
+        viewModel.dispatch(SettingsEvent.MarkFreeFeedLimitWarningAsDone)
+      }
+
+      snackbarHostState.showSnackbar(
+        message = freeFeedLimitReachedString,
+        actionLabel = upgradeToPremiumString,
+      )
+    }
+  }
+
+  Scaffold(
+    modifier = modifier,
+    topBar = {
+      Box {
+        CenterAlignedTopAppBar(
+          title = {
+            Text(
+              stringResource(Res.string.settingsFeaturesAndBehaviors),
+              color = AppTheme.colorScheme.onSurface,
+              style = MaterialTheme.typography.titleMedium,
+            )
+          },
+          navigationIcon = {
+            CircularIconButton(
+              modifier = Modifier.padding(start = 12.dp),
+              icon = TwineIcons.ArrowBack,
+              label = stringResource(Res.string.buttonGoBack),
+              onClick = goBack,
+            )
+          },
+          contentPadding = PaddingValues(vertical = 8.dp),
+          colors =
+            TopAppBarDefaults.topAppBarColors(
+              containerColor = AppTheme.colorScheme.surface,
+              navigationIconContentColor = AppTheme.colorScheme.onSurface,
+              titleContentColor = AppTheme.colorScheme.onSurface,
+              actionIconContentColor = AppTheme.colorScheme.onSurface,
+            ),
+        )
+
+        HorizontalDivider(
+          modifier = Modifier.fillMaxWidth().align(Alignment.BottomStart),
+          color = AppTheme.colorScheme.outlineVariant,
+        )
+      }
+    },
+    snackbarHost = {
+      SnackbarHost(hostState = snackbarHostState) { snackbarData ->
+        Snackbar(
+          modifier = Modifier.padding(12.dp),
+          content = {
+            Text(
+              text = snackbarData.visuals.message,
+              maxLines = 4,
+              overflow = TextOverflow.Ellipsis,
+            )
+          },
+          action = {
+            snackbarData.visuals.actionLabel?.let { actionLabel ->
+              TextButton(
+                onClick = { snackbarHostState.currentSnackbarData?.performAction() },
+                colors =
+                  ButtonDefaults.textButtonColors(contentColor = AppTheme.colorScheme.primary),
+                shape = MaterialTheme.shapes.medium,
+              ) {
+                Text(text = actionLabel, style = MaterialTheme.typography.labelLarge)
+              }
+            }
+          },
+          containerColor = AppTheme.colorScheme.inverseSurface,
+          contentColor = AppTheme.colorScheme.inverseOnSurface,
+        )
+      }
+    },
+    content = { padding ->
+      if (state.opmlFeedsToSelect != null) {
+        OpmlFeedSelectionSheet(
+          feeds = state.opmlFeedsToSelect!!,
+          onFeedsSelected = { viewModel.dispatch(SettingsEvent.OnOpmlFeedsSelected(it)) },
+          onDismiss = { viewModel.dispatch(SettingsEvent.ClearOpmlFeedsToSelect) },
+        )
+      }
+
+      LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding =
+          PaddingValues(
+            start = padding.calculateStartPadding(layoutDirection) + settingsItemHorizontalPadding,
+            top = padding.calculateTopPadding() + 8.dp,
+            end = padding.calculateEndPadding(layoutDirection) + settingsItemHorizontalPadding,
+            bottom = padding.calculateBottomPadding() + 80.dp,
+          ),
+      ) {
+        item {
+          ShowReaderViewSettingItem(
+            showReaderView = state.showReaderView,
+            onValueChanged = { newValue ->
+              viewModel.dispatch(SettingsEvent.ToggleShowReaderView(newValue))
+            },
+          )
+        }
+
+        item { SettingsDivider(24.dp) }
+
+        item {
+          BrowserTypeSettingItem(
+            browserType = state.browserType,
+            onBrowserTypeChanged = { newBrowserType ->
+              viewModel.dispatch(SettingsEvent.UpdateBrowserType(newBrowserType))
+            },
+          )
+        }
+
+        item { SettingsDivider(24.dp) }
+
+        item {
+          UnreadPostsCountSettingItem(
+            showUnreadCountEnabled = state.showUnreadPostsCount,
+            onValueChanged = { newValue ->
+              viewModel.dispatch(SettingsEvent.ToggleShowUnreadPostsCount(newValue))
+            },
+          )
+        }
+
+        item { SettingsDivider(24.dp) }
+
+        item {
+          AutoSyncSettingItem(
+            enableAutoSync = state.enableAutoSync,
+            onValueChanged = { newValue ->
+              viewModel.dispatch(SettingsEvent.ToggleAutoSync(newValue))
+            },
+          )
+        }
+
+        item { SettingsDivider(24.dp) }
+
+        item {
+          ShowFeedFavIconSettingItem(
+            showFeedFavIcon = state.showFeedFavIcon,
+            onValueChanged = { newValue ->
+              viewModel.dispatch(SettingsEvent.ToggleShowFeedFavIcon(newValue))
+            },
+          )
+        }
+
+        item { SettingsDivider(24.dp) }
+
+        item {
+          BlockImagesSettingItem(
+            blockImages = state.blockImages,
+            onValueChanged = { newValue ->
+              viewModel.dispatch(SettingsEvent.ToggleBlockImages(newValue))
+            },
+          )
+        }
+
+        item { SettingsDivider(24.dp) }
+
+        item {
+          NotificationsSettingItem(
+            enableNotifications = state.enableNotifications,
+            onValueChanged = { newValue ->
+              viewModel.dispatch(SettingsEvent.ToggleNotifications(newValue))
+            },
+          )
+        }
+
+        item { SettingsDivider(24.dp) }
+
+        item {
+          DownloadFullContentSettingItem(
+            downloadFullContent = state.downloadFullContent,
+            onValueChanged = { newValue ->
+              viewModel.dispatch(SettingsEvent.ToggleDownloadFullContent(newValue))
+            },
+          )
+        }
+
+        item { SettingsDivider(24.dp) }
+
+        item { BlockedWordsSettingItem { openBlockedWords() } }
+
+        item { SettingsDivider(24.dp) }
+
+        item {
+          MarkAsReadOnSettingItem(articleMarkAsReadOn = state.markAsReadOn) {
+            viewModel.dispatch(SettingsEvent.MarkAsReadOnChanged(it))
+          }
+        }
+
+        item { SettingsDivider(24.dp) }
+
+        item {
+          PostsDeletionPeriodSettingItem(
+            postsDeletionPeriod = state.postsDeletionPeriod,
+            onValueChanged = { newValue ->
+              viewModel.dispatch(SettingsEvent.PostsDeletionPeriodChanged(newValue))
+            },
+          )
+        }
+      }
+    },
+    containerColor = AppTheme.colorScheme.backdrop,
+    contentColor = Color.Unspecified,
+  )
+}

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/SettingsBehaviorScreen.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/SettingsBehaviorScreen.kt
@@ -150,6 +150,17 @@ internal fun SettingsBehaviorScreen(
           ),
       ) {
         item {
+          ShowPinnedSourcesSettingItem(
+            showPinnedSources = state.showPinnedSources,
+            onValueChanged = { newValue ->
+              viewModel.dispatch(SettingsEvent.ToggleShowPinnedSources(newValue))
+            },
+          )
+        }
+
+        item { SettingsDivider(24.dp) }
+
+        item {
           ShowReaderViewSettingItem(
             showReaderView = state.showReaderView,
             onValueChanged = { newValue ->
@@ -176,17 +187,6 @@ internal fun SettingsBehaviorScreen(
             showUnreadCountEnabled = state.showUnreadPostsCount,
             onValueChanged = { newValue ->
               viewModel.dispatch(SettingsEvent.ToggleShowUnreadPostsCount(newValue))
-            },
-          )
-        }
-
-        item { SettingsDivider(24.dp) }
-
-        item {
-          ShowPinnedSourcesSettingItem(
-            showPinnedSources = state.showPinnedSources,
-            onValueChanged = { newValue ->
-              viewModel.dispatch(SettingsEvent.ToggleShowPinnedSources(newValue))
             },
           )
         }

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/SettingsBehaviorScreen.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/SettingsBehaviorScreen.kt
@@ -16,17 +16,13 @@
  */
 package dev.sasikanth.rss.reader.settings.ui
 
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.CenterAlignedTopAppBar
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Snackbar
@@ -34,21 +30,17 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import dev.sasikanth.rss.reader.components.CircularIconButton
-import dev.sasikanth.rss.reader.resources.icons.ArrowBack
-import dev.sasikanth.rss.reader.resources.icons.TwineIcons
+import dev.sasikanth.rss.reader.components.SimpleTopAppBar
 import dev.sasikanth.rss.reader.settings.SettingsEvent
 import dev.sasikanth.rss.reader.settings.SettingsViewModel
 import dev.sasikanth.rss.reader.settings.ui.items.AutoSyncSettingItem
@@ -70,7 +62,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 import twine.shared.generated.resources.Res
-import twine.shared.generated.resources.buttonGoBack
 import twine.shared.generated.resources.settingsFeaturesAndBehaviors
 import twine.shared.generated.resources.settingsFreeFeedLimitReached
 import twine.shared.generated.resources.settingsUpgradeToPremium
@@ -106,38 +97,10 @@ internal fun SettingsBehaviorScreen(
   Scaffold(
     modifier = modifier,
     topBar = {
-      Box {
-        CenterAlignedTopAppBar(
-          title = {
-            Text(
-              stringResource(Res.string.settingsFeaturesAndBehaviors),
-              color = AppTheme.colorScheme.onSurface,
-              style = MaterialTheme.typography.titleMedium,
-            )
-          },
-          navigationIcon = {
-            CircularIconButton(
-              modifier = Modifier.padding(start = 12.dp),
-              icon = TwineIcons.ArrowBack,
-              label = stringResource(Res.string.buttonGoBack),
-              onClick = goBack,
-            )
-          },
-          contentPadding = PaddingValues(vertical = 8.dp),
-          colors =
-            TopAppBarDefaults.topAppBarColors(
-              containerColor = AppTheme.colorScheme.surface,
-              navigationIconContentColor = AppTheme.colorScheme.onSurface,
-              titleContentColor = AppTheme.colorScheme.onSurface,
-              actionIconContentColor = AppTheme.colorScheme.onSurface,
-            ),
-        )
-
-        HorizontalDivider(
-          modifier = Modifier.fillMaxWidth().align(Alignment.BottomStart),
-          color = AppTheme.colorScheme.outlineVariant,
-        )
-      }
+      SimpleTopAppBar(
+        title = stringResource(Res.string.settingsFeaturesAndBehaviors),
+        onBackClick = goBack,
+      )
     },
     snackbarHost = {
       SnackbarHost(hostState = snackbarHostState) { snackbarData ->

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/SettingsBehaviorScreen.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/SettingsBehaviorScreen.kt
@@ -61,6 +61,7 @@ import dev.sasikanth.rss.reader.settings.ui.items.NotificationsSettingItem
 import dev.sasikanth.rss.reader.settings.ui.items.OpmlFeedSelectionSheet
 import dev.sasikanth.rss.reader.settings.ui.items.PostsDeletionPeriodSettingItem
 import dev.sasikanth.rss.reader.settings.ui.items.ShowFeedFavIconSettingItem
+import dev.sasikanth.rss.reader.settings.ui.items.ShowPinnedSourcesSettingItem
 import dev.sasikanth.rss.reader.settings.ui.items.ShowReaderViewSettingItem
 import dev.sasikanth.rss.reader.settings.ui.items.UnreadPostsCountSettingItem
 import dev.sasikanth.rss.reader.ui.AppTheme
@@ -212,6 +213,17 @@ internal fun SettingsBehaviorScreen(
             showUnreadCountEnabled = state.showUnreadPostsCount,
             onValueChanged = { newValue ->
               viewModel.dispatch(SettingsEvent.ToggleShowUnreadPostsCount(newValue))
+            },
+          )
+        }
+
+        item { SettingsDivider(24.dp) }
+
+        item {
+          ShowPinnedSourcesSettingItem(
+            showPinnedSources = state.showPinnedSources,
+            onValueChanged = { newValue ->
+              viewModel.dispatch(SettingsEvent.ToggleShowPinnedSources(newValue))
             },
           )
         }

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/SettingsDataScreen.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/SettingsDataScreen.kt
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2026 Sasikanth Miriyampalli
+ *
+ * Licensed under the GPL, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package dev.sasikanth.rss.reader.settings.ui
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.dp
+import dev.sasikanth.rss.reader.components.CircularIconButton
+import dev.sasikanth.rss.reader.resources.icons.ArrowBack
+import dev.sasikanth.rss.reader.resources.icons.TwineIcons
+import dev.sasikanth.rss.reader.settings.SettingsEvent
+import dev.sasikanth.rss.reader.settings.SettingsViewModel
+import dev.sasikanth.rss.reader.settings.ui.items.DeleteAppDataConfirmationDialog
+import dev.sasikanth.rss.reader.settings.ui.items.DeleteAppDataSettingItem
+import dev.sasikanth.rss.reader.settings.ui.items.StatisticsItem
+import dev.sasikanth.rss.reader.ui.AppTheme
+import org.jetbrains.compose.resources.stringResource
+import twine.shared.generated.resources.Res
+import twine.shared.generated.resources.buttonGoBack
+import twine.shared.generated.resources.settingsYourInsights
+
+@Composable
+internal fun SettingsDataScreen(
+  viewModel: SettingsViewModel,
+  goBack: () -> Unit,
+  openStatistics: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  val layoutDirection = LocalLayoutDirection.current
+  var showDeleteAppDataConfirmation by remember { mutableStateOf(false) }
+
+  if (showDeleteAppDataConfirmation) {
+    DeleteAppDataConfirmationDialog(
+      onConfirm = {
+        showDeleteAppDataConfirmation = false
+        viewModel.dispatch(SettingsEvent.DeleteAppData)
+      },
+      onDismiss = { showDeleteAppDataConfirmation = false },
+    )
+  }
+
+  Scaffold(
+    modifier = modifier,
+    topBar = {
+      Box {
+        CenterAlignedTopAppBar(
+          title = {
+            Text(
+              stringResource(Res.string.settingsYourInsights),
+              color = AppTheme.colorScheme.onSurface,
+              style = MaterialTheme.typography.titleMedium,
+            )
+          },
+          navigationIcon = {
+            CircularIconButton(
+              modifier = Modifier.padding(start = 12.dp),
+              icon = TwineIcons.ArrowBack,
+              label = stringResource(Res.string.buttonGoBack),
+              onClick = goBack,
+            )
+          },
+          contentPadding = PaddingValues(vertical = 8.dp),
+          colors =
+            TopAppBarDefaults.topAppBarColors(
+              containerColor = AppTheme.colorScheme.surface,
+              navigationIconContentColor = AppTheme.colorScheme.onSurface,
+              titleContentColor = AppTheme.colorScheme.onSurface,
+              actionIconContentColor = AppTheme.colorScheme.onSurface,
+            ),
+        )
+
+        HorizontalDivider(
+          modifier = Modifier.fillMaxWidth().align(Alignment.BottomStart),
+          color = AppTheme.colorScheme.outlineVariant,
+        )
+      }
+    },
+    content = { padding ->
+      LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding =
+          PaddingValues(
+            start = padding.calculateStartPadding(layoutDirection) + settingsItemHorizontalPadding,
+            top = padding.calculateTopPadding() + 8.dp,
+            end = padding.calculateEndPadding(layoutDirection) + settingsItemHorizontalPadding,
+            bottom = padding.calculateBottomPadding() + 80.dp,
+          ),
+      ) {
+        item { StatisticsItem { openStatistics() } }
+
+        item { SettingsDivider(24.dp) }
+
+        item { DeleteAppDataSettingItem { showDeleteAppDataConfirmation = true } }
+      }
+    },
+    containerColor = AppTheme.colorScheme.backdrop,
+    contentColor = Color.Unspecified,
+  )
+}

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/SettingsDataScreen.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/SettingsDataScreen.kt
@@ -16,33 +16,23 @@
  */
 package dev.sasikanth.rss.reader.settings.ui
 
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material3.CenterAlignedTopAppBar
-import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.dp
-import dev.sasikanth.rss.reader.components.CircularIconButton
-import dev.sasikanth.rss.reader.resources.icons.ArrowBack
-import dev.sasikanth.rss.reader.resources.icons.TwineIcons
+import dev.sasikanth.rss.reader.components.SimpleTopAppBar
 import dev.sasikanth.rss.reader.settings.SettingsEvent
 import dev.sasikanth.rss.reader.settings.SettingsViewModel
 import dev.sasikanth.rss.reader.settings.ui.items.DeleteAppDataConfirmationDialog
@@ -51,7 +41,6 @@ import dev.sasikanth.rss.reader.settings.ui.items.StatisticsItem
 import dev.sasikanth.rss.reader.ui.AppTheme
 import org.jetbrains.compose.resources.stringResource
 import twine.shared.generated.resources.Res
-import twine.shared.generated.resources.buttonGoBack
 import twine.shared.generated.resources.settingsYourInsights
 
 @Composable
@@ -77,38 +66,7 @@ internal fun SettingsDataScreen(
   Scaffold(
     modifier = modifier,
     topBar = {
-      Box {
-        CenterAlignedTopAppBar(
-          title = {
-            Text(
-              stringResource(Res.string.settingsYourInsights),
-              color = AppTheme.colorScheme.onSurface,
-              style = MaterialTheme.typography.titleMedium,
-            )
-          },
-          navigationIcon = {
-            CircularIconButton(
-              modifier = Modifier.padding(start = 12.dp),
-              icon = TwineIcons.ArrowBack,
-              label = stringResource(Res.string.buttonGoBack),
-              onClick = goBack,
-            )
-          },
-          contentPadding = PaddingValues(vertical = 8.dp),
-          colors =
-            TopAppBarDefaults.topAppBarColors(
-              containerColor = AppTheme.colorScheme.surface,
-              navigationIconContentColor = AppTheme.colorScheme.onSurface,
-              titleContentColor = AppTheme.colorScheme.onSurface,
-              actionIconContentColor = AppTheme.colorScheme.onSurface,
-            ),
-        )
-
-        HorizontalDivider(
-          modifier = Modifier.fillMaxWidth().align(Alignment.BottomStart),
-          color = AppTheme.colorScheme.outlineVariant,
-        )
-      }
+      SimpleTopAppBar(title = stringResource(Res.string.settingsYourInsights), onBackClick = goBack)
     },
     content = { padding ->
       LazyColumn(

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/SettingsScreen.kt
@@ -16,13 +16,7 @@
  */
 package dev.sasikanth.rss.reader.settings.ui
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.expandVertically
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
@@ -30,189 +24,81 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Snackbar
-import androidx.compose.material3.SnackbarHost
-import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalLayoutDirection
-import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.window.core.layout.WindowSizeClass
 import dev.sasikanth.rss.reader.components.CircularIconButton
 import dev.sasikanth.rss.reader.components.SubHeader
-import dev.sasikanth.rss.reader.components.ToggleableButtonGroup
-import dev.sasikanth.rss.reader.components.ToggleableButtonItem
-import dev.sasikanth.rss.reader.core.model.local.ServiceType
-import dev.sasikanth.rss.reader.data.repository.AppThemeMode
 import dev.sasikanth.rss.reader.platform.LocalLinkHandler
+import dev.sasikanth.rss.reader.resources.icons.Account
+import dev.sasikanth.rss.reader.resources.icons.Appearance
 import dev.sasikanth.rss.reader.resources.icons.ArrowBack
+import dev.sasikanth.rss.reader.resources.icons.Behaviors
+import dev.sasikanth.rss.reader.resources.icons.Sync
 import dev.sasikanth.rss.reader.resources.icons.TwineIcons
-import dev.sasikanth.rss.reader.settings.SettingsEvent
-import dev.sasikanth.rss.reader.settings.SettingsEvent.ChangeHomeViewMode
 import dev.sasikanth.rss.reader.settings.SettingsViewModel
 import dev.sasikanth.rss.reader.settings.ui.items.AboutItem
-import dev.sasikanth.rss.reader.settings.ui.items.AmoledSettingItem
-import dev.sasikanth.rss.reader.settings.ui.items.AppIconSelectionSheet
-import dev.sasikanth.rss.reader.settings.ui.items.AppIconSettingItem
-import dev.sasikanth.rss.reader.settings.ui.items.AutoSyncSettingItem
-import dev.sasikanth.rss.reader.settings.ui.items.BlockImagesSettingItem
-import dev.sasikanth.rss.reader.settings.ui.items.BlockedWordsSettingItem
-import dev.sasikanth.rss.reader.settings.ui.items.BrowserTypeSettingItem
-import dev.sasikanth.rss.reader.settings.ui.items.CloudSyncSettingItem
-import dev.sasikanth.rss.reader.settings.ui.items.DeleteAppDataConfirmationDialog
-import dev.sasikanth.rss.reader.settings.ui.items.DeleteAppDataSettingItem
-import dev.sasikanth.rss.reader.settings.ui.items.DownloadFullContentSettingItem
-import dev.sasikanth.rss.reader.settings.ui.items.HomeLayoutSelector
-import dev.sasikanth.rss.reader.settings.ui.items.MarkAsReadOnSettingItem
-import dev.sasikanth.rss.reader.settings.ui.items.NotificationsSettingItem
-import dev.sasikanth.rss.reader.settings.ui.items.OPMLSettingItem
-import dev.sasikanth.rss.reader.settings.ui.items.OpmlFeedSelectionSheet
-import dev.sasikanth.rss.reader.settings.ui.items.PostsDeletionPeriodSettingItem
 import dev.sasikanth.rss.reader.settings.ui.items.ReportIssueSettingItem
-import dev.sasikanth.rss.reader.settings.ui.items.ShowFeedFavIconSettingItem
-import dev.sasikanth.rss.reader.settings.ui.items.ShowPinnedSourcesSettingItem
-import dev.sasikanth.rss.reader.settings.ui.items.ShowReaderViewSettingItem
-import dev.sasikanth.rss.reader.settings.ui.items.StatisticsItem
-import dev.sasikanth.rss.reader.settings.ui.items.ThemeVariantSettingItem
-import dev.sasikanth.rss.reader.settings.ui.items.TwinePremiumBanner
-import dev.sasikanth.rss.reader.settings.ui.items.UnreadPostsCountSettingItem
+import dev.sasikanth.rss.reader.settings.ui.items.SettingsNavigationItem
 import dev.sasikanth.rss.reader.ui.AppTheme
 import dev.sasikanth.rss.reader.utils.Constants
-import dev.sasikanth.rss.reader.utils.LocalWindowSizeClass
-import kotlin.time.Duration.Companion.seconds
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 import twine.shared.generated.resources.Res
 import twine.shared.generated.resources.buttonGoBack
-import twine.shared.generated.resources.homeViewMode
 import twine.shared.generated.resources.settings
-import twine.shared.generated.resources.settingsCustomisations
-import twine.shared.generated.resources.settingsFreeFeedLimitReached
-import twine.shared.generated.resources.settingsHeaderBehaviour
-import twine.shared.generated.resources.settingsHeaderData
+import twine.shared.generated.resources.settingsAppearanceAndLayout
+import twine.shared.generated.resources.settingsAppearanceAndLayoutSubtitle
+import twine.shared.generated.resources.settingsFeaturesAndBehaviors
+import twine.shared.generated.resources.settingsFeaturesAndBehaviorsSubtitle
 import twine.shared.generated.resources.settingsHeaderFeedback
-import twine.shared.generated.resources.settingsHeaderSync
-import twine.shared.generated.resources.settingsHeaderTheme
-import twine.shared.generated.resources.settingsThemeAuto
-import twine.shared.generated.resources.settingsThemeDark
-import twine.shared.generated.resources.settingsThemeLight
-import twine.shared.generated.resources.settingsUpgradeToPremium
-
-internal val settingsItemHorizontalPadding: Dp
-  @Composable
-  @ReadOnlyComposable
-  get() {
-    val sizeClass = LocalWindowSizeClass.current
-    return when {
-      sizeClass.isWidthAtLeastBreakpoint(WindowSizeClass.WIDTH_DP_EXPANDED_LOWER_BOUND) -> 128.dp
-      else -> 0.dp
-    }
-  }
+import twine.shared.generated.resources.settingsServicesAndSync
+import twine.shared.generated.resources.settingsServicesAndSyncSubtitle
+import twine.shared.generated.resources.settingsYourInsights
+import twine.shared.generated.resources.settingsYourInsightsSubtitle
 
 @Composable
 internal fun SettingsScreen(
   viewModel: SettingsViewModel,
   goBack: () -> Unit,
+  openAppearanceSettings: () -> Unit,
+  openBehaviorSettings: () -> Unit,
+  openServicesSettings: () -> Unit,
+  openDataSettings: () -> Unit,
   openAbout: () -> Unit,
-  openStatistics: () -> Unit,
-  openBlockedWords: () -> Unit,
   openPaywall: () -> Unit,
-  openFreshRssLogin: () -> Unit,
-  openMinifluxLogin: () -> Unit,
   modifier: Modifier = Modifier,
 ) {
   val coroutineScope = rememberCoroutineScope()
   val state by viewModel.state.collectAsStateWithLifecycle()
-  val appInfo = viewModel.appInfo
   val layoutDirection = LocalLayoutDirection.current
   val linkHandler = LocalLinkHandler.current
-
-  var showDeleteAppDataConfirmation by remember { mutableStateOf(false) }
-  val snackbarHostState = remember { SnackbarHostState() }
-  val freeFeedLimitReachedString = stringResource(Res.string.settingsFreeFeedLimitReached)
-  val upgradeToPremiumString = stringResource(Res.string.settingsUpgradeToPremium)
-
-  LaunchedEffect(state.authUrlToOpen) {
-    state.authUrlToOpen?.let { url ->
-      linkHandler.openLink(url, useInAppBrowser = true)
-      viewModel.dispatch(SettingsEvent.ClearAuthUrl)
-    }
-  }
-
-  LaunchedEffect(state.openPaywall) {
-    if (state.openPaywall) {
-      openPaywall()
-      viewModel.dispatch(SettingsEvent.MarkOpenPaywallAsDone)
-    }
-  }
-
-  LaunchedEffect(state.showFreeFeedLimitWarning) {
-    if (state.showFreeFeedLimitWarning) {
-      launch {
-        delay(2.seconds)
-        viewModel.dispatch(SettingsEvent.MarkFreeFeedLimitWarningAsDone)
-      }
-
-      val result =
-        snackbarHostState.showSnackbar(
-          message = freeFeedLimitReachedString,
-          actionLabel = upgradeToPremiumString,
-        )
-
-      if (result == SnackbarResult.ActionPerformed) {
-        openPaywall()
-      }
-    }
-  }
-
-  LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
-    viewModel.dispatch(SettingsEvent.LoadSubscriptionStatus)
-  }
-
-  if (showDeleteAppDataConfirmation) {
-    DeleteAppDataConfirmationDialog(
-      onConfirm = {
-        showDeleteAppDataConfirmation = false
-        viewModel.dispatch(SettingsEvent.DeleteAppData)
-      },
-      onDismiss = { showDeleteAppDataConfirmation = false },
-    )
-  }
 
   Scaffold(
     modifier = modifier,
     topBar = {
       Box {
-        CenterAlignedTopAppBar(
+        TopAppBar(
           title = {
             Text(
-              stringResource(Res.string.settings),
+              modifier = Modifier.padding(start = 12.dp),
+              text = stringResource(Res.string.settings),
               color = AppTheme.colorScheme.onSurface,
-              style = MaterialTheme.typography.titleMedium,
+              style = MaterialTheme.typography.titleLarge,
+              fontWeight = FontWeight.SemiBold,
             )
           },
           navigationIcon = {
@@ -220,13 +106,16 @@ internal fun SettingsScreen(
               modifier = Modifier.padding(start = 12.dp),
               icon = TwineIcons.ArrowBack,
               label = stringResource(Res.string.buttonGoBack),
+              backgroundColor = AppTheme.colorScheme.inverseSurface,
+              borderColor = AppTheme.colorScheme.inverseSurface,
+              contentColor = AppTheme.colorScheme.inverseOnSurface,
               onClick = goBack,
             )
           },
           contentPadding = PaddingValues(vertical = 8.dp),
           colors =
             TopAppBarDefaults.topAppBarColors(
-              containerColor = AppTheme.colorScheme.surface,
+              containerColor = AppTheme.colorScheme.surfaceContainerHigh,
               navigationIconContentColor = AppTheme.colorScheme.onSurface,
               titleContentColor = AppTheme.colorScheme.onSurface,
               actionIconContentColor = AppTheme.colorScheme.onSurface,
@@ -239,54 +128,7 @@ internal fun SettingsScreen(
         )
       }
     },
-    snackbarHost = {
-      SnackbarHost(hostState = snackbarHostState) { snackbarData ->
-        Snackbar(
-          modifier = Modifier.padding(12.dp),
-          content = {
-            Text(
-              text = snackbarData.visuals.message,
-              maxLines = 4,
-              overflow = TextOverflow.Ellipsis,
-            )
-          },
-          action = {
-            snackbarData.visuals.actionLabel?.let { actionLabel ->
-              TextButton(
-                onClick = { snackbarHostState.currentSnackbarData?.performAction() },
-                colors =
-                  ButtonDefaults.textButtonColors(contentColor = AppTheme.colorScheme.primary),
-                shape = MaterialTheme.shapes.medium,
-              ) {
-                Text(text = actionLabel, style = MaterialTheme.typography.labelLarge)
-              }
-            }
-          },
-          containerColor = AppTheme.colorScheme.inverseSurface,
-          contentColor = AppTheme.colorScheme.inverseOnSurface,
-        )
-      }
-    },
     content = { padding ->
-      if (state.opmlFeedsToSelect != null) {
-        OpmlFeedSelectionSheet(
-          feeds = state.opmlFeedsToSelect!!,
-          onFeedsSelected = { viewModel.dispatch(SettingsEvent.OnOpmlFeedsSelected(it)) },
-          onDismiss = { viewModel.dispatch(SettingsEvent.ClearOpmlFeedsToSelect) },
-        )
-      }
-
-      if (state.showAppIconSelectionSheet) {
-        AppIconSelectionSheet(
-          currentAppIcon = state.appIcon,
-          onAppIconChange = {
-            viewModel.dispatch(SettingsEvent.OnAppIconChanged(it))
-            viewModel.dispatch(SettingsEvent.CloseAppIconSelectionSheet)
-          },
-          onDismiss = { viewModel.dispatch(SettingsEvent.CloseAppIconSelectionSheet) },
-        )
-      }
-
       LazyColumn(
         modifier = Modifier.fillMaxSize(),
         contentPadding =
@@ -297,317 +139,43 @@ internal fun SettingsScreen(
             bottom = padding.calculateBottomPadding() + 80.dp,
           ),
       ) {
-        // region Twine Premium banner
         item {
-          AnimatedVisibility(
-            visible = !state.appInfo.isFoss && state.subscriptionResult != null,
-            enter = fadeIn() + expandVertically(),
-            exit = fadeOut() + shrinkVertically(),
-          ) {
-            Column {
-              TwinePremiumBanner(
-                modifier = Modifier.animateItem(),
-                subscriptionResult = state.subscriptionResult,
-                onClick = { openPaywall() },
-              )
-
-              Divider()
-            }
-          }
-        }
-        // endregion
-
-        // region Customisation settings
-        item { SubHeader(text = stringResource(Res.string.settingsCustomisations)) }
-
-        item { SubHeader(text = stringResource(Res.string.homeViewMode)) }
-
-        item {
-          HomeLayoutSelector(
-            homeViewMode = state.homeViewMode,
-            onClick = { viewModel.dispatch(ChangeHomeViewMode(it)) },
+          SettingsNavigationItem(
+            title = stringResource(Res.string.settingsAppearanceAndLayout),
+            subtitle = stringResource(Res.string.settingsAppearanceAndLayoutSubtitle),
+            icon = TwineIcons.Appearance,
+            onClick = openAppearanceSettings,
           )
         }
 
-        item { Divider(24.dp) }
-
-        item { SubHeader(text = stringResource(Res.string.settingsHeaderTheme)) }
-
         item {
-          ThemeVariantSettingItem(
-            selectedThemeVariant = state.themeVariant,
-            isSubscribed = state.isSubscribed,
-            useDarkTheme = AppTheme.isDark,
-            onThemeVariantChanged = {
-              if (it.isPremium && !state.isSubscribed) {
-                openPaywall()
-              } else {
-                viewModel.dispatch(SettingsEvent.OnThemeVariantChanged(it))
-              }
-            },
+          SettingsNavigationItem(
+            title = stringResource(Res.string.settingsFeaturesAndBehaviors),
+            subtitle = stringResource(Res.string.settingsFeaturesAndBehaviorsSubtitle),
+            icon = TwineIcons.Behaviors,
+            onClick = openBehaviorSettings,
           )
         }
 
-        item { Divider(24.dp) }
-
         item {
-          AnimatedVisibility(
-            visible = !state.themeVariant.isDarkModeOnly && !state.themeVariant.isLightModeOnly,
-            enter = fadeIn() + expandVertically(),
-            exit = fadeOut() + shrinkVertically(),
-          ) {
-            val appThemeMode = state.appThemeMode
-            ToggleableButtonGroup(
-              modifier =
-                Modifier.fillMaxWidth()
-                  .padding(horizontal = 24.dp)
-                  .padding(top = 24.dp, bottom = 24.dp),
-              items =
-                listOf(
-                  ToggleableButtonItem(
-                    label = stringResource(Res.string.settingsThemeAuto),
-                    isSelected = appThemeMode == AppThemeMode.Auto,
-                    identifier = AppThemeMode.Auto,
-                  ),
-                  ToggleableButtonItem(
-                    label = stringResource(Res.string.settingsThemeLight),
-                    isSelected = appThemeMode == AppThemeMode.Light,
-                    identifier = AppThemeMode.Light,
-                  ),
-                  ToggleableButtonItem(
-                    label = stringResource(Res.string.settingsThemeDark),
-                    isSelected = appThemeMode == AppThemeMode.Dark,
-                    identifier = AppThemeMode.Dark,
-                  ),
-                ),
-              onItemSelected = {
-                viewModel.dispatch(
-                  SettingsEvent.OnAppThemeModeChanged(it.identifier as AppThemeMode)
-                )
-              },
-            )
-          }
-        }
-
-        item {
-          AnimatedVisibility(
-            visible =
-              AppTheme.isDark &&
-                !state.themeVariant.isDarkModeOnly &&
-                !state.themeVariant.isLightModeOnly,
-            enter = fadeIn() + expandVertically(),
-            exit = fadeOut() + shrinkVertically(),
-          ) {
-            AmoledSettingItem(
-              useAmoled = state.useAmoled,
-              onValueChanged = { newValue ->
-                viewModel.dispatch(SettingsEvent.ToggleAmoled(newValue))
-              },
-            )
-          }
-        }
-
-        if (state.canSubscribe) {
-          item { Divider(24.dp) }
-
-          item {
-            AppIconSettingItem(
-              appIcon = state.appIcon,
-              isSubscribed = state.isSubscribed,
-              onClick = { viewModel.dispatch(SettingsEvent.AppIconClicked) },
-            )
-          }
-        }
-
-        item { Divider() }
-        // endregion
-
-        // region Sync settings
-        item { SubHeader(text = stringResource(Res.string.settingsHeaderSync)) }
-
-        item {
-          CloudSyncSettingItem(
-            syncProgress = state.syncProgress,
-            lastSyncedAt = state.lastSyncedAt,
-            hasCloudServiceSignedIn = state.hasCloudServiceSignedIn,
-            availableProviders = viewModel.availableProviders,
-            isSubscribed = state.isSubscribed,
-            onSyncClicked = {
-              if (it.isPremium && !state.isSubscribed) {
-                openPaywall()
-              } else {
-                viewModel.dispatch(SettingsEvent.SyncClicked(it))
-              }
-            },
-            onAPIServiceClicked = {
-              if (it.isPremium && !state.isSubscribed) {
-                openPaywall()
-              } else {
-                when (it.cloudService) {
-                  ServiceType.FRESH_RSS -> openFreshRssLogin()
-                  ServiceType.MINIFLUX -> openMinifluxLogin()
-                  else -> {
-                    throw IllegalStateException("Unknown cloud service type: ${it.cloudService}")
-                  }
-                }
-              }
-            },
-            onSignOutClicked = { viewModel.dispatch(SettingsEvent.SignOutClicked) },
+          SettingsNavigationItem(
+            title = stringResource(Res.string.settingsServicesAndSync),
+            subtitle = stringResource(Res.string.settingsServicesAndSyncSubtitle),
+            icon = TwineIcons.Sync,
+            onClick = openServicesSettings,
           )
         }
 
-        item { Divider() }
-        // endregion
-
-        // region Behaviour settings
-        item { SubHeader(text = stringResource(Res.string.settingsHeaderBehaviour)) }
-
         item {
-          ShowReaderViewSettingItem(
-            showReaderView = state.showReaderView,
-            onValueChanged = { newValue ->
-              viewModel.dispatch(SettingsEvent.ToggleShowReaderView(newValue))
-            },
+          SettingsNavigationItem(
+            title = stringResource(Res.string.settingsYourInsights),
+            subtitle = stringResource(Res.string.settingsYourInsightsSubtitle),
+            icon = TwineIcons.Account,
+            onClick = openDataSettings,
           )
         }
 
-        item { Divider(24.dp) }
-
-        item {
-          BrowserTypeSettingItem(
-            browserType = state.browserType,
-            onBrowserTypeChanged = { newBrowserType ->
-              viewModel.dispatch(SettingsEvent.UpdateBrowserType(newBrowserType))
-            },
-          )
-        }
-
-        item { Divider(24.dp) }
-
-        item {
-          UnreadPostsCountSettingItem(
-            showUnreadCountEnabled = state.showUnreadPostsCount,
-            onValueChanged = { newValue ->
-              viewModel.dispatch(SettingsEvent.ToggleShowUnreadPostsCount(newValue))
-            },
-          )
-        }
-
-        item { Divider(24.dp) }
-
-        item {
-          ShowPinnedSourcesSettingItem(
-            showPinnedSources = state.showPinnedSources,
-            onValueChanged = { newValue ->
-              viewModel.dispatch(SettingsEvent.ToggleShowPinnedSources(newValue))
-            },
-          )
-        }
-
-        item { Divider(24.dp) }
-
-        item {
-          AutoSyncSettingItem(
-            enableAutoSync = state.enableAutoSync,
-            onValueChanged = { newValue ->
-              viewModel.dispatch(SettingsEvent.ToggleAutoSync(newValue))
-            },
-          )
-        }
-
-        item { Divider(24.dp) }
-
-        item {
-          ShowFeedFavIconSettingItem(
-            showFeedFavIcon = state.showFeedFavIcon,
-            onValueChanged = { newValue ->
-              viewModel.dispatch(SettingsEvent.ToggleShowFeedFavIcon(newValue))
-            },
-          )
-        }
-
-        item { Divider(24.dp) }
-
-        item {
-          BlockImagesSettingItem(
-            blockImages = state.blockImages,
-            onValueChanged = { newValue ->
-              viewModel.dispatch(SettingsEvent.ToggleBlockImages(newValue))
-            },
-          )
-        }
-
-        item { Divider(24.dp) }
-
-        item {
-          NotificationsSettingItem(
-            enableNotifications = state.enableNotifications,
-            onValueChanged = { newValue ->
-              viewModel.dispatch(SettingsEvent.ToggleNotifications(newValue))
-            },
-          )
-        }
-
-        item { Divider(24.dp) }
-
-        item {
-          DownloadFullContentSettingItem(
-            downloadFullContent = state.downloadFullContent,
-            onValueChanged = { newValue ->
-              viewModel.dispatch(SettingsEvent.ToggleDownloadFullContent(newValue))
-            },
-          )
-        }
-
-        item { Divider(24.dp) }
-
-        item { BlockedWordsSettingItem { openBlockedWords() } }
-
-        item { Divider(24.dp) }
-
-        item {
-          MarkAsReadOnSettingItem(articleMarkAsReadOn = state.markAsReadOn) {
-            viewModel.dispatch(SettingsEvent.MarkAsReadOnChanged(it))
-          }
-        }
-
-        item { Divider(24.dp) }
-
-        item {
-          PostsDeletionPeriodSettingItem(
-            postsDeletionPeriod = state.postsDeletionPeriod,
-            onValueChanged = { newValue ->
-              viewModel.dispatch(SettingsEvent.PostsDeletionPeriodChanged(newValue))
-            },
-          )
-        }
-
-        item { Divider(24.dp) }
-
-        item {
-          OPMLSettingItem(
-            opmlResult = state.opmlResult,
-            hasFeeds = state.hasFeeds,
-            onImportClicked = { viewModel.dispatch(SettingsEvent.ImportOpmlClicked) },
-            onExportClicked = { viewModel.dispatch(SettingsEvent.ExportOpmlClicked) },
-            onCancelClicked = { viewModel.dispatch(SettingsEvent.CancelOpmlImportOrExport) },
-          )
-        }
-
-        item { Divider() }
-        // endregion
-
-        // region Data
-        item { SubHeader(text = stringResource(Res.string.settingsHeaderData)) }
-
-        item { StatisticsItem { openStatistics() } }
-
-        item { Divider(24.dp) }
-
-        item { DeleteAppDataSettingItem { showDeleteAppDataConfirmation = true } }
-
-        item { Divider() }
-        // endregion
+        item { SettingsDivider() }
 
         // region Feedback and about
         item { SubHeader(text = stringResource(Res.string.settingsHeaderFeedback)) }
@@ -621,23 +189,15 @@ internal fun SettingsScreen(
           )
         }
 
-        item { Divider() }
+        item { SettingsDivider() }
 
         item { AboutItem { openAbout() } }
 
-        item { Divider() }
+        item { SettingsDivider() }
         // endregion
       }
     },
     containerColor = AppTheme.colorScheme.backdrop,
     contentColor = Color.Unspecified,
-  )
-}
-
-@Composable
-private fun Divider(horizontalInsets: Dp = 0.dp) {
-  HorizontalDivider(
-    modifier = Modifier.padding(vertical = 8.dp, horizontal = horizontalInsets),
-    color = AppTheme.colorScheme.outlineVariant,
   )
 }

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/SettingsScreen.kt
@@ -31,40 +31,31 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.sasikanth.rss.reader.components.CircularIconButton
-import dev.sasikanth.rss.reader.components.SubHeader
-import dev.sasikanth.rss.reader.platform.LocalLinkHandler
 import dev.sasikanth.rss.reader.resources.icons.Account
 import dev.sasikanth.rss.reader.resources.icons.Appearance
 import dev.sasikanth.rss.reader.resources.icons.ArrowBack
 import dev.sasikanth.rss.reader.resources.icons.Behaviors
+import dev.sasikanth.rss.reader.resources.icons.Changelog
 import dev.sasikanth.rss.reader.resources.icons.Sync
 import dev.sasikanth.rss.reader.resources.icons.TwineIcons
-import dev.sasikanth.rss.reader.settings.SettingsViewModel
-import dev.sasikanth.rss.reader.settings.ui.items.AboutItem
-import dev.sasikanth.rss.reader.settings.ui.items.ReportIssueSettingItem
 import dev.sasikanth.rss.reader.settings.ui.items.SettingsNavigationItem
 import dev.sasikanth.rss.reader.ui.AppTheme
-import dev.sasikanth.rss.reader.utils.Constants
-import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 import twine.shared.generated.resources.Res
 import twine.shared.generated.resources.buttonGoBack
 import twine.shared.generated.resources.settings
+import twine.shared.generated.resources.settingsAppInfoAndFeedback
 import twine.shared.generated.resources.settingsAppearanceAndLayout
 import twine.shared.generated.resources.settingsAppearanceAndLayoutSubtitle
 import twine.shared.generated.resources.settingsFeaturesAndBehaviors
 import twine.shared.generated.resources.settingsFeaturesAndBehaviorsSubtitle
-import twine.shared.generated.resources.settingsHeaderFeedback
 import twine.shared.generated.resources.settingsServicesAndSync
 import twine.shared.generated.resources.settingsServicesAndSyncSubtitle
 import twine.shared.generated.resources.settingsYourInsights
@@ -72,19 +63,15 @@ import twine.shared.generated.resources.settingsYourInsightsSubtitle
 
 @Composable
 internal fun SettingsScreen(
-  viewModel: SettingsViewModel,
   goBack: () -> Unit,
   openAppearanceSettings: () -> Unit,
   openBehaviorSettings: () -> Unit,
   openServicesSettings: () -> Unit,
   openDataSettings: () -> Unit,
-  openAbout: () -> Unit,
+  openAppInfoSettings: () -> Unit,
   modifier: Modifier = Modifier,
 ) {
-  val coroutineScope = rememberCoroutineScope()
-  val state by viewModel.state.collectAsStateWithLifecycle()
   val layoutDirection = LocalLayoutDirection.current
-  val linkHandler = LocalLinkHandler.current
 
   Scaffold(
     modifier = modifier,
@@ -174,26 +161,14 @@ internal fun SettingsScreen(
           )
         }
 
-        item { SettingsDivider() }
-
-        // region Feedback and about
-        item { SubHeader(text = stringResource(Res.string.settingsHeaderFeedback)) }
-
         item {
-          ReportIssueSettingItem(
-            appInfo = state.appInfo,
-            onClick = {
-              coroutineScope.launch { linkHandler.openLink(Constants.REPORT_ISSUE_LINK) }
-            },
+          SettingsNavigationItem(
+            title = stringResource(Res.string.settingsAppInfoAndFeedback),
+            subtitle = null,
+            icon = TwineIcons.Changelog,
+            onClick = openAppInfoSettings,
           )
         }
-
-        item { SettingsDivider() }
-
-        item { AboutItem { openAbout() } }
-
-        item { SettingsDivider() }
-        // endregion
       }
     },
     containerColor = AppTheme.colorScheme.backdrop,

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/SettingsScreen.kt
@@ -16,31 +16,21 @@
  */
 package dev.sasikanth.rss.reader.settings.ui
 
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalLayoutDirection
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import dev.sasikanth.rss.reader.components.CircularIconButton
+import dev.sasikanth.rss.reader.components.SimpleTopAppBar
 import dev.sasikanth.rss.reader.resources.icons.Account
 import dev.sasikanth.rss.reader.resources.icons.Appearance
-import dev.sasikanth.rss.reader.resources.icons.ArrowBack
 import dev.sasikanth.rss.reader.resources.icons.Behaviors
 import dev.sasikanth.rss.reader.resources.icons.Changelog
 import dev.sasikanth.rss.reader.resources.icons.Sync
@@ -49,7 +39,6 @@ import dev.sasikanth.rss.reader.settings.ui.items.SettingsNavigationItem
 import dev.sasikanth.rss.reader.ui.AppTheme
 import org.jetbrains.compose.resources.stringResource
 import twine.shared.generated.resources.Res
-import twine.shared.generated.resources.buttonGoBack
 import twine.shared.generated.resources.settings
 import twine.shared.generated.resources.settingsAppInfoAndFeedback
 import twine.shared.generated.resources.settingsAppearanceAndLayout
@@ -75,45 +64,7 @@ internal fun SettingsScreen(
 
   Scaffold(
     modifier = modifier,
-    topBar = {
-      Box {
-        TopAppBar(
-          title = {
-            Text(
-              modifier = Modifier.padding(start = 12.dp),
-              text = stringResource(Res.string.settings),
-              color = AppTheme.colorScheme.onSurface,
-              style = MaterialTheme.typography.titleLarge,
-              fontWeight = FontWeight.SemiBold,
-            )
-          },
-          navigationIcon = {
-            CircularIconButton(
-              modifier = Modifier.padding(start = 12.dp),
-              icon = TwineIcons.ArrowBack,
-              label = stringResource(Res.string.buttonGoBack),
-              backgroundColor = AppTheme.colorScheme.inverseSurface,
-              borderColor = AppTheme.colorScheme.inverseSurface,
-              contentColor = AppTheme.colorScheme.inverseOnSurface,
-              onClick = goBack,
-            )
-          },
-          contentPadding = PaddingValues(vertical = 8.dp),
-          colors =
-            TopAppBarDefaults.topAppBarColors(
-              containerColor = AppTheme.colorScheme.surfaceContainerHigh,
-              navigationIconContentColor = AppTheme.colorScheme.onSurface,
-              titleContentColor = AppTheme.colorScheme.onSurface,
-              actionIconContentColor = AppTheme.colorScheme.onSurface,
-            ),
-        )
-
-        HorizontalDivider(
-          modifier = Modifier.fillMaxWidth().align(Alignment.BottomStart),
-          color = AppTheme.colorScheme.outlineVariant,
-        )
-      }
-    },
+    topBar = { SimpleTopAppBar(title = stringResource(Res.string.settings), onBackClick = goBack) },
     content = { padding ->
       LazyColumn(
         modifier = Modifier.fillMaxSize(),

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/SettingsScreen.kt
@@ -79,7 +79,6 @@ internal fun SettingsScreen(
   openServicesSettings: () -> Unit,
   openDataSettings: () -> Unit,
   openAbout: () -> Unit,
-  openPaywall: () -> Unit,
   modifier: Modifier = Modifier,
 ) {
   val coroutineScope = rememberCoroutineScope()

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/SettingsServicesScreen.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/SettingsServicesScreen.kt
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2026 Sasikanth Miriyampalli
+ *
+ * Licensed under the GPL, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package dev.sasikanth.rss.reader.settings.ui
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import dev.sasikanth.rss.reader.components.CircularIconButton
+import dev.sasikanth.rss.reader.core.model.local.ServiceType
+import dev.sasikanth.rss.reader.platform.LocalLinkHandler
+import dev.sasikanth.rss.reader.resources.icons.ArrowBack
+import dev.sasikanth.rss.reader.resources.icons.TwineIcons
+import dev.sasikanth.rss.reader.settings.SettingsEvent
+import dev.sasikanth.rss.reader.settings.SettingsViewModel
+import dev.sasikanth.rss.reader.settings.ui.items.CloudSyncSettingItem
+import dev.sasikanth.rss.reader.settings.ui.items.OPMLSettingItem
+import dev.sasikanth.rss.reader.settings.ui.items.OpmlFeedSelectionSheet
+import dev.sasikanth.rss.reader.ui.AppTheme
+import org.jetbrains.compose.resources.stringResource
+import twine.shared.generated.resources.Res
+import twine.shared.generated.resources.buttonGoBack
+import twine.shared.generated.resources.settingsServicesAndSync
+
+@Composable
+internal fun SettingsServicesScreen(
+  viewModel: SettingsViewModel,
+  goBack: () -> Unit,
+  openPaywall: () -> Unit,
+  openFreshRssLogin: () -> Unit,
+  openMinifluxLogin: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  val state by viewModel.state.collectAsStateWithLifecycle()
+  val layoutDirection = LocalLayoutDirection.current
+  val linkHandler = LocalLinkHandler.current
+
+  LaunchedEffect(state.authUrlToOpen) {
+    state.authUrlToOpen?.let { url ->
+      linkHandler.openLink(url, useInAppBrowser = true)
+      viewModel.dispatch(SettingsEvent.ClearAuthUrl)
+    }
+  }
+
+  LaunchedEffect(state.openPaywall) {
+    if (state.openPaywall) {
+      openPaywall()
+      viewModel.dispatch(SettingsEvent.MarkOpenPaywallAsDone)
+    }
+  }
+
+  LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
+    viewModel.dispatch(SettingsEvent.LoadSubscriptionStatus)
+  }
+
+  Scaffold(
+    modifier = modifier,
+    topBar = {
+      Box {
+        CenterAlignedTopAppBar(
+          title = {
+            Text(
+              stringResource(Res.string.settingsServicesAndSync),
+              color = AppTheme.colorScheme.onSurface,
+              style = MaterialTheme.typography.titleMedium,
+            )
+          },
+          navigationIcon = {
+            CircularIconButton(
+              modifier = Modifier.padding(start = 12.dp),
+              icon = TwineIcons.ArrowBack,
+              label = stringResource(Res.string.buttonGoBack),
+              onClick = goBack,
+            )
+          },
+          contentPadding = PaddingValues(vertical = 8.dp),
+          colors =
+            TopAppBarDefaults.topAppBarColors(
+              containerColor = AppTheme.colorScheme.surface,
+              navigationIconContentColor = AppTheme.colorScheme.onSurface,
+              titleContentColor = AppTheme.colorScheme.onSurface,
+              actionIconContentColor = AppTheme.colorScheme.onSurface,
+            ),
+        )
+
+        HorizontalDivider(
+          modifier = Modifier.fillMaxWidth().align(Alignment.BottomStart),
+          color = AppTheme.colorScheme.outlineVariant,
+        )
+      }
+    },
+    content = { padding ->
+      if (state.opmlFeedsToSelect != null) {
+        OpmlFeedSelectionSheet(
+          feeds = state.opmlFeedsToSelect!!,
+          onFeedsSelected = { viewModel.dispatch(SettingsEvent.OnOpmlFeedsSelected(it)) },
+          onDismiss = { viewModel.dispatch(SettingsEvent.ClearOpmlFeedsToSelect) },
+        )
+      }
+
+      LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding =
+          PaddingValues(
+            start = padding.calculateStartPadding(layoutDirection) + settingsItemHorizontalPadding,
+            top = padding.calculateTopPadding() + 8.dp,
+            end = padding.calculateEndPadding(layoutDirection) + settingsItemHorizontalPadding,
+            bottom = padding.calculateBottomPadding() + 80.dp,
+          ),
+      ) {
+        item {
+          OPMLSettingItem(
+            opmlResult = state.opmlResult,
+            hasFeeds = state.hasFeeds,
+            onImportClicked = { viewModel.dispatch(SettingsEvent.ImportOpmlClicked) },
+            onExportClicked = { viewModel.dispatch(SettingsEvent.ExportOpmlClicked) },
+            onCancelClicked = { viewModel.dispatch(SettingsEvent.CancelOpmlImportOrExport) },
+          )
+        }
+
+        item { SettingsDivider(24.dp) }
+
+        item {
+          CloudSyncSettingItem(
+            syncProgress = state.syncProgress,
+            lastSyncedAt = state.lastSyncedAt,
+            hasCloudServiceSignedIn = state.hasCloudServiceSignedIn,
+            availableProviders = viewModel.availableProviders,
+            isSubscribed = state.isSubscribed,
+            onSyncClicked = {
+              if (it.isPremium && !state.isSubscribed) {
+                openPaywall()
+              } else {
+                viewModel.dispatch(SettingsEvent.SyncClicked(it))
+              }
+            },
+            onAPIServiceClicked = {
+              if (it.isPremium && !state.isSubscribed) {
+                openPaywall()
+              } else {
+                when (it.cloudService) {
+                  ServiceType.FRESH_RSS -> openFreshRssLogin()
+                  ServiceType.MINIFLUX -> openMinifluxLogin()
+                  else -> {
+                    throw IllegalStateException("Unknown cloud service type: ${it.cloudService}")
+                  }
+                }
+              }
+            },
+            onSignOutClicked = { viewModel.dispatch(SettingsEvent.SignOutClicked) },
+          )
+        }
+      }
+    },
+    containerColor = AppTheme.colorScheme.backdrop,
+    contentColor = Color.Unspecified,
+  )
+}

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/SettingsServicesScreen.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/SettingsServicesScreen.kt
@@ -16,24 +16,16 @@
  */
 package dev.sasikanth.rss.reader.settings.ui
 
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material3.CenterAlignedTopAppBar
-import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalLayoutDirection
@@ -41,11 +33,9 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import dev.sasikanth.rss.reader.components.CircularIconButton
+import dev.sasikanth.rss.reader.components.SimpleTopAppBar
 import dev.sasikanth.rss.reader.core.model.local.ServiceType
 import dev.sasikanth.rss.reader.platform.LocalLinkHandler
-import dev.sasikanth.rss.reader.resources.icons.ArrowBack
-import dev.sasikanth.rss.reader.resources.icons.TwineIcons
 import dev.sasikanth.rss.reader.settings.SettingsEvent
 import dev.sasikanth.rss.reader.settings.SettingsViewModel
 import dev.sasikanth.rss.reader.settings.ui.items.CloudSyncSettingItem
@@ -54,7 +44,6 @@ import dev.sasikanth.rss.reader.settings.ui.items.OpmlFeedSelectionSheet
 import dev.sasikanth.rss.reader.ui.AppTheme
 import org.jetbrains.compose.resources.stringResource
 import twine.shared.generated.resources.Res
-import twine.shared.generated.resources.buttonGoBack
 import twine.shared.generated.resources.settingsServicesAndSync
 
 @Composable
@@ -91,38 +80,10 @@ internal fun SettingsServicesScreen(
   Scaffold(
     modifier = modifier,
     topBar = {
-      Box {
-        CenterAlignedTopAppBar(
-          title = {
-            Text(
-              stringResource(Res.string.settingsServicesAndSync),
-              color = AppTheme.colorScheme.onSurface,
-              style = MaterialTheme.typography.titleMedium,
-            )
-          },
-          navigationIcon = {
-            CircularIconButton(
-              modifier = Modifier.padding(start = 12.dp),
-              icon = TwineIcons.ArrowBack,
-              label = stringResource(Res.string.buttonGoBack),
-              onClick = goBack,
-            )
-          },
-          contentPadding = PaddingValues(vertical = 8.dp),
-          colors =
-            TopAppBarDefaults.topAppBarColors(
-              containerColor = AppTheme.colorScheme.surface,
-              navigationIconContentColor = AppTheme.colorScheme.onSurface,
-              titleContentColor = AppTheme.colorScheme.onSurface,
-              actionIconContentColor = AppTheme.colorScheme.onSurface,
-            ),
-        )
-
-        HorizontalDivider(
-          modifier = Modifier.fillMaxWidth().align(Alignment.BottomStart),
-          color = AppTheme.colorScheme.outlineVariant,
-        )
-      }
+      SimpleTopAppBar(
+        title = stringResource(Res.string.settingsServicesAndSync),
+        onBackClick = goBack,
+      )
     },
     content = { padding ->
       if (state.opmlFeedsToSelect != null) {

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/SettingsShared.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/SettingsShared.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 Sasikanth Miriyampalli
+ *
+ * Licensed under the GPL, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package dev.sasikanth.rss.reader.settings.ui
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.window.core.layout.WindowSizeClass
+import dev.sasikanth.rss.reader.utils.LocalWindowSizeClass
+
+internal val settingsItemHorizontalPadding: Dp
+  @Composable
+  @ReadOnlyComposable
+  get() {
+    val sizeClass = LocalWindowSizeClass.current
+    return when {
+      sizeClass.isWidthAtLeastBreakpoint(WindowSizeClass.WIDTH_DP_EXPANDED_LOWER_BOUND) -> 128.dp
+      else -> 0.dp
+    }
+  }
+
+@Composable
+internal fun SettingsDivider(horizontalInsets: Dp = 0.dp) {
+  HorizontalDivider(
+    modifier = Modifier.padding(vertical = 8.dp, horizontal = horizontalInsets),
+    color = dev.sasikanth.rss.reader.ui.AppTheme.colorScheme.outlineVariant,
+  )
+}

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/items/SettingsNavigationItem.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/items/SettingsNavigationItem.kt
@@ -32,6 +32,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import dev.sasikanth.rss.reader.resources.icons.RSS
 import dev.sasikanth.rss.reader.resources.icons.TwineIcons
@@ -64,12 +65,13 @@ internal fun SettingsNavigationItem(
       Column(modifier = Modifier.weight(1f).padding(start = 16.dp)) {
         Text(
           title,
-          style = MaterialTheme.typography.titleMedium,
+          style = MaterialTheme.typography.titleSmall,
+          fontWeight = FontWeight.Medium,
           color = AppTheme.colorScheme.onSurface,
         )
         Text(
           subtitle,
-          style = MaterialTheme.typography.labelLarge,
+          style = MaterialTheme.typography.bodySmall,
           color = AppTheme.colorScheme.onSurfaceVariant,
         )
       }

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/items/SettingsNavigationItem.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/items/SettingsNavigationItem.kt
@@ -41,7 +41,7 @@ import dev.sasikanth.rss.reader.ui.AppTheme
 @Composable
 internal fun SettingsNavigationItem(
   title: String,
-  subtitle: String,
+  subtitle: String?,
   onClick: () -> Unit,
   modifier: Modifier = Modifier,
   icon: ImageVector = TwineIcons.RSS,
@@ -69,11 +69,14 @@ internal fun SettingsNavigationItem(
           fontWeight = FontWeight.Medium,
           color = AppTheme.colorScheme.onSurface,
         )
-        Text(
-          subtitle,
-          style = MaterialTheme.typography.bodySmall,
-          color = AppTheme.colorScheme.onSurfaceVariant,
-        )
+
+        if (!(subtitle.isNullOrBlank())) {
+          Text(
+            subtitle,
+            style = MaterialTheme.typography.bodySmall,
+            color = AppTheme.colorScheme.onSurfaceVariant,
+          )
+        }
       }
     }
   }

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/items/SettingsNavigationItem.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/settings/ui/items/SettingsNavigationItem.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 Sasikanth Miriyampalli
+ *
+ * Licensed under the GPL, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package dev.sasikanth.rss.reader.settings.ui.items
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+import dev.sasikanth.rss.reader.resources.icons.RSS
+import dev.sasikanth.rss.reader.resources.icons.TwineIcons
+import dev.sasikanth.rss.reader.ui.AppTheme
+
+@Composable
+internal fun SettingsNavigationItem(
+  title: String,
+  subtitle: String,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+  icon: ImageVector = TwineIcons.RSS,
+) {
+  Box(modifier = modifier.clickable(onClick = onClick)) {
+    Row(modifier = Modifier.padding(all = 16.dp), verticalAlignment = Alignment.CenterVertically) {
+      Box(
+        modifier =
+          Modifier.size(40.dp)
+            .background(AppTheme.colorScheme.onSurface.copy(alpha = 0.08f), shape = CircleShape),
+        contentAlignment = Alignment.Center,
+      ) {
+        Icon(
+          modifier = Modifier.size(20.dp),
+          imageVector = icon,
+          contentDescription = null,
+          tint = AppTheme.colorScheme.onSurface,
+        )
+      }
+
+      Column(modifier = Modifier.weight(1f).padding(start = 16.dp)) {
+        Text(
+          title,
+          style = MaterialTheme.typography.titleMedium,
+          color = AppTheme.colorScheme.onSurface,
+        )
+        Text(
+          subtitle,
+          style = MaterialTheme.typography.labelLarge,
+          color = AppTheme.colorScheme.onSurfaceVariant,
+        )
+      }
+    }
+  }
+}

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/statistics/ui/StatisticsScreen.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/statistics/ui/StatisticsScreen.kt
@@ -38,13 +38,10 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -52,17 +49,16 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import dev.sasikanth.rss.reader.components.CircularIconButton
+import dev.sasikanth.rss.reader.components.SimpleTopAppBar
 import dev.sasikanth.rss.reader.components.SubHeader
 import dev.sasikanth.rss.reader.components.image.FeedIcon
 import dev.sasikanth.rss.reader.core.model.local.FeedReadCount
 import dev.sasikanth.rss.reader.core.model.local.ReadingTrend
-import dev.sasikanth.rss.reader.resources.icons.ArrowBack
-import dev.sasikanth.rss.reader.resources.icons.TwineIcons
 import dev.sasikanth.rss.reader.statistics.StatisticsViewModel
 import dev.sasikanth.rss.reader.ui.AppTheme
 import dev.sasikanth.rss.reader.utils.formatReadingTrendDate
@@ -76,7 +72,6 @@ import kotlinx.datetime.plus
 import kotlinx.datetime.todayIn
 import org.jetbrains.compose.resources.stringResource
 import twine.shared.generated.resources.Res
-import twine.shared.generated.resources.buttonGoBack
 import twine.shared.generated.resources.statistics
 import twine.shared.generated.resources.statisticsLess
 import twine.shared.generated.resources.statisticsMore
@@ -97,39 +92,10 @@ fun StatisticsScreen(
   Scaffold(
     modifier = modifier,
     topBar = {
-      Box {
-        CenterAlignedTopAppBar(
-          title = {
-            Text(
-              text = stringResource(Res.string.statistics),
-              color = AppTheme.colorScheme.onSurface,
-              style = MaterialTheme.typography.titleMedium,
-            )
-          },
-          navigationIcon = {
-            CircularIconButton(
-              modifier = Modifier.padding(start = 12.dp),
-              icon = TwineIcons.ArrowBack,
-              label = stringResource(Res.string.buttonGoBack),
-              onClick = goBack,
-            )
-          },
-          colors =
-            TopAppBarDefaults.topAppBarColors(
-              containerColor = AppTheme.colorScheme.surface,
-              navigationIconContentColor = AppTheme.colorScheme.onSurface,
-              titleContentColor = AppTheme.colorScheme.onSurface,
-              actionIconContentColor = AppTheme.colorScheme.onSurface,
-            ),
-        )
-
-        HorizontalDivider(
-          modifier = Modifier.fillMaxWidth().align(Alignment.BottomStart),
-          color = AppTheme.colorScheme.outlineVariant,
-        )
-      }
+      SimpleTopAppBar(title = stringResource(Res.string.statistics), onBackClick = goBack)
     },
     containerColor = AppTheme.colorScheme.backdrop,
+    contentColor = Color.Unspecified,
   ) { padding ->
     if (state.isLoading) {
       Box(modifier = Modifier.fillMaxSize().padding(padding), contentAlignment = Alignment.Center) {


### PR DESCRIPTION
This PR refactors the settings screen into multiple sub-screens (Appearance, Behavior, Notifications, etc.) and improves the overall UI consistency.

Key changes:
- Introduced SimpleTopAppBar for consistent navigation in secondary screens.
- Split settings into dedicated screens: Appearance, Behavior, Notifications, and App info & feedback.
- Updated settings navigation items with optional subtitles and improved typography.
- Fixed back navigation issues in MainScreen.
- Moved "Show pinned sources" setting to the top of Behavior settings.
- Cleaned up unused navigation and resources.