### PR TITLE
Refactor pinned sources UI and add drag-and-reorder support

### DIFF
--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/common/SourcesPinned.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/common/SourcesPinned.kt
@@ -18,194 +18,169 @@
 package dev.sasikanth.rss.reader.feeds.ui.common
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredSize
-import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ExpandLess
-import androidx.compose.material.icons.filled.ExpandMore
-import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material.icons.rounded.Remove
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.dropShadow
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.unit.dp
+import dev.sasikanth.rss.reader.components.image.FeedIcon
 import dev.sasikanth.rss.reader.core.model.local.Feed
 import dev.sasikanth.rss.reader.core.model.local.FeedGroup
 import dev.sasikanth.rss.reader.core.model.local.Source
-import dev.sasikanth.rss.reader.core.model.local.SourceType
-import dev.sasikanth.rss.reader.feeds.ui.FeedGroupItem
-import dev.sasikanth.rss.reader.feeds.ui.FeedListItem
-import dev.sasikanth.rss.reader.resources.icons.DragIndicator
-import dev.sasikanth.rss.reader.resources.icons.TwineIcons
+import dev.sasikanth.rss.reader.feeds.ui.FeedGroupIconGrid
 import dev.sasikanth.rss.reader.ui.AppTheme
-import dev.sasikanth.rss.reader.utils.bottomPaddingOfSourceItem
-import org.jetbrains.compose.resources.stringResource
-import sh.calvin.reorderable.ReorderableCollectionItemScope
 import sh.calvin.reorderable.ReorderableItem
-import sh.calvin.reorderable.ReorderableLazyListState
-import twine.shared.generated.resources.Res
-import twine.shared.generated.resources.pinnedFeeds
+import sh.calvin.reorderable.rememberReorderableLazyListState
 
 internal fun LazyListScope.pinnedSources(
-  reorderableLazyListState: ReorderableLazyListState,
   pinnedSources: List<Source>,
-  selectedSources: Set<Source>,
-  isPinnedSectionExpanded: Boolean,
-  canShowUnreadPostsCount: Boolean,
-  isInMultiSelectMode: Boolean,
-  onTogglePinnedSection: () -> Unit,
   onSourceClick: (Source) -> Unit,
-  onToggleSourceSelection: (Source) -> Unit,
   onPinClick: (Source) -> Unit,
+  onPinnedSourceOrderChanged: (List<Source>) -> Unit,
 ) {
   if (pinnedSources.isNotEmpty()) {
-    stickyHeader(key = "PinnedFeedsHeader") {
-      PinnedFeedsHeader(
-        modifier = Modifier.animateItem(),
-        isPinnedSectionExpanded = isPinnedSectionExpanded,
-        onToggleSection = onTogglePinnedSection,
-      )
-    }
+    item(key = "PinnedSourcesRow") {
+      val lazyListState = androidx.compose.foundation.lazy.rememberLazyListState()
+      val reorderableLazyRowState =
+        rememberReorderableLazyListState(
+          lazyListState = lazyListState,
+          onMove = { from, to ->
+            onPinnedSourceOrderChanged(
+              pinnedSources.toMutableList().apply { add(to.index, removeAt(from.index)) }
+            )
+          },
+        )
 
-    if (isPinnedSectionExpanded) {
-      items(
-        count = pinnedSources.size,
-        key = { "PinnedSource: ${pinnedSources[it].id}" },
-        contentType = {
-          if (pinnedSources[it].sourceType == SourceType.FeedGroup) {
-            "FeedGroupItem"
-          } else {
-            "FeedListItem"
-          }
-        },
-      ) { index ->
-        val source = pinnedSources[index]
-        val startPadding = 24.dp
-        val endPadding = 16.dp
-        val topPadding = 4.dp
-        val bottomPadding = bottomPaddingOfSourceItem(index, pinnedSources.size)
-        val interactionSource = remember { MutableInteractionSource() }
+      LazyRow(
+        state = lazyListState,
+        contentPadding = PaddingValues(horizontal = 16.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = Modifier.fillMaxWidth().padding(top = 12.dp, bottom = 16.dp).animateItem(),
+      ) {
+        items(items = pinnedSources, key = { "PinnedSource: ${it.id}" }) { source ->
+          ReorderableItem(state = reorderableLazyRowState, key = "PinnedSource: ${source.id}") {
+            isDragging ->
+            val haptic = LocalHapticFeedback.current
+            val interactionSource = remember { MutableInteractionSource() }
 
-        ReorderableItem(state = reorderableLazyListState, key = "PinnedSource: ${source.id}") {
-          when (source) {
-            is FeedGroup -> {
-              FeedGroupItem(
-                feedGroup = source,
-                canShowUnreadPostsCount = canShowUnreadPostsCount,
-                isInMultiSelectMode = isInMultiSelectMode,
-                selected = selectedSources.any { it.id == source.id },
-                onFeedGroupSelected = onToggleSourceSelection,
-                onFeedGroupClick = onSourceClick,
-                onOptionsClick = { onToggleSourceSelection(source) },
-                onPinClick = onPinClick,
-                dragHandle = { DragHandle(this, interactionSource) },
-                interactionSource = interactionSource,
-                modifier =
-                  Modifier.padding(
-                      start = startPadding,
-                      top = topPadding,
-                      end = endPadding,
-                      bottom = bottomPadding,
-                    )
-                    .animateItem(),
-              )
-            }
-            is Feed -> {
-              FeedListItem(
-                feed = source,
-                canShowUnreadPostsCount = canShowUnreadPostsCount,
-                isInMultiSelectMode = isInMultiSelectMode,
-                isFeedSelected = selectedSources.any { it.id == source.id },
-                onFeedClick = onSourceClick,
-                onFeedSelected = onToggleSourceSelection,
-                onOptionsClick = { onToggleSourceSelection(source) },
-                onPinClick = onPinClick,
-                dragHandle = { DragHandle(this, interactionSource) },
-                interactionSource = interactionSource,
-                modifier =
-                  Modifier.padding(
-                      start = startPadding,
-                      top = topPadding,
-                      end = endPadding,
-                      bottom = bottomPadding,
-                    )
-                    .animateItem(),
-              )
-            }
+            PinnedSourceItem(
+              source = source,
+              onSourceClick = onSourceClick,
+              onRemoveClick = onPinClick,
+              isDragging = isDragging,
+              modifier =
+                Modifier.longPressDraggableHandle(
+                  onDragStarted = { haptic.performHapticFeedback(HapticFeedbackType.LongPress) },
+                  interactionSource = interactionSource,
+                ),
+            )
           }
         }
       }
     }
-
-    item {
-      HorizontalDivider(
-        modifier = Modifier.padding(top = 24.dp).animateItem(),
-        color = AppTheme.colorScheme.surfaceContainerLow,
-      )
-    }
   }
 }
 
 @Composable
-private fun DragHandle(
-  scope: ReorderableCollectionItemScope,
-  interactionSource: MutableInteractionSource,
-) {
-  with(scope) {
-    Box(modifier = Modifier.requiredSize(40.dp), contentAlignment = Alignment.Center) {
-      Icon(
-        modifier =
-          Modifier.requiredSize(20.dp).draggableHandle(interactionSource = interactionSource),
-        imageVector = TwineIcons.DragIndicator,
-        contentDescription = null,
-        tint = AppTheme.colorScheme.onSurfaceVariant,
-      )
-    }
-  }
-}
-
-@Composable
-private fun PinnedFeedsHeader(
-  isPinnedSectionExpanded: Boolean,
+private fun PinnedSourceItem(
+  source: Source,
+  onSourceClick: (Source) -> Unit,
+  onRemoveClick: (Source) -> Unit,
+  isDragging: Boolean,
   modifier: Modifier = Modifier,
-  onToggleSection: () -> Unit,
 ) {
-  Row(
+  Box(
     modifier =
-      Modifier.background(AppTheme.colorScheme.bottomSheet)
-        .padding(start = 32.dp, end = 20.dp)
-        .padding(vertical = 12.dp)
-        .then(modifier),
-    verticalAlignment = Alignment.CenterVertically,
+      modifier
+        .requiredSize(64.dp)
+        .graphicsLayer(compositingStrategy = CompositingStrategy.Offscreen),
+    contentAlignment = Alignment.Center,
   ) {
-    Text(
-      modifier = Modifier.weight(1f),
-      text = stringResource(Res.string.pinnedFeeds),
-      style = MaterialTheme.typography.titleMedium,
-      color = AppTheme.colorScheme.onSurface,
-    )
+    val shape = RoundedCornerShape(16.dp)
+    val borderColor = AppTheme.colorScheme.outlineVariant
 
-    val icon =
-      if (isPinnedSectionExpanded) {
-        Icons.Filled.ExpandLess
-      } else {
-        Icons.Filled.ExpandMore
+    Box(
+      modifier =
+        Modifier.clip(shape)
+          .background(AppTheme.colorScheme.backdrop)
+          .border(1.dp, borderColor, shape)
+          .clickable(enabled = !isDragging) { onSourceClick(source) },
+      contentAlignment = Alignment.Center,
+    ) {
+      when (source) {
+        is Feed -> {
+          FeedIcon(
+            icon = source.icon,
+            homepageLink = source.homepageLink,
+            showFeedFavIcon = source.showFeedFavIcon,
+            contentDescription = null,
+            modifier = Modifier.requiredSize(48.dp),
+            shape = shape,
+          )
+        }
+        is FeedGroup -> {
+          FeedGroupIconGrid(
+            feedHomepageLinks = source.feedHomepageLinks,
+            feedIconLinks = source.feedIconLinks,
+            feedShowFavIconSettings = source.feedShowFavIconSettings,
+            modifier = Modifier.requiredSize(48.dp),
+          )
+        }
       }
+    }
 
-    Spacer(Modifier.requiredWidth(12.dp))
-
-    IconButton(onClick = onToggleSection) {
-      Icon(imageVector = icon, contentDescription = null, tint = AppTheme.colorScheme.onSurface)
+    if (!isDragging) {
+      Surface(
+        modifier =
+          Modifier.align(Alignment.TopEnd)
+            .requiredSize(20.dp)
+            .dropShadow(shape) {
+              spread = 1.dp.toPx()
+              color = Color.Black
+              blendMode = BlendMode.DstOut
+            }
+            .clickable(
+              interactionSource = remember { MutableInteractionSource() },
+              indication = null,
+              onClick = { onRemoveClick(source) },
+            ),
+        shape = CircleShape,
+        color = AppTheme.colorScheme.inverseSurface,
+        contentColor = AppTheme.colorScheme.inverseOnSurface,
+      ) {
+        Icon(
+          imageVector = Icons.Rounded.Remove,
+          contentDescription = null,
+          modifier = Modifier.padding(4.dp),
+        )
+      }
     }
   }
 }

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/pinned/PinnedFeedGroupItem.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/pinned/PinnedFeedGroupItem.kt
@@ -41,6 +41,7 @@ internal fun PinnedFeedGroupItem(
   onClick: (() -> Unit)? = null,
   hasActiveSource: Boolean = false,
   selected: Boolean = false,
+  isDragging: Boolean = false,
 ) {
   Box(
     modifier = modifier.graphicsLayer { alpha = if (selected || !hasActiveSource) 1f else 0.25f }
@@ -48,7 +49,8 @@ internal fun PinnedFeedGroupItem(
     Box(modifier = Modifier.size(64.dp), contentAlignment = Alignment.Center) {
       val shape = RoundedCornerShape(16.dp)
       val clickableModifier =
-        if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier
+        if (onClick != null) Modifier.clickable(enabled = !isDragging, onClick = onClick)
+        else Modifier
 
       Box(
         modifier =
@@ -72,7 +74,7 @@ internal fun PinnedFeedGroupItem(
     }
 
     val badgeCount = feedGroup.numberOfUnreadPosts
-    if (badgeCount > 0 && canShowUnreadPostsCount) {
+    if (!isDragging && badgeCount > 0 && canShowUnreadPostsCount) {
       UnreadCountBadge(badgeCount)
     }
   }

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/pinned/PinnedFeedItem.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/pinned/PinnedFeedItem.kt
@@ -49,6 +49,7 @@ internal fun PinnedFeedItem(
   modifier: Modifier = Modifier,
   hasActiveSource: Boolean = false,
   selected: Boolean = false,
+  isDragging: Boolean = false,
 ) {
   Box(
     modifier =
@@ -66,7 +67,10 @@ internal fun PinnedFeedItem(
       showFeedFavIcon = showFeedFavIcon,
       contentDescription = null,
       shape = feedIconShape,
-      modifier = Modifier.requiredSize(48.dp).clip(feedIconShape).clickable(onClick = onClick),
+      modifier =
+        Modifier.requiredSize(48.dp)
+          .clip(feedIconShape)
+          .clickable(enabled = !isDragging, onClick = onClick),
     )
 
     Box(
@@ -74,7 +78,7 @@ internal fun PinnedFeedItem(
         Modifier.requiredSize(48.dp).border(1.dp, AppTheme.colorScheme.outlineVariant, shape)
     )
 
-    if (badgeCount > 0 && canShowUnreadPostsCount) {
+    if (!isDragging && badgeCount > 0 && canShowUnreadPostsCount) {
       UnreadCountBadge(badgeCount)
     }
   }

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/pinned/PinnedSourcesBottomBar.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/feeds/ui/pinned/PinnedSourcesBottomBar.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -35,7 +36,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.unit.dp
 import dev.sasikanth.rss.reader.core.model.local.Feed
 import dev.sasikanth.rss.reader.core.model.local.FeedGroup
@@ -44,6 +47,8 @@ import dev.sasikanth.rss.reader.ui.AppTheme
 import dev.sasikanth.rss.reader.utils.BOTTOM_BAR_CORNER_RADIUS
 import dev.sasikanth.rss.reader.utils.BOTTOM_BAR_MAX_WIDTH
 import dev.sasikanth.rss.reader.utils.PINNED_SOURCES_BOTTOM_BAR_HEIGHT
+import sh.calvin.reorderable.ReorderableItem
+import sh.calvin.reorderable.rememberReorderableLazyListState
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -53,14 +58,26 @@ internal fun PinnedSourcesBottomBar(
   canShowUnreadPostsCount: Boolean,
   onSourceClick: (Source) -> Unit,
   onHomeSelected: () -> Unit,
+  onPinnedSourceOrderChanged: (List<Source>) -> Unit,
   modifier: Modifier = Modifier,
   scrollBehavior: PinnedSourcesBottomBarScrollBehavior? = null,
 ) {
   val shape = RoundedCornerShape(BOTTOM_BAR_CORNER_RADIUS)
 
   val translationY = scrollBehavior?.state?.heightOffset ?: 0f
+  val lazyListState = rememberLazyListState()
+  val reorderableLazyRowState =
+    rememberReorderableLazyListState(
+      lazyListState = lazyListState,
+      onMove = { from, to ->
+        onPinnedSourceOrderChanged(
+          pinnedSources.toMutableList().apply { add(to.index, removeAt(from.index)) }
+        )
+      },
+    )
 
   LazyRow(
+    state = lazyListState,
     modifier =
       Modifier.onGloballyPositioned { coordinates ->
           val height = coordinates.size.height.toFloat()
@@ -81,14 +98,24 @@ internal fun PinnedSourcesBottomBar(
     verticalAlignment = Alignment.CenterVertically,
     contentPadding = PaddingValues(start = 8.dp, end = 8.dp),
   ) {
-    items(pinnedSources.size) { index ->
-      SourceItem(
-        source = pinnedSources[index],
-        activeSource = activeSource,
-        canShowUnreadPostsCount = canShowUnreadPostsCount,
-        onHomeSelected = onHomeSelected,
-        onSourceClick = onSourceClick,
-      )
+    items(count = pinnedSources.size, key = { pinnedSources[it].id }) { index ->
+      val source = pinnedSources[index]
+      ReorderableItem(state = reorderableLazyRowState, key = source.id) { isDragging ->
+        val haptic = LocalHapticFeedback.current
+
+        SourceItem(
+          source = source,
+          activeSource = activeSource,
+          canShowUnreadPostsCount = canShowUnreadPostsCount,
+          onHomeSelected = onHomeSelected,
+          onSourceClick = onSourceClick,
+          isDragging = isDragging,
+          modifier =
+            Modifier.longPressDraggableHandle(
+              onDragStarted = { haptic.performHapticFeedback(HapticFeedbackType.LongPress) }
+            ),
+        )
+      }
     }
   }
 }
@@ -100,6 +127,8 @@ private fun SourceItem(
   canShowUnreadPostsCount: Boolean,
   onHomeSelected: () -> Unit,
   onSourceClick: (Source) -> Unit,
+  isDragging: Boolean,
+  modifier: Modifier = Modifier,
 ) {
   when (val source = source) {
     is FeedGroup -> {
@@ -108,6 +137,8 @@ private fun SourceItem(
         canShowUnreadPostsCount = canShowUnreadPostsCount,
         hasActiveSource = activeSource != null,
         selected = activeSource?.id == source.id,
+        isDragging = isDragging,
+        modifier = modifier,
         onClick = {
           if (activeSource?.id == source.id) {
             onHomeSelected()
@@ -126,6 +157,8 @@ private fun SourceItem(
         canShowUnreadPostsCount = canShowUnreadPostsCount,
         hasActiveSource = activeSource != null,
         selected = activeSource?.id == source.id,
+        isDragging = isDragging,
+        modifier = modifier,
         onClick = {
           if (activeSource?.id == source.id) {
             onHomeSelected()

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/ui/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/home/ui/HomeScreen.kt
@@ -266,6 +266,9 @@ internal fun HomeScreen(
               canShowUnreadPostsCount = feedsState.canShowUnreadPostsCount,
               onSourceClick = { feed -> feedsViewModel.dispatch(FeedsEvent.OnSourceClick(feed)) },
               onHomeSelected = { feedsViewModel.dispatch(FeedsEvent.OnHomeSelected) },
+              onPinnedSourceOrderChanged = { newPinnedSources ->
+                feedsViewModel.dispatch(FeedsEvent.OnPinnedSourcePositionChanged(newPinnedSources))
+              },
               scrollBehavior = bottomBarScrollState,
             )
           }

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/main/ui/NavigationDrawerContent.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/main/ui/NavigationDrawerContent.kt
@@ -97,6 +97,7 @@ import dev.sasikanth.rss.reader.feeds.ui.DeleteConfirmationDialog
 import dev.sasikanth.rss.reader.feeds.ui.FeedGroupIconGrid
 import dev.sasikanth.rss.reader.feeds.ui.common.AllFeedsHeader
 import dev.sasikanth.rss.reader.feeds.ui.common.allSources
+import dev.sasikanth.rss.reader.feeds.ui.common.pinnedSources
 import dev.sasikanth.rss.reader.feeds.ui.common.sourcesSearchResults
 import dev.sasikanth.rss.reader.resources.icons.Add
 import dev.sasikanth.rss.reader.resources.icons.Close
@@ -337,6 +338,15 @@ private fun ExpandedDrawerContent(
             onAddNewFeedClick = { feedsViewModel.dispatch(FeedsEvent.OnNewFeedClicked) },
           )
         }
+
+        pinnedSources(
+          pinnedSources = state.pinnedSources,
+          onSourceClick = { feedsViewModel.dispatch(FeedsEvent.OnSourceClick(it)) },
+          onPinClick = { feedsViewModel.dispatch(FeedsEvent.OnSourcePinClicked(it)) },
+          onPinnedSourceOrderChanged = {
+            feedsViewModel.dispatch(FeedsEvent.OnPinnedSourcePositionChanged(it))
+          },
+        )
 
         item {
           SearchBar(


### PR DESCRIPTION
This PR refactors the pinned sources in the navigation drawer into a horizontal LazyRow and introduces drag-and-reorder functionality.

Key changes:
- Refactored pinned sources in the navigation drawer to a horizontal LazyRow.
- Implemented long-press drag-and-reorder support for pinned sources in both the drawer and the bottom bar.
- Added a new PinnedSourceItem UI for the drawer with an overlapping remove badge.
- Improved UX by hiding badges/remove icons during drag operations.
- Integrated haptic feedback when starting a drag operation.