### PR TITLE
⚡ Batch update seed colors to eliminate N+1 query pattern

### DIFF
--- a/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/repository/RssRepository.kt
+++ b/core/data/src/commonMain/kotlin/dev/sasikanth/rss/reader/data/repository/RssRepository.kt
@@ -690,6 +690,16 @@ class RssRepository(
     }
   }
 
+  suspend fun updateSeedColors(updates: Map<String, Int>) {
+    withContext(dispatchersProvider.databaseWrite) {
+      transactionRunner.invoke {
+        updates.forEach { (id, seedColor) ->
+          postQueries.updateSeedColor(seedColor = seedColor.toLong(), id = id)
+        }
+      }
+    }
+  }
+
   suspend fun allReadPostsBlocking(): List<ReadPostSyncEntity> {
     return withContext(dispatchersProvider.databaseRead) {
       postQueries

--- a/core/data/src/jvmTest/kotlin/dev/sasikanth/rss/reader/data/repository/RssRepositoryTest.kt
+++ b/core/data/src/jvmTest/kotlin/dev/sasikanth/rss/reader/data/repository/RssRepositoryTest.kt
@@ -322,6 +322,39 @@ class RssRepositoryTest {
   }
 
   @Test
+  fun updateSeedColorsShouldUpdateMultiplePosts() = runTest {
+    // given
+    val feedId = "feed-1"
+    database.feedQueries.upsert(
+      id = feedId,
+      name = "Feed 1",
+      icon = "icon",
+      description = "description",
+      homepageLink = "homepage",
+      createdAt = Instant.fromEpochMilliseconds(0),
+      link = "link",
+      alwaysFetchSourceArticle = false,
+      showFeedFavIcon = false,
+      lastUpdatedAt = Instant.fromEpochMilliseconds(0),
+    )
+
+    insertPost(id = "post-1", sourceId = feedId, postDate = Instant.fromEpochMilliseconds(0))
+    insertPost(id = "post-2", sourceId = feedId, postDate = Instant.fromEpochMilliseconds(0))
+
+    val updates = mapOf("post-1" to 123, "post-2" to 456)
+
+    // when
+    repository.updateSeedColors(updates)
+
+    // then
+    val post1 = repository.post("post-1")
+    val post2 = repository.post("post-2")
+
+    assertEquals(123, post1.seedColor)
+    assertEquals(456, post2.seedColor)
+  }
+
+  @Test
   fun postPositionShouldMatchIndexInAllPostsForAllSortOrders() = runTest {
     // given
     val feedId = "feed-1"

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/posts/AllPostsPager.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/posts/AllPostsPager.kt
@@ -45,6 +45,8 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -52,8 +54,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
@@ -138,25 +138,27 @@ class AllPostsPager(
           postsUpperBound = params.postsUpperBound,
         )
         .onEach { posts ->
-          val seedColorUpdates =
-            posts
-              .filter { it.seedColor == null && !it.imageUrl.isNullOrBlank() }
-              .map { post ->
-                coroutineScope.async {
-                  val seedColor = seedColorExtractor.calculateSeedColor(post.imageUrl)
-                  if (seedColor != null) {
-                    post.id to seedColor.toArgb()
-                  } else {
-                    null
+          coroutineScope.launch {
+            val seedColorUpdates =
+              posts
+                .filter { it.seedColor == null && !it.imageUrl.isNullOrBlank() }
+                .map { post ->
+                  async {
+                    val seedColor = seedColorExtractor.calculateSeedColor(post.imageUrl)
+                    if (seedColor != null) {
+                      post.id to seedColor.toArgb()
+                    } else {
+                      null
+                    }
                   }
                 }
-              }
-              .awaitAll()
-              .filterNotNull()
-              .toMap()
+                .awaitAll()
+                .filterNotNull()
+                .toMap()
 
-          if (seedColorUpdates.isNotEmpty()) {
-            rssRepository.updateSeedColors(seedColorUpdates)
+            if (seedColorUpdates.isNotEmpty()) {
+              rssRepository.updateSeedColors(seedColorUpdates)
+            }
           }
         }
         .map { featuredPosts ->

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/posts/AllPostsPager.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/posts/AllPostsPager.kt
@@ -52,6 +52,8 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
@@ -136,15 +138,25 @@ class AllPostsPager(
           postsUpperBound = params.postsUpperBound,
         )
         .onEach { posts ->
-          posts.forEach { post ->
-            if (post.seedColor == null && !post.imageUrl.isNullOrBlank()) {
-              coroutineScope.launch {
-                val seedColor = seedColorExtractor.calculateSeedColor(post.imageUrl)
-                if (seedColor != null) {
-                  rssRepository.updateSeedColor(seedColor.toArgb(), post.id)
+          val seedColorUpdates =
+            posts
+              .filter { it.seedColor == null && !it.imageUrl.isNullOrBlank() }
+              .map { post ->
+                coroutineScope.async {
+                  val seedColor = seedColorExtractor.calculateSeedColor(post.imageUrl)
+                  if (seedColor != null) {
+                    post.id to seedColor.toArgb()
+                  } else {
+                    null
+                  }
                 }
               }
-            }
+              .awaitAll()
+              .filterNotNull()
+              .toMap()
+
+          if (seedColorUpdates.isNotEmpty()) {
+            rssRepository.updateSeedColors(seedColorUpdates)
           }
         }
         .map { featuredPosts ->

--- a/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/posts/PostSyncProcessor.kt
+++ b/shared/src/commonMain/kotlin/dev/sasikanth/rss/reader/posts/PostSyncProcessor.kt
@@ -27,6 +27,8 @@ import dev.sasikanth.rss.reader.ui.SeedColorExtractor
 import dev.sasikanth.rss.reader.util.DispatchersProvider
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -58,13 +60,25 @@ class PostSyncProcessor(
       val posts =
         rssRepository.postsWithImagesAndNoSeedColor(limit = Constants.NUMBER_OF_FEATURED_POSTS * 2)
 
-      posts.forEach { post ->
-        if (post.seedColor == null && !post.imageUrl.isNullOrBlank()) {
-          val seedColor = seedColorExtractor.calculateSeedColor(post.imageUrl)
-          if (seedColor != null) {
-            rssRepository.updateSeedColor(seedColor = seedColor.toArgb(), id = post.id)
+      val seedColorUpdates =
+        posts
+          .filter { it.seedColor == null && !it.imageUrl.isNullOrBlank() }
+          .map { post ->
+            async {
+              val seedColor = seedColorExtractor.calculateSeedColor(post.imageUrl)
+              if (seedColor != null) {
+                post.id to seedColor.toArgb()
+              } else {
+                null
+              }
+            }
           }
-        }
+          .awaitAll()
+          .filterNotNull()
+          .toMap()
+
+      if (seedColorUpdates.isNotEmpty()) {
+        rssRepository.updateSeedColors(seedColorUpdates)
       }
     }
   }


### PR DESCRIPTION
The optimization addresses a clear N+1 query pattern where post seed colors were being updated one-by-one in individual database transactions. 

By introducing a `updateSeedColors` method in `RssRepository` that wraps multiple updates in a single SQLDelight transaction, we've reduced the I/O overhead associated with SQLite's ACID compliance (multiple fsyncs). 

Furthermore, I've parallelized the seed color extraction process in both `AllPostsPager` and `PostSyncProcessor` using coroutines (`async`/`awaitAll`). This allows multiple images to be processed concurrently before their extracted colors are committed to the database in a single batch.

Key changes:
- `core:data`: Added `RssRepository.updateSeedColors` and corresponding unit tests.
- `shared`: Refactored `AllPostsPager` and `PostSyncProcessor` to use batch updates and parallel processing.
- `core:data`: Added `updateSeedColorsShouldUpdateMultiplePosts` test case to `RssRepositoryTest`.

---
*PR created automatically by Jules for task [3556081030079056907](https://jules.google.com/task/3556081030079056907) started by @msasikanth*