### PR TITLE
Fix media element parsing truncating feeds and dropping images

### DIFF
--- a/core/network/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/network/parser/xml/AtomFeedParser.kt
+++ b/core/network/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/network/parser/xml/AtomFeedParser.kt
@@ -87,7 +87,7 @@ class AtomContentParser(httpClient: HttpClient, override val articleHtmlParser: 
         }
         TAG_ITUNES_IMAGE -> {
           iconUrl = parser.getAttributeValue(parser.namespace, ATTR_HREF)
-          parser.nextTag()
+          parser.skipSubTree()
         }
         TAG_ATOM_ENTRY -> {
           val host = UrlUtils.extractHost(link ?: feedUrl)
@@ -117,6 +117,7 @@ class AtomContentParser(httpClient: HttpClient, override val articleHtmlParser: 
         postsFlow(
           parser = parser,
           firstPost = firstPost,
+          containerTag = TAG_ATOM_FEED,
           itemTag = TAG_ATOM_ENTRY,
           readItem = { readAtomEntry(it, UrlUtils.extractHost(link ?: feedUrl)) },
         ),
@@ -140,10 +141,8 @@ class AtomContentParser(httpClient: HttpClient, override val articleHtmlParser: 
     var image: String? = null
     var audioUrl: String? = null
 
-    while (parser.next() != EventType.END_TAG) {
-      if (parser.eventType != EventType.START_TAG) continue
-
-      when (val tagName = parser.name) {
+    forEachChildTag(parser, TAG_ATOM_ENTRY) { tagName ->
+      when (tagName) {
         TAG_TITLE -> {
           title = parser.nextText()
         }
@@ -159,7 +158,7 @@ class AtomContentParser(httpClient: HttpClient, override val articleHtmlParser: 
           if (link.isNullOrBlank() && (rel == ATTR_VALUE_ALTERNATE || rel.isNullOrBlank())) {
             link = href
           }
-          parser.nextTag()
+          parser.skipSubTree()
         }
         TAG_CONTENT,
         TAG_SUMMARY -> {
@@ -179,8 +178,17 @@ class AtomContentParser(httpClient: HttpClient, override val articleHtmlParser: 
           }
         }
         TAG_ITUNES_IMAGE -> {
-          image = parser.getAttributeValue(parser.namespace, ATTR_HREF)
-          parser.nextTag()
+          val itunesImage = parser.getAttributeValue(parser.namespace, ATTR_HREF)
+          parser.skipSubTree()
+          if (image.isNullOrBlank()) {
+            image = itunesImage
+          }
+        }
+        in XmlFeedParser.imageTags -> {
+          val mediaImage = readMediaImageUrl(parser)
+          if (image.isNullOrBlank()) {
+            image = mediaImage
+          }
         }
         TAG_MEDIA_GROUP -> {
           val mediaGroupResult = readMediaGroup(parser)

--- a/core/network/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/network/parser/xml/RDFFeedParser.kt
+++ b/core/network/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/network/parser/xml/RDFFeedParser.kt
@@ -81,6 +81,7 @@ class RDFContentParser(override val articleHtmlParser: ArticleHtmlParser) : XmlC
       posts =
         postsFlow(
           parser = parser,
+          containerTag = XmlFeedParser.RDF_TAG,
           itemTag = TAG_RSS_ITEM,
           readItem = { readRssItem(it, UrlUtils.extractHost(link ?: feedUrl)) },
         ),
@@ -105,10 +106,7 @@ class RDFContentParser(override val articleHtmlParser: ArticleHtmlParser) : XmlC
     var date: String? = null
     var image: String? = null
 
-    while (parser.next() != EventType.END_TAG) {
-      if (parser.eventType != EventType.START_TAG) continue
-      val name = parser.name
-
+    forEachChildTag(parser, TAG_RSS_ITEM) { name ->
       when {
         name == TAG_TITLE -> {
           title = parser.nextText()

--- a/core/network/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/network/parser/xml/RssFeedParser.kt
+++ b/core/network/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/network/parser/xml/RssFeedParser.kt
@@ -97,6 +97,7 @@ class RSSContentParser(override val articleHtmlParser: ArticleHtmlParser) : XmlC
         postsFlow(
           parser = parser,
           firstPost = firstPost,
+          containerTag = TAG_RSS_CHANNEL,
           itemTag = TAG_RSS_ITEM,
           readItem = { readRssItem(it, UrlUtils.extractHost(link ?: feedUrl)) },
         ),
@@ -137,10 +138,7 @@ class RSSContentParser(override val articleHtmlParser: ArticleHtmlParser) : XmlC
     var audioUrl: String? = null
     var commentsLink: String? = null
 
-    while (parser.next() != EventType.END_TAG) {
-      if (parser.eventType != EventType.START_TAG) continue
-      val name = parser.name
-
+    forEachChildTag(parser, TAG_RSS_ITEM) { name ->
       when {
         name == TAG_TITLE -> {
           title = parser.nextText()
@@ -164,7 +162,7 @@ class RSSContentParser(override val articleHtmlParser: ArticleHtmlParser) : XmlC
             image = enclosureUrl
           }
 
-          parser.nextTag()
+          parser.skipSubTree()
         }
         name == TAG_DESCRIPTION || name == TAG_CONTENT_ENCODED -> {
           val postContent = parsePostContent(parser)
@@ -177,13 +175,18 @@ class RSSContentParser(override val articleHtmlParser: ArticleHtmlParser) : XmlC
         name == TAG_PUB_DATE -> {
           date = parser.nextText()
         }
-        image.isNullOrBlank() && name == TAG_ITUNES_IMAGE -> {
-          image = parser.getAttributeValue(parser.namespace, XmlFeedParser.ATTR_HREF)
-          parser.nextTag()
+        name == TAG_ITUNES_IMAGE -> {
+          val itunesImage = parser.getAttributeValue(parser.namespace, XmlFeedParser.ATTR_HREF)
+          parser.skipSubTree()
+          if (image.isNullOrBlank()) {
+            image = itunesImage
+          }
         }
-        image.isNullOrBlank() && hasRssImageUrl(name, parser) -> {
-          image = parser.getAttributeValue(parser.namespace, ATTR_URL)
-          parser.nextTag()
+        name in XmlFeedParser.imageTags -> {
+          val mediaImage = readMediaImageUrl(parser)
+          if (image.isNullOrBlank()) {
+            image = mediaImage
+          }
         }
         image.isNullOrBlank() && name == TAG_FEATURED_IMAGE -> {
           image = parser.nextText()
@@ -212,10 +215,4 @@ class RSSContentParser(override val articleHtmlParser: ArticleHtmlParser) : XmlC
       hostLink = hostLink,
     )
   }
-
-  private fun hasRssImageUrl(name: String, parser: XmlPullParser) =
-    (XmlFeedParser.imageTags.contains(name) ||
-      (name == TAG_ENCLOSURE &&
-        parser.getAttributeValue(parser.namespace, ATTR_TYPE) == ATTR_VALUE_IMAGE)) &&
-      !parser.getAttributeValue(parser.namespace, ATTR_URL).isNullOrBlank()
 }

--- a/core/network/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/network/parser/xml/XmlContentParser.kt
+++ b/core/network/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/network/parser/xml/XmlContentParser.kt
@@ -20,9 +20,10 @@ package dev.sasikanth.rss.reader.core.network.parser.xml
 import dev.sasikanth.rss.reader.core.model.remote.FeedPayload
 import dev.sasikanth.rss.reader.core.model.remote.PostPayload
 import dev.sasikanth.rss.reader.core.network.parser.common.ArticleHtmlParser
+import dev.sasikanth.rss.reader.core.network.parser.xml.XmlFeedParser.Companion.ATTR_URL
 import dev.sasikanth.rss.reader.core.network.parser.xml.XmlFeedParser.Companion.TAG_MEDIA_CONTENT
+import dev.sasikanth.rss.reader.core.network.parser.xml.XmlFeedParser.Companion.TAG_MEDIA_GROUP
 import dev.sasikanth.rss.reader.core.network.parser.xml.XmlFeedParser.Companion.TAG_MEDIA_THUMBNAIL
-import dev.sasikanth.rss.reader.core.network.parser.xml.XmlFeedParser.Companion.TAG_URL
 import dev.sasikanth.rss.reader.core.network.utils.UrlUtils
 import dev.sasikanth.rss.reader.util.dateStringToEpochMillis
 import dev.sasikanth.rss.reader.util.decodeHTMLString
@@ -41,6 +42,7 @@ abstract class XmlContentParser {
   protected fun postsFlow(
     parser: XmlPullParser,
     firstPost: PostPayload? = null,
+    containerTag: String,
     itemTag: String,
     readItem: (XmlPullParser) -> PostPayload?,
   ): Flow<PostPayload> = flow {
@@ -48,10 +50,8 @@ abstract class XmlContentParser {
       emit(firstPost)
     }
 
-    while (parser.next() != EventType.END_TAG) {
-      if (parser.eventType != EventType.START_TAG) continue
-
-      if (parser.name == itemTag) {
+    forEachChildTag(parser, containerTag) { name ->
+      if (name == itemTag) {
         val post = readItem(parser)
         if (post != null) {
           emit(post)
@@ -60,6 +60,58 @@ abstract class XmlContentParser {
         parser.skipSubTree()
       }
     }
+  }
+
+  /**
+   * Loops over the direct children of the tag the parser is currently inside, stopping only at
+   * [containerTag]'s end tag. Bailing on any end tag would truncate the rest of the container when
+   * a single child leaves the parser misaligned.
+   */
+  protected inline fun forEachChildTag(
+    parser: XmlPullParser,
+    containerTag: String,
+    block: (String) -> Unit,
+  ) {
+    while (true) {
+      val eventType = parser.next()
+      if (eventType == EventType.END_DOCUMENT) return
+      if (eventType == EventType.END_TAG && parser.name == containerTag) return
+      if (eventType != EventType.START_TAG) continue
+
+      block(parser.name)
+    }
+  }
+
+  /**
+   * Reads a media image URL from either the `url` attribute or the element's text content, and
+   * consumes the whole element. Feeds like MyAnimeList put the URL in the text, and feeds like The
+   * Guardian nest `media:credit` inside `media:content`.
+   */
+  protected fun readMediaImageUrl(parser: XmlPullParser): String? {
+    val urlFromAttribute = parser.getAttributeValue(parser.namespace, ATTR_URL)
+    if (!urlFromAttribute.isNullOrBlank()) {
+      parser.skipSubTree()
+      return urlFromAttribute
+    }
+
+    return readTextContentAndSkipSubTree(parser)
+  }
+
+  protected fun readTextContentAndSkipSubTree(parser: XmlPullParser): String? {
+    var text: String? = null
+    var depth = 1
+
+    while (depth > 0) {
+      when (parser.next()) {
+        EventType.START_TAG -> depth++
+        EventType.END_TAG -> depth--
+        EventType.TEXT -> if (depth == 1 && text.isNullOrBlank()) text = parser.text
+        EventType.END_DOCUMENT -> break
+        else -> {}
+      }
+    }
+
+    return text?.trim()?.ifBlank { null }
   }
 
   protected fun createFeedPayload(
@@ -104,13 +156,13 @@ abstract class XmlContentParser {
     var image: String? = null
     var description: String? = null
 
-    while (parser.next() != EventType.END_TAG) {
-      if (parser.eventType != EventType.START_TAG) continue
-
-      when (parser.name) {
+    forEachChildTag(parser, TAG_MEDIA_GROUP) { name ->
+      when (name) {
         TAG_MEDIA_THUMBNAIL -> {
-          image = parser.getAttributeValue(parser.namespace, TAG_URL)
-          parser.nextTag()
+          val imageUrl = readMediaImageUrl(parser)
+          if (image.isNullOrBlank()) {
+            image = imageUrl
+          }
         }
         TAG_MEDIA_CONTENT -> {
           description = parser.nextText()

--- a/core/network/src/commonTest/kotlin/dev/sasikanth/rss/reader/core/network/parser/XmlFeedParserTest.kt
+++ b/core/network/src/commonTest/kotlin/dev/sasikanth/rss/reader/core/network/parser/XmlFeedParserTest.kt
@@ -33,6 +33,7 @@ import dev.sasikanth.rss.reader.core.network.utils.podcastRssFeedUrl
 import dev.sasikanth.rss.reader.core.network.utils.podcastRssXmlContent
 import dev.sasikanth.rss.reader.core.network.utils.rdfXmlContent
 import dev.sasikanth.rss.reader.core.network.utils.rssXmlContent
+import dev.sasikanth.rss.reader.core.network.utils.rssXmlContentWithNestedMediaInFirstItem
 import dev.sasikanth.rss.reader.core.network.utils.youtubeAtomFeed
 import dev.sasikanth.rss.reader.core.network.utils.youtubeChannelHtml
 import dev.sasikanth.rss.reader.core.network.utils.youtubeFeedUrl
@@ -279,6 +280,60 @@ class XmlFeedParserTest {
                 isDateParsedCorrectly = true,
                 audioUrl = null,
               ),
+              PostPayload(
+                title = "Post with nested media content",
+                link = "https://example.com/post-with-nested-media-content",
+                description = "Nested media content description.",
+                rawContent =
+                  """
+                  <html>
+                   <body>Nested media content description.</body>
+                  </html>
+                  """
+                    .trimIndent(),
+                fullContent = null,
+                imageUrl = "https://example.com/media/nested-media-content",
+                date = 1685005200000,
+                commentsLink = null,
+                isDateParsedCorrectly = true,
+                audioUrl = null,
+              ),
+              PostPayload(
+                title = "Post with media thumbnail as text",
+                link = "https://example.com/post-with-media-thumbnail-text",
+                description = "Media thumbnail text description.",
+                rawContent =
+                  """
+                  <html>
+                   <body>Media thumbnail text description.</body>
+                  </html>
+                  """
+                    .trimIndent(),
+                fullContent = null,
+                imageUrl = "https://example.com/media/thumbnail-as-text",
+                date = 1685005200000,
+                commentsLink = null,
+                isDateParsedCorrectly = true,
+                audioUrl = null,
+              ),
+              PostPayload(
+                title = "Post after nested media content",
+                link = "https://example.com/post-after-nested-media-content",
+                description = "Post after nested media content description.",
+                rawContent =
+                  """
+                  <html>
+                   <body>Post after nested media content description.</body>
+                  </html>
+                  """
+                    .trimIndent(),
+                fullContent = null,
+                imageUrl = null,
+                date = 1685005200000,
+                commentsLink = null,
+                isDateParsedCorrectly = true,
+                audioUrl = null,
+              ),
             )
             .asFlow(),
       )
@@ -289,6 +344,18 @@ class XmlFeedParserTest {
 
     // then
     assertFeedPayloadEquals(expectedFeedPayload, payload)
+  }
+
+  @Test
+  fun parsingRssFeedWithNestedMediaContentShouldNotTruncateItems() = runTest {
+    // when
+    val content = ByteReadChannel(rssXmlContentWithNestedMediaInFirstItem.toByteArray())
+    val payload = xmlFeedParser.parse(content, feedUrl, Charsets.UTF8)
+    val posts = payload.posts.toList()
+
+    // then
+    assertEquals(listOf("First post", "Second post", "Third post"), posts.map { it.title })
+    assertEquals("https://example.com/media/first-post-140", posts.first().imageUrl)
   }
 
   @Test

--- a/core/network/src/commonTest/kotlin/dev/sasikanth/rss/reader/core/network/utils/TestData.kt
+++ b/core/network/src/commonTest/kotlin/dev/sasikanth/rss/reader/core/network/utils/TestData.kt
@@ -92,6 +92,66 @@ const val rssXmlContent =
         <media:thumbnail url="https://example.com/media/maxresdefault.jpg" />
     </media:group>
     </item>
+    <item>
+      <title>Post with nested media content</title>
+      <link>https://example.com/post-with-nested-media-content</link>
+      <description>Nested media content description.</description>
+      <pubDate>Thu, 25 May 2023 09:00:00 +0000</pubDate>
+      <media:content url="https://example.com/media/nested-media-content" type="image/jpeg" medium="image">
+        <media:thumbnail url="https://example.com/media/nested-media-thumbnail" />
+        <media:credit scheme="urn:ebu">Example Credit</media:credit>
+      </media:content>
+    </item>
+    <item>
+      <title>Post with media thumbnail as text</title>
+      <link>https://example.com/post-with-media-thumbnail-text</link>
+      <description>Media thumbnail text description.</description>
+      <media:thumbnail>https://example.com/media/thumbnail-as-text</media:thumbnail>
+      <pubDate>Thu, 25 May 2023 09:00:00 +0000</pubDate>
+    </item>
+    <item>
+      <title>Post after nested media content</title>
+      <link>https://example.com/post-after-nested-media-content</link>
+      <description>Post after nested media content description.</description>
+      <pubDate>Thu, 25 May 2023 09:00:00 +0000</pubDate>
+    </item>
+  </channel>
+  </rss>
+  """
+
+// Shape used by The Guardian and Ars Technica: the very first item carries a `media:content`
+// element with nested children.
+const val rssXmlContentWithNestedMediaInFirstItem =
+  """<?xml version="1.0" encoding="UTF-8"?>
+  <rss version="2.0">
+  <channel>
+    <title>Feed title</title>
+    <link>https://example.com</link>
+    <description>Feed description</description>
+    <item>
+      <title>First post</title>
+      <link>https://example.com/first-post</link>
+      <description>First post description.</description>
+      <pubDate>Thu, 25 May 2023 09:00:00 +0000</pubDate>
+      <media:content width="140" url="https://example.com/media/first-post-140">
+        <media:credit scheme="urn:ebu">Photograph: Example</media:credit>
+      </media:content>
+      <media:content width="460" url="https://example.com/media/first-post-460">
+        <media:credit scheme="urn:ebu">Photograph: Example</media:credit>
+      </media:content>
+    </item>
+    <item>
+      <title>Second post</title>
+      <link>https://example.com/second-post</link>
+      <description>Second post description.</description>
+      <pubDate>Thu, 25 May 2023 09:00:00 +0000</pubDate>
+    </item>
+    <item>
+      <title>Third post</title>
+      <link>https://example.com/third-post</link>
+      <description>Third post description.</description>
+      <pubDate>Thu, 25 May 2023 09:00:00 +0000</pubDate>
+    </item>
   </channel>
   </rss>
   """


### PR DESCRIPTION
Fixes #1908
Fixes #1909

## What's wrong

Both issues come from the same place: how `media:content` / `media:thumbnail` are read in `readRssItem`.

**#1909 — only one item rendered.** Media elements were read by pulling the `url` attribute and then calling `parser.nextTag()`, which assumes the element is empty. The Guardian and Ars Technica nest children inside `media:content`:

```xml
<media:content width="140" url="https://i.guim.co.uk/...">
  <media:credit scheme="urn:ebu">Photograph: Alexander Wiaplah/AP</media:credit>
</media:content>
```

`nextTag()` landed on `<media:credit>`, leaving the parser a level deep. Since both the item loop and `postsFlow` were `while (parser.next() != END_TAG)`, the next nested end tag terminated the item — and then `postsFlow` hit `</media:content>` and ended the flow. One post per feed.

**#1908 — no images for MyAnimeList.** The image tag guard required a non-blank `url` attribute. MAL puts the URL in the element's text instead:

```xml
<media:thumbnail>https://cdn.myanimelist.net/s/common/uploaded_files/....jpeg</media:thumbnail>
```

so it fell through to `skipSubTree()` and no image was ever found.

## The fix

- `readMediaImageUrl()` reads the URL from either the `url` attribute or the element's text content, and consumes the whole element in both cases.
- `forEachChildTag(parser, containerTag)` replaces the `END_TAG`-terminated loops. It stops only at its container's end tag (or `END_DOCUMENT`), so one misaligned child degrades a single item instead of truncating the rest of the feed.
- Remaining attribute-only branches (`enclosure`, `itunes:image`, Atom `link`) use `skipSubTree()` instead of `nextTag()`.
- Dropped `hasRssImageUrl` — its `enclosure` clause was dead code, since the `TAG_ENCLOSURE` branch matched first.
- Atom entries now also read bare `media:content` / `media:thumbnail`, which they previously ignored outside `media:group`.

## Testing

New fixtures in `rssXmlContent` (nested `media:content`, text-content `media:thumbnail`, and a following item to prove the feed isn't truncated), plus `parsingRssFeedWithNestedMediaContentShouldNotTruncateItems` using a Guardian-shaped feed where the *first* item carries the nested media.

`:core:network:jvmTest` passes; iOS arm64 and Android both compile.

I also ran the three reported feeds through the parser directly to confirm before/after:

| feed | before | after |
|---|---|---|
| `myanimelist.net/rss/news.xml` | 20 posts, 0 images | 20 posts, 20 images |
| `arstechnica.com/feed` | 1 post | 20 posts, 20 images |
| `theguardian.com/world/rss` | 1 post | 45 posts, 45 images |

Tom's Hardware (mentioned in a comment on #1909) is the same shape and should be fixed too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)