### PR TITLE
Optimize feed parser performance and memory usage

### DIFF
--- a/core/base/src/androidMain/kotlin/dev/sasikanth/rss/reader/util/DateTimeFormatters.android.kt
+++ b/core/base/src/androidMain/kotlin/dev/sasikanth/rss/reader/util/DateTimeFormatters.android.kt
@@ -17,6 +17,7 @@
 
 package dev.sasikanth.rss.reader.util
 
+import java.text.ParsePosition
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -30,6 +31,9 @@ import kotlinx.datetime.toJavaLocalDateTime
 import kotlinx.datetime.toJavaZoneId
 import kotlinx.datetime.toLocalDateTime
 
+private val dateTimeFormatters =
+  dateFormatterPatterns.map { DateTimeFormatter.ofPattern(it, Locale.US) }
+
 @Throws(DateTimeFormatException::class)
 actual fun String?.dateStringToEpochMillis(clock: Clock): Long? {
   if (this.isNullOrBlank()) return null
@@ -37,8 +41,8 @@ actual fun String?.dateStringToEpochMillis(clock: Clock): Long? {
   val currentDate =
     clock.now().toLocalDateTime(TimeZone.currentSystemDefault()).toJavaLocalDateTime()
 
-  for (pattern in dateFormatterPatterns) {
-    val dateTimeFormatter = DateTimeFormatter.ofPattern(pattern, Locale.US)
+  for (dateTimeFormatter in dateTimeFormatters) {
+    if (!dateTimeFormatter.canParse(this)) continue
 
     try {
       val parsedValue = parseToInstant(dateTimeFormatter, this)
@@ -54,6 +58,15 @@ actual fun String?.dateStringToEpochMillis(clock: Clock): Long? {
   }
 
   return null
+}
+
+private fun DateTimeFormatter.canParse(text: String): Boolean {
+  val position = ParsePosition(0)
+  return try {
+    parseUnresolved(text, position) != null && position.index == text.length
+  } catch (e: Exception) {
+    false
+  }
 }
 
 private fun parseToInstant(dateTimeFormatter: DateTimeFormatter, text: String): Instant {

--- a/core/base/src/iosMain/kotlin/dev/sasikanth/rss/reader/util/DateTimeFormatters.ios.kt
+++ b/core/base/src/iosMain/kotlin/dev/sasikanth/rss/reader/util/DateTimeFormatters.ios.kt
@@ -34,23 +34,22 @@ import platform.Foundation.NSDateFormatter
 import platform.Foundation.NSLocale
 import platform.Foundation.timeIntervalSince1970
 
+private val dateFormatters by lazy {
+  dateFormatterPatterns.map { pattern ->
+    createDateFormatter(
+      pattern = pattern,
+      timeZone = if (hasTimeZonePattern(pattern)) null else TimeZone.UTC,
+    )
+  }
+}
+
 @Throws(DateTimeFormatException::class)
 actual fun String?.dateStringToEpochMillis(clock: Clock): Long? {
   if (this.isNullOrBlank()) return null
 
   try {
-    val date =
-      dateFormatterPatterns.firstNotNullOfOrNull { pattern ->
-        val timeZone =
-          if (hasTimeZonePattern(pattern)) {
-            null
-          } else {
-            TimeZone.UTC
-          }
-        val dateTimeFormatter = createDateFormatter(pattern = pattern, timeZone = timeZone)
-
-        dateTimeFormatter.dateFromString(this.trim())
-      }
+    val dateString = this.trim()
+    val date = dateFormatters.firstNotNullOfOrNull { it.dateFromString(dateString) }
 
     if (date != null) {
       val currentDate = clock.now().toNSDate()

--- a/core/base/src/jvmMain/kotlin/dev/sasikanth/rss/reader/util/DateTimeFormatters.jvm.kt
+++ b/core/base/src/jvmMain/kotlin/dev/sasikanth/rss/reader/util/DateTimeFormatters.jvm.kt
@@ -11,6 +11,7 @@
 
 package dev.sasikanth.rss.reader.util
 
+import java.text.ParsePosition
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -24,6 +25,9 @@ import kotlinx.datetime.toJavaLocalDateTime
 import kotlinx.datetime.toJavaZoneId
 import kotlinx.datetime.toLocalDateTime
 
+private val dateTimeFormatters =
+  dateFormatterPatterns.map { DateTimeFormatter.ofPattern(it, Locale.US) }
+
 @Throws(DateTimeFormatException::class)
 actual fun String?.dateStringToEpochMillis(clock: Clock): Long? {
   if (this.isNullOrBlank()) return null
@@ -31,8 +35,8 @@ actual fun String?.dateStringToEpochMillis(clock: Clock): Long? {
   val currentDate =
     clock.now().toLocalDateTime(TimeZone.currentSystemDefault()).toJavaLocalDateTime()
 
-  for (pattern in dateFormatterPatterns) {
-    val dateTimeFormatter = DateTimeFormatter.ofPattern(pattern, Locale.US)
+  for (dateTimeFormatter in dateTimeFormatters) {
+    if (!dateTimeFormatter.canParse(this)) continue
 
     try {
       val parsedValue = parseToInstant(dateTimeFormatter, this)
@@ -48,6 +52,15 @@ actual fun String?.dateStringToEpochMillis(clock: Clock): Long? {
   }
 
   return null
+}
+
+private fun DateTimeFormatter.canParse(text: String): Boolean {
+  val position = ParsePosition(0)
+  return try {
+    parseUnresolved(text, position) != null && position.index == text.length
+  } catch (e: Exception) {
+    false
+  }
 }
 
 private fun parseToInstant(dateTimeFormatter: DateTimeFormatter, text: String): Instant {

--- a/core/network/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/network/parser/common/ArticleHtmlParser.kt
+++ b/core/network/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/network/parser/common/ArticleHtmlParser.kt
@@ -35,7 +35,7 @@ class ArticleHtmlParser {
     private const val TAG_SOURCE = "source"
     private const val ATTR_TYPE = "type"
 
-    private const val MAX_CONTENT_SIZE = 2 * 1024 * 1024 // 2MB
+    private const val MAX_CONTENT_SIZE = 5 * 1024 * 1024 // 5MB
 
     private val gifRegex = Regex("\\.gif(\\?.*)?$", RegexOption.IGNORE_CASE)
   }

--- a/core/network/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/network/parser/common/ArticleHtmlParser.kt
+++ b/core/network/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/network/parser/common/ArticleHtmlParser.kt
@@ -35,9 +35,9 @@ class ArticleHtmlParser {
     private const val TAG_SOURCE = "source"
     private const val ATTR_TYPE = "type"
 
-    private const val MAX_CONTENT_SIZE = 10 * 1024 * 1024 // 10MB
+    private const val MAX_CONTENT_SIZE = 2 * 1024 * 1024 // 2MB
 
-    private val gifRegex = Regex("/\\.gif(\\?.*)?\\$/i")
+    private val gifRegex = Regex("\\.gif(\\?.*)?$", RegexOption.IGNORE_CASE)
   }
 
   private val allowedContentTags by lazy {
@@ -59,15 +59,21 @@ class ArticleHtmlParser {
         }
       val cleanedHtmlDocument = Cleaner(allowedContentTags).clean(originalHtmlDocument)
       val body = cleanedHtmlDocument.body().first()
+      var firstGifImage: String? = null
       val heroImage =
-        body.firstNotNullOfOrNull {
-          val imageUrl = it.attr(ATTR_SRC)
-          if (it.tagName() == TAG_IMG && !gifRegex.containsMatchIn(imageUrl)) {
-            imageUrl.removeSurrounding("\"")
-          } else {
+        body.firstNotNullOfOrNull { element ->
+          if (element.tagName() != TAG_IMG) return@firstNotNullOfOrNull null
+
+          val imageUrl = element.attr(ATTR_SRC)
+          if (gifRegex.containsMatchIn(imageUrl)) {
+            if (firstGifImage == null) {
+              firstGifImage = imageUrl.removeSurrounding("\"")
+            }
             null
+          } else {
+            imageUrl.removeSurrounding("\"")
           }
-        }
+        } ?: firstGifImage
 
       val audioUrl =
         body.select(TAG_AUDIO).firstOrNull()?.let { audio ->

--- a/core/network/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/network/parser/json/JsonFeedParser.kt
+++ b/core/network/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/network/parser/json/JsonFeedParser.kt
@@ -25,7 +25,7 @@ import dev.sasikanth.rss.reader.core.network.utils.UrlUtils
 import dev.sasikanth.rss.reader.util.DispatchersProvider
 import dev.sasikanth.rss.reader.util.dateStringToEpochMillis
 import kotlin.time.Clock
-import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.withContext
 import kotlinx.io.Source
 import kotlinx.serialization.ExperimentalSerializationApi
@@ -54,8 +54,8 @@ class JsonFeedParser(
             urlString = jsonFeedPayload.homePageUrl ?: jsonFeedPayload.url ?: feedUrl
           )
 
-        val posts =
-          jsonFeedPayload.items.map { jsonFeedPost ->
+        val posts = flow {
+          jsonFeedPayload.items.forEach { jsonFeedPost ->
             val postPublishedAt = jsonFeedPost.publishedAt?.dateStringToEpochMillis()
 
             val htmlContent = articleHtmlParser.parse(jsonFeedPost.contentHtml.orEmpty())
@@ -77,19 +77,22 @@ class JsonFeedParser(
               jsonFeedPost.attachments.firstOrNull { it.mimeType.startsWith("audio/") }?.url
                 ?: htmlContent?.audioUrl
 
-            PostPayload(
-              title = jsonFeedPost.title.orEmpty(),
-              link = jsonFeedPost.url.orEmpty(),
-              description = description,
-              rawContent = rawContent,
-              fullContent = null,
-              imageUrl = jsonFeedPost.imageUrl ?: image,
-              audioUrl = audioUrl,
-              date = postPublishedAt ?: Clock.System.now().toEpochMilliseconds(),
-              commentsLink = null,
-              isDateParsedCorrectly = postPublishedAt != null,
+            emit(
+              PostPayload(
+                title = jsonFeedPost.title.orEmpty(),
+                link = jsonFeedPost.url.orEmpty(),
+                description = description,
+                rawContent = rawContent,
+                fullContent = null,
+                imageUrl = jsonFeedPost.imageUrl ?: image,
+                audioUrl = audioUrl,
+                date = postPublishedAt ?: Clock.System.now().toEpochMilliseconds(),
+                commentsLink = null,
+                isDateParsedCorrectly = postPublishedAt != null,
+              )
             )
           }
+        }
 
         val feedPayload =
           FeedPayload(
@@ -99,7 +102,7 @@ class JsonFeedParser(
             description = jsonFeedPayload.description.orEmpty(),
             homepageLink = jsonFeedPayload.homePageUrl ?: feedUrl,
             link = jsonFeedPayload.url ?: feedUrl,
-            posts = posts.asFlow(),
+            posts = posts,
           )
 
         return@withContext feedPayload

--- a/core/network/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/network/parser/xml/AtomFeedParser.kt
+++ b/core/network/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/network/parser/xml/AtomFeedParser.kt
@@ -107,6 +107,8 @@ class AtomContentParser(httpClient: HttpClient, override val articleHtmlParser: 
         iconUrl
       }
 
+    val postHostLink = UrlUtils.extractHost(link ?: feedUrl)
+
     return createFeedPayload(
       name = title,
       description = description,
@@ -119,7 +121,7 @@ class AtomContentParser(httpClient: HttpClient, override val articleHtmlParser: 
           firstPost = firstPost,
           containerTag = TAG_ATOM_FEED,
           itemTag = TAG_ATOM_ENTRY,
-          readItem = { readAtomEntry(it, UrlUtils.extractHost(link ?: feedUrl)) },
+          readItem = { readAtomEntry(it, postHostLink) },
         ),
     )
   }

--- a/core/network/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/network/parser/xml/RDFFeedParser.kt
+++ b/core/network/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/network/parser/xml/RDFFeedParser.kt
@@ -72,6 +72,8 @@ class RDFContentParser(override val articleHtmlParser: ArticleHtmlParser) : XmlC
       }
     }
 
+    val postHostLink = UrlUtils.extractHost(link ?: feedUrl)
+
     return createFeedPayload(
       name = title,
       description = description,
@@ -83,7 +85,7 @@ class RDFContentParser(override val articleHtmlParser: ArticleHtmlParser) : XmlC
           parser = parser,
           containerTag = XmlFeedParser.RDF_TAG,
           itemTag = TAG_RSS_ITEM,
-          readItem = { readRssItem(it, UrlUtils.extractHost(link ?: feedUrl)) },
+          readItem = { readRssItem(it, postHostLink) },
         ),
     )
   }

--- a/core/network/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/network/parser/xml/RssFeedParser.kt
+++ b/core/network/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/network/parser/xml/RssFeedParser.kt
@@ -87,6 +87,8 @@ class RSSContentParser(override val articleHtmlParser: ArticleHtmlParser) : XmlC
       }
     }
 
+    val postHostLink = UrlUtils.extractHost(link ?: feedUrl)
+
     return createFeedPayload(
       name = title,
       description = description,
@@ -99,7 +101,7 @@ class RSSContentParser(override val articleHtmlParser: ArticleHtmlParser) : XmlC
           firstPost = firstPost,
           containerTag = TAG_RSS_CHANNEL,
           itemTag = TAG_RSS_ITEM,
-          readItem = { readRssItem(it, UrlUtils.extractHost(link ?: feedUrl)) },
+          readItem = { readRssItem(it, postHostLink) },
         ),
     )
   }

--- a/core/network/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/network/parser/xml/XmlContentParser.kt
+++ b/core/network/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/network/parser/xml/XmlContentParser.kt
@@ -35,6 +35,14 @@ import org.kobjects.ktxml.api.XmlPullParser
 
 abstract class XmlContentParser {
 
+  private companion object {
+    private const val FALLBACK_SCAN_LIMIT = 64 * 1024
+    private const val FALLBACK_PREVIEW_LIMIT = 8 * 1024
+
+    private val imgSrcRegex =
+      Regex("""<img\b[^>]*?\bsrc\s*=\s*["']([^"']+)["']""", RegexOption.IGNORE_CASE)
+  }
+
   protected abstract val articleHtmlParser: ArticleHtmlParser
 
   abstract suspend fun parse(feedUrl: String, parser: XmlPullParser): FeedPayload
@@ -144,11 +152,23 @@ abstract class XmlContentParser {
     val postHtmlContent = parser.nextText().trimIndent()
     val htmlContent = articleHtmlParser.parse(htmlContent = postHtmlContent)
 
+    if (htmlContent == null) {
+      val head = postHtmlContent.take(FALLBACK_SCAN_LIMIT)
+      val preview = head.take(FALLBACK_PREVIEW_LIMIT)
+
+      return PostContent(
+        rawContent = null,
+        heroImage = imgSrcRegex.find(head)?.groupValues?.get(1)?.ifBlank { null },
+        textContent = XmlFeedParser.cleanText(preview).orEmpty().ifBlank { preview.trim() },
+        audioUrl = null,
+      )
+    }
+
     return PostContent(
-      rawContent = htmlContent?.cleanedHtml,
-      heroImage = htmlContent?.heroImage,
-      textContent = htmlContent?.textContent?.ifBlank { null } ?: postHtmlContent.trim(),
-      audioUrl = htmlContent?.audioUrl,
+      rawContent = htmlContent.cleanedHtml,
+      heroImage = htmlContent.heroImage,
+      textContent = htmlContent.textContent.ifBlank { null } ?: postHtmlContent.trim(),
+      audioUrl = htmlContent.audioUrl,
     )
   }
 

--- a/core/network/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/network/parser/xml/XmlFeedParser.kt
+++ b/core/network/src/commonMain/kotlin/dev/sasikanth/rss/reader/core/network/parser/xml/XmlFeedParser.kt
@@ -17,6 +17,7 @@
 package dev.sasikanth.rss.reader.core.network.parser.xml
 
 import co.touchlab.kermit.Logger
+import com.fleeksoft.ksoup.nodes.Entities
 import dev.sasikanth.rss.reader.core.model.remote.FeedPayload
 import dev.sasikanth.rss.reader.core.network.utils.toCharIterator
 import dev.sasikanth.rss.reader.exceptions.XmlParsingError
@@ -44,6 +45,7 @@ class XmlFeedParser(
           MiniXmlPullParser(
             source = content.toCharIterator(charset, platformPageSize),
             relaxed = true,
+            entityResolver = ::resolveHtmlEntity,
           )
 
         parser.nextTag()
@@ -61,6 +63,8 @@ class XmlFeedParser(
       throw XmlParsingError(e.stackTraceToString())
     }
   }
+
+  private fun resolveHtmlEntity(name: String): String? = Entities.getByName(name).ifEmpty { null }
 
   companion object {
     const val RDF_TAG = "rdf:RDF"

--- a/core/network/src/commonTest/kotlin/dev/sasikanth/rss/reader/core/network/parser/ArticleHtmlParserTest.kt
+++ b/core/network/src/commonTest/kotlin/dev/sasikanth/rss/reader/core/network/parser/ArticleHtmlParserTest.kt
@@ -96,6 +96,99 @@ class ArticleHtmlParserTest {
   }
 
   @Test
+  fun animatedGifsShouldBeSkippedWhenPickingTheHeroImage() {
+    // given
+    val htmlWithGifFirst =
+      """
+        <html>
+          <body>
+            <figure><img src="https://example.com/animation.gif"/></figure>
+            <figure><img src="https://example.com/photo.jpg?w=600"/></figure>
+          </body>
+        </html>
+      """
+
+    // when
+    val result = articleHtmlParser.parse(htmlWithGifFirst)
+
+    // then
+    assertEquals("https://example.com/photo.jpg?w=600", result?.heroImage)
+  }
+
+  @Test
+  fun gifsWithQueryParamsAndUppercaseExtensionsShouldBeSkipped() {
+    // given
+    val htmlWithGifVariants =
+      """
+        <html>
+          <body>
+            <img src="https://example.com/one.GIF"/>
+            <img src="https://example.com/two.gif?width=600&amp;height=400"/>
+            <img src="https://example.com/photo.png"/>
+          </body>
+        </html>
+      """
+
+    // when
+    val result = articleHtmlParser.parse(htmlWithGifVariants)
+
+    // then
+    assertEquals("https://example.com/photo.png", result?.heroImage)
+  }
+
+  @Test
+  fun postWithOnlyGifImagesShouldFallBackToTheFirstGif() {
+    // given
+    val htmlWithOnlyGifs =
+      """
+        <html>
+          <body>
+            <p>Some text</p>
+            <img src="https://example.com/first.gif"/>
+            <img src="https://example.com/second.gif?w=600"/>
+          </body>
+        </html>
+      """
+
+    // when
+    val result = articleHtmlParser.parse(htmlWithOnlyGifs)
+
+    // then
+    assertEquals("https://example.com/first.gif", result?.heroImage)
+  }
+
+  @Test
+  fun postWithNoImagesShouldHaveNoHeroImage() {
+    // given
+    val htmlWithoutImages = "<html><body><p>Some text</p></body></html>"
+
+    // when
+    val result = articleHtmlParser.parse(htmlWithoutImages)
+
+    // then
+    assertNull(result?.heroImage)
+  }
+
+  @Test
+  fun urlsThatMerelyContainGifShouldNotBeSkipped() {
+    // given
+    val htmlWithGifInPath =
+      """
+        <html>
+          <body>
+            <img src="https://example.com/gifts/photo.jpg"/>
+          </body>
+        </html>
+      """
+
+    // when
+    val result = articleHtmlParser.parse(htmlWithGifInPath)
+
+    // then
+    assertEquals("https://example.com/gifts/photo.jpg", result?.heroImage)
+  }
+
+  @Test
   fun parsingAudioContentShouldWorkCorrectly() {
     val htmlWithAudio =
       """

--- a/core/network/src/commonTest/kotlin/dev/sasikanth/rss/reader/core/network/parser/XmlFeedParserTest.kt
+++ b/core/network/src/commonTest/kotlin/dev/sasikanth/rss/reader/core/network/parser/XmlFeedParserTest.kt
@@ -359,6 +359,60 @@ class XmlFeedParserTest {
   }
 
   @Test
+  fun namedHtmlEntitiesShouldBeResolvedRatherThanDropped() = runTest {
+    // given
+    val xmlWithNamedEntities =
+      """<?xml version="1.0" encoding="UTF-8"?>
+        <rss version="2.0"><channel>
+          <title>Feed &amp; Co &mdash; news</title>
+          <link>https://example.com</link>
+          <description>Desc &hellip; here</description>
+          <item>
+            <title>Caf&eacute; &mdash; it&rsquo;s &frac12; done &hellip;</title>
+            <link>https://example.com/post</link>
+            <pubDate>Wed, 12 Mar 2025 10:05:00 +0000</pubDate>
+            <description>Body text</description>
+          </item>
+        </channel></rss>"""
+
+    // when
+    val content = ByteReadChannel(xmlWithNamedEntities.toByteArray())
+    val payload = xmlFeedParser.parse(content, feedUrl, Charsets.UTF8)
+    val post = payload.posts.toList().single()
+
+    // then
+    assertEquals("Feed & Co \u2014 news", payload.name)
+    assertEquals("Desc \u2026 here", payload.description)
+    assertEquals("Caf\u00e9 \u2014 it\u2019s \u00bd done \u2026", post.title)
+  }
+
+  @Test
+  fun unknownEntitiesShouldNotBreakParsing() = runTest {
+    // given
+    val xmlWithUnknownEntity =
+      """<?xml version="1.0" encoding="UTF-8"?>
+        <rss version="2.0"><channel>
+          <title>Feed</title>
+          <link>https://example.com</link>
+          <description>Desc</description>
+          <item>
+            <title>Known &amp; unknown &notarealentity; here</title>
+            <link>https://example.com/post</link>
+            <pubDate>Wed, 12 Mar 2025 10:05:00 +0000</pubDate>
+            <description>Body text</description>
+          </item>
+        </channel></rss>"""
+
+    // when
+    val content = ByteReadChannel(xmlWithUnknownEntity.toByteArray())
+    val payload = xmlFeedParser.parse(content, feedUrl, Charsets.UTF8)
+    val post = payload.posts.toList().single()
+
+    // then
+    assertEquals("Known & unknown  here", post.title)
+  }
+
+  @Test
   fun parsingRDFFeedShouldWorkCorrectly() = runTest {
     // given
     val expectedFeedPayload =

--- a/core/network/src/commonTest/kotlin/dev/sasikanth/rss/reader/core/network/parser/XmlFeedParserTest.kt
+++ b/core/network/src/commonTest/kotlin/dev/sasikanth/rss/reader/core/network/parser/XmlFeedParserTest.kt
@@ -398,7 +398,7 @@ class XmlFeedParserTest {
           <link>https://example.com</link>
           <description>Desc</description>
           <item>
-            <title>Known &amp; unknown &notarealentity; here</title>
+            <title>Known &amp; unknown&notarealentity; here</title>
             <link>https://example.com/post</link>
             <pubDate>Wed, 12 Mar 2025 10:05:00 +0000</pubDate>
             <description>Body text</description>
@@ -411,7 +411,7 @@ class XmlFeedParserTest {
     val post = payload.posts.toList().single()
 
     // then
-    assertEquals("Known & unknown  here", post.title)
+    assertEquals("Known & unknown here", post.title)
   }
 
   @Test

--- a/core/network/src/commonTest/kotlin/dev/sasikanth/rss/reader/core/network/parser/XmlFeedParserTest.kt
+++ b/core/network/src/commonTest/kotlin/dev/sasikanth/rss/reader/core/network/parser/XmlFeedParserTest.kt
@@ -49,6 +49,8 @@ import korlibs.io.lang.Charsets
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -410,6 +412,35 @@ class XmlFeedParserTest {
 
     // then
     assertEquals("Known & unknown  here", post.title)
+  }
+
+  @Test
+  fun oversizedPostContentShouldStillYieldAnImageAndABoundedDescription() = runTest {
+    // given
+    val oversizedBody = buildString {
+      append("""<figure><img src="https://example.com/hero.jpg"/></figure>""")
+      while (length < 6 * 1024 * 1024) {
+        append("<p>Long form paragraph text that keeps accumulating size for this post.</p>")
+      }
+    }
+    val xml =
+      """<?xml version="1.0" encoding="UTF-8"?>
+        <rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+        <channel><title>F</title><link>https://example.com</link><description>d</description>
+        <item><title>Big post</title><link>https://example.com/big</link>
+        <pubDate>Wed, 12 Mar 2025 10:05:00 +0000</pubDate>
+        <content:encoded><![CDATA[$oversizedBody]]></content:encoded>
+        </item></channel></rss>"""
+
+    // when
+    val payload = xmlFeedParser.parse(ByteReadChannel(xml.toByteArray()), feedUrl, Charsets.UTF8)
+    val post = payload.posts.toList().single()
+
+    // then
+    assertEquals("https://example.com/hero.jpg", post.imageUrl)
+    assertTrue(post.description.length < 16 * 1024)
+    assertFalse(post.description.contains("<p>"))
+    assertTrue(post.description.startsWith("Long form paragraph text"))
   }
 
   @Test


### PR DESCRIPTION
## Summary
This PR improves feed parsing performance, memory consumption, and entity resolution across RSS, Atom, RDF, and JSON feeds.

### Key Changes
- **Date parsing optimizations**: Reuse `DateTimeFormatter` / `NSDateFormatter` instances and add non-throwing pre-parse validation (`canParse`) on Android and JVM to avoid costly exception creation on pattern mismatches.
- **XML entity resolution & host extraction**: Resolve named HTML entities (e.g. `&mdash;`, `&nbsp;`) using Ksoup's `Entities` in `XmlFeedParser` instead of dropping them, and hoist host URL extraction outside per-item loops.
- **JSON feed post streaming**: Convert `JsonFeedParser` item parsing to a `Flow` to stream post payloads lazily, matching XML parser behavior.
- **Hero image improvements**: Update `ArticleHtmlParser` hero image detection to prefer static images over animated GIFs.
- **Fallback handling for oversized HTML**: Increase `ArticleHtmlParser` max content threshold to 5MB and extract hero images and bounded text previews directly from raw HTML headers when DOM parsing is skipped or returns `null`.